### PR TITLE
Fixing namespace for OperatorGroup and Subscription

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -197,7 +197,7 @@ objects:
             namespace: openshift-managed-upgrade-operator
           spec:
             targetNamespaces:
-              - managed-upgrade-operator
+              - openshift-managed-upgrade-operator
         - apiVersion: operators.coreos.com/v1alpha1
           kind: Subscription
           metadata:
@@ -207,7 +207,7 @@ objects:
             channel: ${CHANNEL}
             name: managed-upgrade-operator
             source: managed-upgrade-operator-catalog
-            sourceNamespace: managed-upgrade-operator
+            sourceNamespace: openshift-managed-upgrade-operator
         - apiVersion: apiextensions.k8s.io/v1
           kind: CustomResourceDefinition
           metadata:


### PR DESCRIPTION
Setting the sourceNamespace and targetNamespaces for OperatorGroup and Subscription to right namespace.