### PR TITLE
OSD-4522 Add PDBForceDrainTimeout to CRD

### DIFF
--- a/deploy/crds/upgrade.managed.openshift.io_upgradeconfigs_crd.yaml
+++ b/deploy/crds/upgrade.managed.openshift.io_upgradeconfigs_crd.yaml
@@ -53,6 +53,13 @@ spec:
             description: UpgradeConfigSpec defines the desired state of UpgradeConfig
               and upgrade window and freeze window
             properties:
+              PDBForceDrainTimeout:
+                default: 60
+                description: The maximum grace period granted to a node whose drain
+                  is blocked by a Pod Disruption Budget, before that drain is forced.
+                  Measured in minutes.
+                format: int32
+                type: integer
               desired:
                 description: Specify the desired OpenShift release
                 properties:
@@ -77,11 +84,6 @@ spec:
                   to upgrade, proceed governs this decision to continue and commence
                   the upgrade
                 type: boolean
-              type:
-                description: Type indicates the ClusterUpgrader implementation to use to perform an upgrade of the cluster
-                enum:
-                  - OSD
-                type: string
               subscriptionUpdates:
                 description: This defines the 3rd party operator subscriptions upgrade
                 items:
@@ -103,12 +105,20 @@ spec:
                   - namespace
                   type: object
                 type: array
+              type:
+                description: Type indicates the ClusterUpgrader implementation to
+                  use to perform an upgrade of the cluster
+                enum:
+                - OSD
+                type: string
               upgradeAt:
                 description: Specify the upgrade start time
                 type: string
             required:
+            - PDBForceDrainTimeout
             - desired
             - proceed
+            - type
             - upgradeAt
             type: object
           status:

--- a/deploy/crds/upgrade.managed.openshift.io_v1alpha1_upgradeconfig_cr.yaml
+++ b/deploy/crds/upgrade.managed.openshift.io_v1alpha1_upgradeconfig_cr.yaml
@@ -6,6 +6,7 @@ spec:
   type: "OSD"
   upgradeAt: "2020-01-01T00:00:00Z"
   proceed: true
+  PDBForceDrainTimeout: 60
   desired:
     channel: "fast-4.4"
     force: false

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -266,6 +266,14 @@ objects:
                           UpgradeConfigSpec defines the desired state of UpgradeConfig
                           and upgrade window and freeze window
                         properties:
+                          PDBForceDrainTimeout:
+                            default: 60
+                            description:
+                              The maximum grace period granted to a node whose drain
+                              is blocked by a Pod Disruption Budget, before that drain is forced.
+                              Measured in minutes.
+                            format: int32
+                            type: integer
                           desired:
                             description: Specify the desired OpenShift release
                             properties:
@@ -291,17 +299,10 @@ objects:
                               to upgrade, proceed governs this decision to continue and commence
                               the upgrade
                             type: boolean
-                          type:
-                            description: Type indicates the ClusterUpgrader implementation to use to perform an upgrade of the cluster
-                            enum:
-                              - OSD
-                            type: string
                           subscriptionUpdates:
                             description: This defines the 3rd party operator subscriptions upgrade
                             items:
-                              description:
-                                SubscriptionUpdate describe the 3rd party operator
-                                update config
+                              description: SubscriptionUpdate describe the 3rd party operator update config
                               properties:
                                 channel:
                                   description: Describe the channel for the Subscription
@@ -318,12 +319,19 @@ objects:
                                 - namespace
                               type: object
                             type: array
+                          type:
+                            description: Type indicates the ClusterUpgrader implementation to use to perform an upgrade of the cluster
+                            enum:
+                              - OSD
+                            type: string
                           upgradeAt:
                             description: Specify the upgrade start time
                             type: string
                         required:
+                          - PDBForceDrainTimeout
                           - desired
                           - proceed
+                          - type
                           - upgradeAt
                         type: object
                       status:
@@ -350,14 +358,12 @@ objects:
                                         format: date-time
                                         type: string
                                       lastTransitionTime:
-                                        description:
-                                          Last time the condition transit from one
+                                        description: Last time the condition transit from one
                                           status to another.
                                         format: date-time
                                         type: string
                                       message:
-                                        description:
-                                          Human readable message indicating details
+                                        description: Human readable message indicating details
                                           about last transition.
                                         type: string
                                       reason:
@@ -368,8 +374,7 @@ objects:
                                         format: date-time
                                         type: string
                                       status:
-                                        description:
-                                          Status of condition, one of True, False,
+                                        description: Status of condition, one of True, False,
                                           Unknown
                                         type: string
                                       type:

--- a/pkg/apis/upgrade/v1alpha1/upgradeconfig_types.go
+++ b/pkg/apis/upgrade/v1alpha1/upgradeconfig_types.go
@@ -21,10 +21,16 @@ type UpgradeConfigSpec struct {
 	// Specify the upgrade start time
 	UpgradeAt string `json:"upgradeAt"`
 
+	// +kubebuilder:default:=60
+	// The maximum grace period granted to a node whose drain is blocked by a Pod Disruption Budget, before that drain is forced. Measured in minutes.
+	PDBForceDrainTimeout int32 `json:"PDBForceDrainTimeout"`
+
 	// +kubebuilder:default:=true
 	// Given all conditions have passed and cluster is ready to upgrade, proceed governs this decision to continue and commence the upgrade
 	Proceed bool `json:"proceed"`
 
+	// +kubebuilder:validation:Enum={"OSD"}
+	// Type indicates the ClusterUpgrader implementation to use to perform an upgrade of the cluster
 	Type UpgradeType `json:"type"`
 
 	// This defines the 3rd party operator subscriptions upgrade

--- a/util/mocks/structs/upgradeconfig.go
+++ b/util/mocks/structs/upgradeconfig.go
@@ -33,7 +33,7 @@ func NewUpgradeConfigBuilder() *testUpgradeConfigBuilder {
 				},
 				Proceed: true,
 				UpgradeAt: time.Now().Format(time.RFC3339),
-
+				PDBForceDrainTimeout: 60,
 			},
 		},
 	}


### PR DESCRIPTION
- Adds "PDBForceDrainTimeout" to the UpgradeConfig CRD.
- Adds missing comment and enum comments for the "type" field so that the CRD regenerates it properly.

Refs OSD-4522.