### PR TITLE
AlertManager based maintenace API

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,5 @@
+package config
+
+const (
+	OperatorName string = "managed-upgrade-operator"
+)

--- a/pkg/controller/upgradeconfig/cluster_upgrader.go
+++ b/pkg/controller/upgradeconfig/cluster_upgrader.go
@@ -253,7 +253,8 @@ func CommenceUpgrade(c client.Client, m maintenance.Maintenance, upgradeConfig *
 
 // Create the maintenance window for control plane
 func CreateControlPlaneMaintWindow(c client.Client, m maintenance.Maintenance, upgradeConfig *upgradev1alpha1.UpgradeConfig, reqLogger logr.Logger) (bool, error) {
-	err := m.Start(time.Now().Add(time.Minute * 90))
+	endTime := time.Now().Add(90 * time.Minute)
+	err := m.Start(endTime)
 	if err != nil {
 		return false, err
 	}
@@ -280,9 +281,10 @@ func CreateWorkerMaintWindow(c client.Client, m maintenance.Maintenance, upgrade
 	}
 
 	pendingWorkerCount := configPool.Status.MachineCount - configPool.Status.UpdatedMachineCount
-	var maintenanceTimePerNode int32 = 8
-	workerMaintenanceExpectedMins := time.Duration(pendingWorkerCount * maintenanceTimePerNode)
-	err = m.Start(time.Now().Add(time.Minute * workerMaintenanceExpectedMins))
+	maintenanceDurationPerNode := 8 * time.Minute
+	workerMaintenanceExpectedDuration := time.Duration(pendingWorkerCount) * maintenanceDurationPerNode
+	endTime := time.Now().Add(workerMaintenanceExpectedDuration)
+	err = m.Start(endTime)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/maintenance/alertManagerSilenceClient.go
+++ b/pkg/maintenance/alertManagerSilenceClient.go
@@ -1,0 +1,73 @@
+package maintenance
+
+import (
+	"context"
+	httptransport "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+	amSilence "github.com/prometheus/alertmanager/api/v2/client/silence"
+	amv2Models "github.com/prometheus/alertmanager/api/v2/models"
+	"net/http"
+)
+
+type alertManagerSilenceClient struct {
+	transport *httptransport.Runtime
+}
+
+// Creates a silence in Alertmanager instance defined in transport
+func (ams *alertManagerSilenceClient) create(matchers amv2Models.Matchers, startsAt strfmt.DateTime, endsAt strfmt.DateTime, creator string, comment string) error {
+	psParams := &amSilence.PostSilencesParams{
+		Silence: &amv2Models.PostableSilence{
+			Silence: amv2Models.Silence{
+				CreatedBy: &creator,
+				Comment:   &comment,
+				EndsAt:    &endsAt,
+				StartsAt:  &startsAt,
+				Matchers:  matchers,
+			},
+		},
+		Context:    context.TODO(),
+		HTTPClient: &http.Client{},
+	}
+
+	silenceClient := amSilence.New(ams.transport, strfmt.Default)
+	_, err := silenceClient.PostSilences(psParams)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// list silences in Alertmanager instance defined in transport
+func (ams *alertManagerSilenceClient) List(filter []string) (*amSilence.GetSilencesOK, error) {
+	gParams := &amSilence.GetSilencesParams{
+		Filter:     filter,
+		Context:    context.TODO(),
+		HTTPClient: &http.Client{},
+	}
+
+	silenceClient := amSilence.New(ams.transport, strfmt.Default)
+	results, err := silenceClient.GetSilences(gParams)
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+// list silence in Alertmanager instance defined in transport
+func (ams *alertManagerSilenceClient) Delete(id string) error {
+	dParams := &amSilence.DeleteSilenceParams{
+		SilenceID:  strfmt.UUID(id),
+		Context:    context.TODO(),
+		HTTPClient: &http.Client{},
+	}
+
+	silenceClient := amSilence.New(ams.transport, strfmt.Default)
+	_, err := silenceClient.DeleteSilence(dParams)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/maintenance/alertManagerSilenceClient.go
+++ b/pkg/maintenance/alertManagerSilenceClient.go
@@ -15,7 +15,7 @@ type alertManagerSilenceClient struct {
 
 // Creates a silence in Alertmanager instance defined in transport
 func (ams *alertManagerSilenceClient) create(matchers amv2Models.Matchers, startsAt strfmt.DateTime, endsAt strfmt.DateTime, creator string, comment string) error {
-	psParams := &amSilence.PostSilencesParams{
+	pParams := &amSilence.PostSilencesParams{
 		Silence: &amv2Models.PostableSilence{
 			Silence: amv2Models.Silence{
 				CreatedBy: &creator,
@@ -30,7 +30,7 @@ func (ams *alertManagerSilenceClient) create(matchers amv2Models.Matchers, start
 	}
 
 	silenceClient := amSilence.New(ams.transport, strfmt.Default)
-	_, err := silenceClient.PostSilences(psParams)
+	_, err := silenceClient.PostSilences(pParams)
 	if err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func (ams *alertManagerSilenceClient) List(filter []string) (*amSilence.GetSilen
 	return results, nil
 }
 
-// list silence in Alertmanager instance defined in transport
+// Delete silence in Alertmanager instance defined in transport
 func (ams *alertManagerSilenceClient) Delete(id string) error {
 	dParams := &amSilence.DeleteSilenceParams{
 		SilenceID:  strfmt.UUID(id),

--- a/pkg/maintenance/alertmanagerMaintenance.go
+++ b/pkg/maintenance/alertmanagerMaintenance.go
@@ -1,0 +1,125 @@
+package maintenance
+
+import (
+	"context"
+	"github.com/coreos/pkg/multierror"
+	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/openshift/managed-upgrade-operator/config"
+	amv2Models "github.com/prometheus/alertmanager/api/v2/models"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+	"time"
+)
+
+var (
+	alertManagerNamespace          = "openshift-monitoring"
+	alertManagerRouteName          = "alertmanager-main"
+	alertManagerServiceAccountName = "prometheus-k8s"
+	alertManagerBasePath           = "/api/v2/"
+)
+
+type alertManagerMaintenance struct {
+	client alertManagerSilenceClient
+}
+
+func newAlertManagerMaintenance(client client.Client) (Maintenance, error) {
+	transport, err := getTransport(client)
+	if err != nil {
+		return nil, err
+	}
+
+	transport.DefaultAuthentication, err = getAuthentication(client)
+	if err != nil {
+		return nil, err
+	}
+
+	return &alertManagerMaintenance{
+		client: alertManagerSilenceClient{
+			transport: transport,
+		},
+	}, nil
+}
+
+func getTransport(c client.Client) (*httptransport.Runtime, error) {
+	amRoute := &routev1.Route{}
+	err := c.Get(
+		context.TODO(),
+		types.NamespacedName{Namespace: alertManagerNamespace, Name: alertManagerRouteName},
+		amRoute,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return httptransport.New(
+		amRoute.Spec.Host,
+		alertManagerBasePath,
+		[]string{"https"},
+	), nil
+}
+
+func getAuthentication(c client.Client) (runtime.ClientAuthInfoWriter, error) {
+	sl := &corev1.SecretList{}
+	err := c.List(
+		context.TODO(),
+		sl,
+		&client.ListOptions{Namespace: alertManagerNamespace},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var token string
+	for _, s := range sl.Items {
+		if strings.Contains(s.Name, alertManagerServiceAccountName+"-token") {
+			token = string(s.Data["token"])
+		}
+	}
+
+	return httptransport.BearerToken(token), nil
+}
+
+// Start a maintenance in Alertmanager
+func (amm *alertManagerMaintenance) Start(endsAt time.Time) error {
+	isRegex := true
+	alertMatchKey := "alertname"
+	// TODO: refine these alerts -> https://github.com/openshift/managed-upgrade-operator/pull/10#discussion_r434249118
+	alertRegex := "[A-Z].*"
+	silenceComment := "Silence for OSD upgrade"
+	matchers := amv2Models.Matchers{
+		{
+			Name:    &alertMatchKey,
+			IsRegex: &isRegex,
+			Value:   &alertRegex,
+		},
+	}
+	return amm.client.create(matchers, strfmt.DateTime(time.Now().UTC()), strfmt.DateTime(endsAt), config.OperatorName, silenceComment)
+}
+
+// End all active maintenances created by managed-upgrade-operator in Alertmanager
+func (amm *alertManagerMaintenance) End() error {
+	silences, err := amm.client.List([]string{})
+	if err != nil {
+		return err
+	}
+
+	var deleteErrors multierror.Error
+	for _, s := range silences.Payload {
+		if *s.CreatedBy == config.OperatorName && *s.Status.State == amv2Models.SilenceStatusStateActive {
+			err := amm.client.Delete(*s.ID)
+			if err != nil {
+				deleteErrors = append(deleteErrors, err)
+			}
+		}
+	}
+	if len(deleteErrors) > 0 {
+		return deleteErrors.AsError()
+	}
+
+	return nil
+}

--- a/pkg/maintenance/maintenance.go
+++ b/pkg/maintenance/maintenance.go
@@ -1,0 +1,20 @@
+package maintenance
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+type Maintenance interface {
+	Start(endsAt time.Time) error
+	End() error
+}
+
+func NewClient(client client.Client) (Maintenance, error) {
+	amm, err := newAlertManagerMaintenance(client)
+	if err != nil {
+		return nil, err
+	}
+
+	return amm, nil
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-3658

This is what im thinking the maintenance client will look like. (I'll fit it into [the upgrade controller](https://github.com/openshift/managed-upgrade-operator/pull/9) once that is ready)

Should be just:

```.go
m, err := maintenance.NewMaintenace()
  if err != nil {
    return reconcile.Result{}, err
  }
   err = m.Start()
     /
     /
  err = m.End()
```