### PR TITLE
Fixing image repo name from USER to app-sre

### DIFF
--- a/project.mk
+++ b/project.mk
@@ -3,7 +3,7 @@ OPERATOR_NAME?=managed-upgrade-operator
 OPERATOR_NAMESPACE?=managed-upgrade-operator
 
 IMAGE_REGISTRY?=quay.io
-IMAGE_REPOSITORY?=$(USER)
+IMAGE_REPOSITORY?=app-sre
 IMAGE_NAME?=$(OPERATOR_NAME)
 
 VERSION_MAJOR?=0


### PR DESCRIPTION
Based on https://ci.int.devshift.net/job/openshift-managed-upgrade-operator-gh-build-master/3/console, which is originally triggered by https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/6053, changing image repo name from $USER to app-sre to have the image created.