### PR TITLE
Refinement of upgrade maintenance

### DIFF
--- a/pkg/controller/upgradeconfig/cluster_upgrader.go
+++ b/pkg/controller/upgradeconfig/cluster_upgrader.go
@@ -255,7 +255,7 @@ func CommenceUpgrade(c client.Client, m maintenance.Maintenance, upgradeConfig *
 // Create the maintenance window for control plane
 func CreateControlPlaneMaintWindow(c client.Client, m maintenance.Maintenance, upgradeConfig *upgradev1alpha1.UpgradeConfig, reqLogger logr.Logger) (bool, error) {
 	endTime := time.Now().Add(90 * time.Minute)
-	err := m.Start(endTime)
+	err := m.StartControlPlane(endTime)
 	if err != nil {
 		return false, err
 	}
@@ -285,7 +285,7 @@ func CreateWorkerMaintWindow(c client.Client, m maintenance.Maintenance, upgrade
 	maintenanceDurationPerNode := 8 * time.Minute
 	workerMaintenanceExpectedDuration := time.Duration(pendingWorkerCount) * maintenanceDurationPerNode
 	endTime := time.Now().Add(workerMaintenanceExpectedDuration)
-	err = m.Start(endTime)
+	err = m.StartWorker(endTime)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/maintenance/alertmanagerMaintenance.go
+++ b/pkg/maintenance/alertmanagerMaintenance.go
@@ -90,9 +90,10 @@ func getAuthentication(c client.Client) (runtime.ClientAuthInfoWriter, error) {
 }
 
 // Start a control plane maintenance in Alertmanager
+// Time is converted to UTC
 func (amm *alertManagerMaintenance) StartControlPlane(endsAt time.Time) error {
 	now := strfmt.DateTime(time.Now().UTC())
-	end := strfmt.DateTime(endsAt)
+	end := strfmt.DateTime(endsAt.UTC())
 	err := amm.client.create(createDefaultMatchers(), now, end, config.OperatorName, "Silence for OSD upgrade")
 	if err != nil {
 		return err
@@ -108,9 +109,10 @@ func (amm *alertManagerMaintenance) StartControlPlane(endsAt time.Time) error {
 }
 
 // Start a control plane maintenance in Alertmanager
+// Time is converted to UTC
 func (amm *alertManagerMaintenance) StartWorker(endsAt time.Time) error {
 	now := strfmt.DateTime(time.Now().UTC())
-	end := strfmt.DateTime(endsAt)
+	end := strfmt.DateTime(endsAt.UTC())
 	err := amm.client.create(createDefaultMatchers(), now, end, config.OperatorName, "Silence for OSD upgrade")
 	if err != nil {
 		return err

--- a/pkg/maintenance/maintenance.go
+++ b/pkg/maintenance/maintenance.go
@@ -6,7 +6,8 @@ import (
 )
 
 type Maintenance interface {
-	Start(endsAt time.Time) error
+	StartControlPlane(endsAt time.Time) error
+	StartWorker(endsAt time.Time) error
 	End() error
 }
 


### PR DESCRIPTION
There was a discussion about this within the monitoring team (https://issues.redhat.com/browse/MON-1093)

tl;dr is that critical alerts "shouldn't" occur during upgrade but that there is a [shortlist of criticals](https://bugzilla.redhat.com/buglist.cgi?quicksearch=%5Balert%5D) than do/may occur during upgrade. (There is work to refine those to not fire/fire less but a target of 4.7 has been set)


- Silencing all warning|info alerts as these can be noise during an upgrade.
- From the above critical list only  `etcdMembersDown` is certain to happen so I have silenced that for control plane maintenance and we can refine this list as we iterate further and see alerts.