### PR TITLE
add the metrics to the operator to track the upgrade status

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -29,6 +29,7 @@ rules:
   - apps
   resources:
   - deployments
+  - deployments/finalizers
   - daemonsets
   - replicasets
   - statefulsets
@@ -91,6 +92,10 @@ rules:
   - subscriptions
   verbs:
   - '*'
-
-
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - '*'
 

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/operator-framework/api v0.3.6
 	github.com/operator-framework/operator-sdk v0.17.0
 	github.com/prometheus/alertmanager v0.20.0
+	github.com/prometheus/client_golang v1.5.1
 	github.com/spf13/pflag v1.0.5
 	github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50 // indirect
 	golang.org/x/net v0.0.0-20200506145744-7e3656a0809f // indirect

--- a/pkg/controller/upgradeconfig/cluster_upgrader.go
+++ b/pkg/controller/upgradeconfig/cluster_upgrader.go
@@ -247,7 +247,7 @@ func CommenceUpgrade(c client.Client, m maintenance.Maintenance, upgradeConfig *
 	clusterVersion.Spec.Channel = upgradeConfig.Spec.Desired.Channel
 
 	//Record the timestamp when we start the upgrade
-	metrics.UpdateMetricUpgradeStartTime(time.Now(), upgradeConfig.Name)
+	metrics.UpdateMetricUpgradeStartTime(time.Now().UTC(), upgradeConfig.Name)
 	err = c.Update(context.TODO(), clusterVersion)
 	if err != nil {
 		return false, err
@@ -441,7 +441,7 @@ func NodesUpgraded(c client.Client, nodeType string, upgradeConfig *upgradev1alp
 	}
 
 	// send node upgrade complete metrics
-	metrics.UpdateMetricNodeUpgradeEndTime(time.Now(), upgradeConfig.Name)
+	metrics.UpdateMetricNodeUpgradeEndTime(time.Now().UTC(), upgradeConfig.Name)
 	return true, nil
 }
 
@@ -456,7 +456,7 @@ func ControlPlaneUpgraded(c client.Client, m maintenance.Maintenance, upgradeCon
 	for _, c := range clusterVersion.Status.History {
 		if c.State == configv1.CompletedUpdate && c.Version == upgradeConfig.Spec.Desired.Version {
 			// send controlplane upgrade complete timestamp
-			metrics.UpdateMetricControlPlaneEndTime(time.Now(), upgradeConfig.Name)
+			metrics.UpdateMetricControlPlaneEndTime(time.Now().UTC(), upgradeConfig.Name)
 			return true, nil
 		}
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -53,16 +53,28 @@ func init() {
 	metrics.Registry.MustRegister(metricPostVerificationFailed)
 }
 
-func UpdateMetricValidationFailed(x int, upgradeconfig string) {
+func UpdateMetricValidationFailed(upgradeconfig string) {
 	metricValidationFailed.With(prometheus.Labels{
 		nameLabel: upgradeconfig}).Set(
-			float64(x))
+			float64(1))
 }
 
-func UpdateMetricClusterCheckFailed(x int, upgradeconfig string) {
+func UpdateMetricValidationSucceeded(upgradeconfig string) {
+	metricValidationFailed.With(prometheus.Labels{
+		nameLabel: upgradeconfig}).Set(
+			float64(0))
+}
+
+func UpdateMetricClusterCheckFailed(upgradeconfig string) {
 	metricClusterCheckFailed.With(prometheus.Labels{
 		nameLabel: upgradeconfig}).Set(
-			float64(x))
+			float64(1))
+}
+
+func UpdateMetricClusterCheckSucceeded(upgradeconfig string) {
+	metricClusterCheckFailed.With(prometheus.Labels{
+		nameLabel: upgradeconfig}).Set(
+			float64(0))
 }
 
 func UpdateMetricUpgradeStartTime(time time.Time, upgradeconfig string) {
@@ -80,11 +92,18 @@ func UpdateMetricControlPlaneEndTime(time time.Time, upgradeconfig string) {
 func UpdateMetricNodeUpgradeEndTime(time time.Time, upgradeconfig string) {
 	metricNodeUpgradeEndTime.With(prometheus.Labels{
 		nameLabel: upgradeconfig}).Set(
-		float64(time.Unix()))
+			float64(time.Unix()))
 }
 
-func UpdateMetricPostVerificationFailed(x int, upgradeconfig string) {
+func UpdateMetricPostVerificationFailed(upgradeconfig string) {
 	metricPostVerificationFailed.With(prometheus.Labels{
 		nameLabel: upgradeconfig}).Set(
-			float64(x))
+			float64(1))
 }
+
+func UpdateMetricPostVerificationSucceeded(upgradeconfig string) {
+	metricPostVerificationFailed.With(prometheus.Labels{
+		nameLabel: upgradeconfig}).Set(
+			float64(0))
+}
+

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,90 @@
+package metrics
+
+import (
+	"time"
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	metricsTag 	= "upgradeoperator"
+	nameLabel 	= "upgradeconfig_name"
+)
+
+var (
+	metricValidationFailed = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: metricsTag,
+		Name: "upgradeconfig_validation_failed",
+		Help: "Failed to validate the upgrade config",
+	}, []string{nameLabel})
+	metricClusterCheckFailed = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: metricsTag,
+		Name: "cluster_check_failed",
+		Help: "Failed on the cluster check step",
+	}, []string{nameLabel})
+	metricUpgradeStartTime = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: metricsTag,
+		Name: "upgrade_start_timestamp",
+		Help: "Timestamp for the real upgrade process is started",
+	}, []string{nameLabel})
+	metricControlPlaneUpgradeEndTime = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: metricsTag,
+		Name: "controlplane_upgrade_end_timestamp",
+		Help: "Timestamp for the control plane upgrade is finished",
+	}, []string{nameLabel})
+	metricNodeUpgradeEndTime = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: metricsTag,
+		Name: "node_upgrade_end_timestamp",
+		Help: "Timestamp for the node upgrade is finished",
+	}, []string{nameLabel})
+	metricPostVerificationFailed = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: metricsTag,
+		Name: "post_verification_failed",
+		Help: "Failed on the post upgrade verification step",
+	}, []string{nameLabel})
+)
+
+func init() {
+	metrics.Registry.MustRegister(metricValidationFailed)
+	metrics.Registry.MustRegister(metricClusterCheckFailed)
+	metrics.Registry.MustRegister(metricUpgradeStartTime)
+	metrics.Registry.MustRegister(metricControlPlaneUpgradeEndTime)
+	metrics.Registry.MustRegister(metricNodeUpgradeEndTime)
+	metrics.Registry.MustRegister(metricPostVerificationFailed)
+}
+
+func UpdateMetricValidationFailed(x int, upgradeconfig string) {
+	metricValidationFailed.With(prometheus.Labels{
+		nameLabel: upgradeconfig}).Set(
+			float64(x))
+}
+
+func UpdateMetricClusterCheckFailed(x int, upgradeconfig string) {
+	metricClusterCheckFailed.With(prometheus.Labels{
+		nameLabel: upgradeconfig}).Set(
+			float64(x))
+}
+
+func UpdateMetricUpgradeStartTime(time time.Time, upgradeconfig string) {
+	metricUpgradeStartTime.With(prometheus.Labels{
+		nameLabel: upgradeconfig}).Set(
+			float64(time.Unix()))
+}
+
+func UpdateMetricControlPlaneEndTime(time time.Time, upgradeconfig string) {
+	metricControlPlaneUpgradeEndTime.With(prometheus.Labels{
+		nameLabel: upgradeconfig}).Set(
+			float64(time.Unix()))
+}
+
+func UpdateMetricNodeUpgradeEndTime(time time.Time, upgradeconfig string) {
+	metricNodeUpgradeEndTime.With(prometheus.Labels{
+		nameLabel: upgradeconfig}).Set(
+		float64(time.Unix()))
+}
+
+func UpdateMetricPostVerificationFailed(x int, upgradeconfig string) {
+	metricPostVerificationFailed.With(prometheus.Labels{
+		nameLabel: upgradeconfig}).Set(
+			float64(x))
+}


### PR DESCRIPTION
With the metrics added, we can create the prometheus rules to trigger the alerts.

Prometheus rules:
1. validation failed
2. cluster check failed
3. upgrade started for 90 mins and controlplane upgrade not finished
4. upgrade started for 3 hours and node upgrade not finished 
5. Post verification failed

With rules like:
```
apiVersion: monitoring.coreos.com/v1
kind: PrometheusRule
metadata:
  annotations:
  labels:
    prometheus: managed-upgrade-operator
    role: alert-rules
  name: sre-managed-upgrade-alerts
  namespace: openshift-monitoring
spec:
  groups:
  - name: sre-managed-upgrade-alerts
    rules:
    - alert: UpgradeConfigValidationFailed
      expr: upgradeoperator_upgradeconfig_validation_failed > 0
      labels:
        severity: critical
    - alert: UpgradeClusterHealthCheckFailed
      expr: upgradeoperator_cluster_check_failed > 0
      labels:
        severity: critical
    - alert: UpgradeControlPlaneTimeout
      expr:  //PromQL needs to be worked out
      for: 1m
      labels:
        severity: critical
    - alert: UpgradeNodeTimeout
      expr:  //PromQL needs to be worked out
      for: 1m
      labels:
        severity: critical
    - alert: UpgradePostValidationFailed
      expr: upgradeoperator_post_verification_failed > 0
      labels: 
        severity: critical
```