### PR TITLE
Osd 4497 remove extra conditions

### DIFF
--- a/pkg/cluster_upgrader_builder/cluster_upgrader_builder.go
+++ b/pkg/cluster_upgrader_builder/cluster_upgrader_builder.go
@@ -11,7 +11,7 @@ import (
 // Interface describing the functions of a cluster upgrader.
 //go:generate mockgen -destination=mocks/cluster_upgrader.go -package=mocks github.com/openshift/managed-upgrade-operator/pkg/cluster_upgrader_builder ClusterUpgrader
 type ClusterUpgrader interface {
-	UpgradeCluster(upgradeConfig *upgradev1alpha1.UpgradeConfig, logger logr.Logger) error
+	UpgradeCluster(upgradeConfig *upgradev1alpha1.UpgradeConfig, logger logr.Logger) (upgradev1alpha1.UpgradePhase, *upgradev1alpha1.UpgradeCondition, error)
 }
 
 //go:generate mockgen -destination=mocks/cluster_upgrader_builder.go -package=mocks github.com/openshift/managed-upgrade-operator/pkg/cluster_upgrader_builder ClusterUpgraderBuilder

--- a/pkg/cluster_upgrader_builder/mocks/cluster_upgrader.go
+++ b/pkg/cluster_upgrader_builder/mocks/cluster_upgrader.go
@@ -35,11 +35,13 @@ func (m *MockClusterUpgrader) EXPECT() *MockClusterUpgraderMockRecorder {
 }
 
 // UpgradeCluster mocks base method
-func (m *MockClusterUpgrader) UpgradeCluster(arg0 *v1alpha1.UpgradeConfig, arg1 logr.Logger) error {
+func (m *MockClusterUpgrader) UpgradeCluster(arg0 *v1alpha1.UpgradeConfig, arg1 logr.Logger) (v1alpha1.UpgradePhase, *v1alpha1.UpgradeCondition, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradeCluster", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(v1alpha1.UpgradePhase)
+	ret1, _ := ret[1].(*v1alpha1.UpgradeCondition)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // UpgradeCluster indicates an expected call of UpgradeCluster

--- a/pkg/osd_cluster_upgrader/upgrader.go
+++ b/pkg/osd_cluster_upgrader/upgrader.go
@@ -21,7 +21,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -428,89 +427,30 @@ func ControlPlaneUpgraded(c client.Client, scaler scaler.Scaler, metricsClient m
 }
 
 // This trigger the upgrade process
-func (cu osdClusterUpgrader) UpgradeCluster(upgradeConfig *upgradev1alpha1.UpgradeConfig, logger logr.Logger) error {
-	logger.Info("upgrading cluster")
-	history := upgradeConfig.Status.History.GetHistory(upgradeConfig.Spec.Desired.Version)
-	conditions := history.Conditions
-
-	if history.Phase != upgradev1alpha1.UpgradePhaseUpgrading {
-		history.Phase = upgradev1alpha1.UpgradePhaseUpgrading
-		history.StartTime = &metav1.Time{Time: time.Now()}
-		upgradeConfig.Status.History.SetHistory(*history)
-		err := cu.client.Status().Update(context.TODO(), upgradeConfig)
-		if err != nil {
-			logger.Error(err, "failed to update upgradeconfig")
-		}
-	}
+func (cu osdClusterUpgrader) UpgradeCluster(upgradeConfig *upgradev1alpha1.UpgradeConfig, logger logr.Logger) (upgradev1alpha1.UpgradePhase, *upgradev1alpha1.UpgradeCondition, error) {
+	logger.Info("Upgrading cluster")
 
 	for _, key := range cu.Ordering {
 
-		logger.Info(fmt.Sprintf("Perform %s", key))
-
-		condition := conditions.GetCondition(key)
-		if condition == nil {
-			logger.Info(fmt.Sprintf("Adding %s condition", key))
-			condition = newUpgradeCondition(fmt.Sprintf("start %s", key), fmt.Sprintf("start %s", key), key, corev1.ConditionFalse)
-			condition.StartTime = &metav1.Time{Time: time.Now()}
-			conditions.SetCondition(*condition)
-			history.Conditions = conditions
-			upgradeConfig.Status.History.SetHistory(*history)
-			err := cu.client.Status().Update(context.TODO(), upgradeConfig)
-			if err != nil {
-				return err
-			}
-		}
+		logger.Info(fmt.Sprintf("Performing %s", key))
 
 		result, err := cu.Steps[key](cu.client, cu.scaler, cu.metrics, cu.maintenance, upgradeConfig, logger)
 
 		if err != nil {
-			logger.Error(err, fmt.Sprintf("error when %s", key))
-			condition.Reason = fmt.Sprintf("%s not done", key)
-			condition.Message = err.Error()
-			conditions.SetCondition(*condition)
-			history.Conditions = conditions
-			upgradeConfig.Status.History.SetHistory(*history)
-			err = cu.client.Status().Update(context.TODO(), upgradeConfig)
-			if err != nil {
-				return err
-			}
-			return err
+			logger.Error(err, fmt.Sprintf("Error when %s", key))
+			condition := newUpgradeCondition(fmt.Sprintf("%s not done", key), err.Error(), key, corev1.ConditionFalse)
+			return upgradev1alpha1.UpgradePhaseUpgrading, condition, err
 		}
-		if result {
-			condition.CompleteTime = &metav1.Time{Time: time.Now()}
-			condition.Reason = fmt.Sprintf("%s succeed", key)
-			condition.Message = fmt.Sprintf("%s succeed", key)
-			condition.Status = corev1.ConditionTrue
-			conditions.SetCondition(*condition)
-			history.Conditions = conditions
-			upgradeConfig.Status.History.SetHistory(*history)
-			err = cu.client.Status().Update(context.TODO(), upgradeConfig)
-			if err != nil {
-				return err
-			}
-		} else {
+		if !result {
 			logger.Info(fmt.Sprintf("%s not done, skip following steps", key))
-			condition.Reason = fmt.Sprintf("%s not done", key)
-			condition.Message = fmt.Sprintf("%s still in progress", key)
-			conditions.SetCondition(*condition)
-			history.Conditions = conditions
-			upgradeConfig.Status.History.SetHistory(*history)
-			err = cu.client.Status().Update(context.TODO(), upgradeConfig)
-			if err != nil {
-				return err
-			}
-			return nil
+			condition := newUpgradeCondition(fmt.Sprintf("%s not done", key), fmt.Sprintf("%s still in progress", key), key, corev1.ConditionFalse)
+			return upgradev1alpha1.UpgradePhaseUpgrading, condition, nil
 		}
 	}
-	history.Phase = upgradev1alpha1.UpgradePhaseUpgraded
-	history.CompleteTime = &metav1.Time{Time: time.Now()}
-	upgradeConfig.Status.History.SetHistory(*history)
-	err := cu.client.Status().Update(context.TODO(), upgradeConfig)
-	if err != nil {
-		return err
-	}
-	return nil
 
+	key := cu.Ordering[len(cu.Ordering)-1]
+	condition := newUpgradeCondition(fmt.Sprintf("%s done", key), fmt.Sprintf("%s is completed", key), key, corev1.ConditionTrue)
+	return upgradev1alpha1.UpgradePhaseUpgraded, condition, nil
 }
 
 // check several things about the cluster and report problems

--- a/pkg/osd_cluster_upgrader/upgrader_test.go
+++ b/pkg/osd_cluster_upgrader/upgrader_test.go
@@ -379,24 +379,6 @@ var _ = Describe("ClusterUpgrader", func() {
 			}
 		})
 
-		Context("When the UpgradeConfig history status is not Upgrading", func() {
-			JustBeforeEach(func() {
-				upgradeConfig.Status.History = []upgradev1alpha1.UpgradeHistory{
-					{
-						Version: upgradeConfig.Spec.Desired.Version,
-						Phase:   upgradev1alpha1.UpgradePhasePending,
-					},
-				}
-			})
-			It("Adds a new Upgrading history to the UpgradeConfig", func() {
-				sw := mocks.NewMockStatusWriter(mockCtrl)
-				mockKubeClient.EXPECT().Status().AnyTimes().Return(sw)
-				sw.EXPECT().Update(gomock.Any(), gomock.Any()).AnyTimes()
-				err := cu.UpgradeCluster(upgradeConfig, logger)
-				Expect(err).NotTo(HaveOccurred())
-			})
-		})
-
 		Context("When a step does not occur in the history", func() {
 			BeforeEach(func() {
 				cu.Steps = map[upgradev1alpha1.UpgradeConditionType]UpgradeStep{
@@ -406,15 +388,19 @@ var _ = Describe("ClusterUpgrader", func() {
 				mockKubeClient.EXPECT().Status().AnyTimes().Return(sw)
 				sw.EXPECT().Update(gomock.Any(), gomock.Any()).AnyTimes()
 			})
-			It("adds the step to the UpgradeConfig's history", func() {
+
+			It("returns an uncompleted condition for the step", func() {
 				// Add a step that will not complete on execution, so we can observe it starting
-				err := cu.UpgradeCluster(upgradeConfig, logger)
-				stepHistoryReason := upgradeConfig.Status.History.GetHistory(upgradeConfig.Spec.Desired.Version).Conditions.GetCondition(step1).Reason
+				phase, condition, err := cu.UpgradeCluster(upgradeConfig, logger)
+				stepHistoryReason := condition.Reason
+				Expect(phase).To(Equal(upgradev1alpha1.UpgradePhaseUpgrading))
+				Expect(condition.Status).To(Equal(corev1.ConditionFalse))
 				Expect(stepHistoryReason).To(Equal(string(step1) + " not done"))
 				Expect(err).NotTo(HaveOccurred())
 			})
+
 			It("runs the step", func() {
-				err := cu.UpgradeCluster(upgradeConfig, logger)
+				_, _, err := cu.UpgradeCluster(upgradeConfig, logger)
 				Expect(stepCounter[step1]).To(Equal(1))
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -429,36 +415,17 @@ var _ = Describe("ClusterUpgrader", func() {
 				mockKubeClient.EXPECT().Status().AnyTimes().Return(sw)
 				sw.EXPECT().Update(gomock.Any(), gomock.Any()).AnyTimes()
 			})
-			It("Indicates the error in the UpgradeConfig step's history", func() {
-				err := cu.UpgradeCluster(upgradeConfig, logger)
-				stepHistoryReason := upgradeConfig.Status.History.GetHistory(upgradeConfig.Spec.Desired.Version).Conditions.GetCondition(step1).Reason
-				stepHistoryMsg := upgradeConfig.Status.History.GetHistory(upgradeConfig.Spec.Desired.Version).Conditions.GetCondition(step1).Message
+			It("Indicates the error in the condition", func() {
+				_, condition, err := cu.UpgradeCluster(upgradeConfig, logger)
+				stepHistoryReason := condition.Reason
+				stepHistoryMsg := condition.Message
 				Expect(stepHistoryReason).To(Equal(string(step1) + " not done"))
 				Expect(stepHistoryMsg).To(Equal("step " + string(step1) + " failed"))
 				Expect(stepCounter[step1]).To(Equal(1))
 				// TODO - this needs eyes in cluster-upgrader - need to doublecheck whether it is expected to return nil here
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(HaveOccurred())
 			})
-		})
 
-		Context("When running a step completes successfully", func() {
-			BeforeEach(func() {
-				sw := mocks.NewMockStatusWriter(mockCtrl)
-				mockKubeClient.EXPECT().Status().AnyTimes().Return(sw)
-				sw.EXPECT().Update(gomock.Any(), gomock.Any()).AnyTimes()
-			})
-			It("flags that in the UpgradeConfig's history", func() {
-				err := cu.UpgradeCluster(upgradeConfig, logger)
-				stepHistoryReason := upgradeConfig.Status.History.GetHistory(upgradeConfig.Spec.Desired.Version).Conditions.GetCondition(step1).Reason
-				stepHistoryMsg := upgradeConfig.Status.History.GetHistory(upgradeConfig.Spec.Desired.Version).Conditions.GetCondition(step1).Message
-				stepHistoryCondition := upgradeConfig.Status.History.GetHistory(upgradeConfig.Spec.Desired.Version).Conditions.GetCondition(step1).Status
-				Expect(stepHistoryReason).To(Equal(string(step1) + " succeed"))
-				Expect(stepHistoryMsg).To(Equal(string(step1) + " succeed"))
-				Expect(stepHistoryCondition).To(Equal(corev1.ConditionTrue))
-				// TODO - need to doublecheck whether it is expected to return nil here
-				Expect(stepCounter[step1]).To(Equal(1))
-				Expect(err).NotTo(HaveOccurred())
-			})
 		})
 
 		Context("When all steps have indicated completion", func() {
@@ -481,10 +448,11 @@ var _ = Describe("ClusterUpgrader", func() {
 				mockKubeClient.EXPECT().Status().AnyTimes().Return(sw)
 				sw.EXPECT().Update(gomock.Any(), gomock.Any()).AnyTimes()
 			})
-			It("flags the upgrade as completed in the UpgradeConfig's history", func() {
-				err := cu.UpgradeCluster(upgradeConfig, logger)
+			It("flags the upgrade as completed", func() {
+				phase, condition, err := cu.UpgradeCluster(upgradeConfig, logger)
+				Expect(phase).To(Equal(upgradev1alpha1.UpgradePhaseUpgraded))
+				Expect(condition.Status).To(Equal(corev1.ConditionTrue))
 				Expect(err).NotTo(HaveOccurred())
-
 			})
 		})
 	})


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-4497

Fixes a few things.

- ClusterUpgraders are now pluggable components so to keep the history status updating consistent I have moved it to the reconciler. ClusterUpgraders will report their status and conditions.
- We only display the one condition in our printer columns so im just saving the current one (Status gets very unreadable after a few upgrades)
https://github.com/openshift/managed-upgrade-operator/blob/e83d853b605f688188a7193c84373a039315f839/deploy/crds/upgrade.managed.openshift.io_upgradeconfigs_crd.yaml#L23-L34
- Test updates

