### PR TITLE
Masters are reported upgraded by CVO

### DIFF
--- a/pkg/apis/upgrade/v1alpha1/upgradeconfig_types.go
+++ b/pkg/apis/upgrade/v1alpha1/upgradeconfig_types.go
@@ -78,7 +78,6 @@ const (
 	ControlPlaneMaintWindow       UpgradeConditionType = "ControlPlaneMaintWindow"
 	CommenceUpgrade               UpgradeConditionType = "CommenceUpgrade"
 	ControlPlaneUpgraded          UpgradeConditionType = "ControlPlaneUpgraded"
-	AllMasterNodesUpgraded        UpgradeConditionType = "AllMasterNodesUpgraded"
 	RemoveControlPlaneMaintWindow UpgradeConditionType = "RemoveControlPlaneMaintWindow"
 	WorkersMaintWindow            UpgradeConditionType = "WorkersMaintWindow"
 	AllWorkerNodesUpgraded        UpgradeConditionType = "AllWorkerNodesUpgraded"


### PR DESCRIPTION
CVO reports if master nodes are upgraded so there is no need for the `AllMastersUpgraded` check.
And depending on how long the control plane lasts, all workers may already be upgraded.