### PR TITLE
update the metrics to record the upgrade started

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -706,6 +706,7 @@ github.com/mattn/go-runewidth v0.0.6/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/mattn/go-shellwords v1.0.5/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-shellwords v1.0.9/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/mattn/go-sqlite3 v1.10.0 h1:jbhqpg7tQe4SupckyijYiy0mJJ/pRyHvXf7JdWK860o=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=

--- a/pkg/metrics/mocks/metrics.go
+++ b/pkg/metrics/mocks/metrics.go
@@ -64,19 +64,19 @@ func (mr *MockMetricsMockRecorder) IsMetricNodeUpgradeEndTimeSet(arg0, arg1 inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsMetricNodeUpgradeEndTimeSet", reflect.TypeOf((*MockMetrics)(nil).IsMetricNodeUpgradeEndTimeSet), arg0, arg1)
 }
 
-// IsMetricUpgradeStartTimeSet mocks base method
-func (m *MockMetrics) IsMetricUpgradeStartTimeSet(arg0, arg1 string) (bool, error) {
+// IsMetricUpgradeStartedSet mocks base method
+func (m *MockMetrics) IsMetricUpgradeStartedSet(arg0, arg1 string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsMetricUpgradeStartTimeSet", arg0, arg1)
+	ret := m.ctrl.Call(m, "IsMetricUpgradeStartedSet", arg0, arg1)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// IsMetricUpgradeStartTimeSet indicates an expected call of IsMetricUpgradeStartTimeSet
-func (mr *MockMetricsMockRecorder) IsMetricUpgradeStartTimeSet(arg0, arg1 interface{}) *gomock.Call {
+// IsMetricUpgradeStartedSet indicates an expected call of IsMetricUpgradeStartedSet
+func (mr *MockMetricsMockRecorder) IsMetricUpgradeStartedSet(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsMetricUpgradeStartTimeSet", reflect.TypeOf((*MockMetrics)(nil).IsMetricUpgradeStartTimeSet), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsMetricUpgradeStartedSet", reflect.TypeOf((*MockMetrics)(nil).IsMetricUpgradeStartedSet), arg0, arg1)
 }
 
 // Query mocks base method
@@ -190,18 +190,6 @@ func (mr *MockMetricsMockRecorder) UpdateMetricScalingSucceeded(arg0 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricScalingSucceeded", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricScalingSucceeded), arg0)
 }
 
-// UpdateMetricUpgradeStartTime mocks base method
-func (m *MockMetrics) UpdateMetricUpgradeStartTime(arg0 time.Time, arg1, arg2 string) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdateMetricUpgradeStartTime", arg0, arg1, arg2)
-}
-
-// UpdateMetricUpgradeStartTime indicates an expected call of UpdateMetricUpgradeStartTime
-func (mr *MockMetricsMockRecorder) UpdateMetricUpgradeStartTime(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricUpgradeStartTime", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricUpgradeStartTime), arg0, arg1, arg2)
-}
-
 // UpdateMetricValidationFailed mocks base method
 func (m *MockMetrics) UpdateMetricValidationFailed(arg0 string) {
 	m.ctrl.T.Helper()
@@ -224,4 +212,16 @@ func (m *MockMetrics) UpdateMetricValidationSucceeded(arg0 string) {
 func (mr *MockMetricsMockRecorder) UpdateMetricValidationSucceeded(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricValidationSucceeded", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricValidationSucceeded), arg0)
+}
+
+// UpdateMetricUpgrardeStarted mocks base method
+func (m *MockMetrics) UpdateMetricUpgradeStarted(arg0, arg1 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateMetricUpgrardeStarted", arg0, arg1)
+}
+
+// UpdateMetricUpgrardeStarted indicates an expected call of UpdateMetricUpgrardeStarted
+func (mr *MockMetricsMockRecorder) UpdateMetricUpgradeStarted(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricUpgrardeStarted", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricUpgradeStarted), arg0, arg1)
 }

--- a/pkg/osd_cluster_upgrader/upgrader_test.go
+++ b/pkg/osd_cluster_upgrader/upgrader_test.go
@@ -193,14 +193,14 @@ var _ = Describe("ClusterUpgrader", func() {
 				expectUpgradeCommenced(mockKubeClient, clusterVersionList, nil)
 				expectGetClusterVersion(mockKubeClient, clusterVersionList, nil)
 				gomock.InOrder(
-					mockMetricsClient.EXPECT().IsMetricUpgradeStartTimeSet(upgradeConfig.Name, upgradeConfig.Spec.Desired.Version).Times(1),
+					mockMetricsClient.EXPECT().IsMetricUpgradeStartedSet(upgradeConfig.Name, upgradeConfig.Spec.Desired.Version).Times(1),
 					mockKubeClient.EXPECT().Update(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
 						func(ctx context.Context, cv *configv1.ClusterVersion) error {
 							Expect(cv.Spec.DesiredUpdate.Version).To(Equal(upgradeConfig.Spec.Desired.Version))
 							Expect(cv.Spec.Channel).To(Equal(upgradeConfig.Spec.Desired.Channel))
 							return nil
 						}).Times(1),
-					mockMetricsClient.EXPECT().UpdateMetricUpgradeStartTime(gomock.Any(), upgradeConfig.Name, upgradeConfig.Spec.Desired.Version).Times(1),
+					mockMetricsClient.EXPECT().UpdateMetricUpgradeStarted(upgradeConfig.Name, upgradeConfig.Spec.Desired.Version).Times(1),
 				)
 				result, err := CommenceUpgrade(mockKubeClient, mockScalerClient, mockMetricsClient, mockMaintClient, upgradeConfig, logger)
 				Expect(err).NotTo(HaveOccurred())
@@ -225,14 +225,14 @@ var _ = Describe("ClusterUpgrader", func() {
 				expectUpgradeHasNotCommenced(mockKubeClient, upgradeConfig, nil)
 				expectGetClusterVersion(mockKubeClient, clusterVersionList, nil)
 				gomock.InOrder(
-					mockMetricsClient.EXPECT().IsMetricUpgradeStartTimeSet(upgradeConfig.Name, upgradeConfig.Spec.Desired.Version).Times(1),
+					mockMetricsClient.EXPECT().IsMetricUpgradeStartedSet(upgradeConfig.Name, upgradeConfig.Spec.Desired.Version).Times(1),
 					mockKubeClient.EXPECT().Update(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
 						func(ctx context.Context, cv *configv1.ClusterVersion) error {
 							Expect(cv.Spec.DesiredUpdate.Version).To(Equal(upgradeConfig.Spec.Desired.Version))
 							Expect(cv.Spec.Channel).To(Equal(upgradeConfig.Spec.Desired.Channel))
 							return nil
 						}).Times(1),
-					mockMetricsClient.EXPECT().UpdateMetricUpgradeStartTime(gomock.Any(), upgradeConfig.Name, upgradeConfig.Spec.Desired.Version).Times(1),
+					mockMetricsClient.EXPECT().UpdateMetricUpgradeStarted(upgradeConfig.Name, upgradeConfig.Spec.Desired.Version).Times(1),
 				)
 				result, err := CommenceUpgrade(mockKubeClient, mockScalerClient, mockMetricsClient, mockMaintClient, upgradeConfig, logger)
 				Expect(err).NotTo(HaveOccurred())
@@ -246,9 +246,9 @@ var _ = Describe("ClusterUpgrader", func() {
 				expectUpgradeHasNotCommenced(mockKubeClient, upgradeConfig, nil)
 				expectGetClusterVersion(mockKubeClient, preUpgradeCV, nil)
 				gomock.InOrder(
-					mockMetricsClient.EXPECT().IsMetricUpgradeStartTimeSet(upgradeConfig.Name, upgradeConfig.Spec.Desired.Version).Times(1),
+					mockMetricsClient.EXPECT().IsMetricUpgradeStartedSet(upgradeConfig.Name, upgradeConfig.Spec.Desired.Version).Times(1),
 					mockKubeClient.EXPECT().Update(gomock.Any(), gomock.Any()).Times(1).Return(fakeError),
-					mockMetricsClient.EXPECT().UpdateMetricUpgradeStartTime(gomock.Any(), upgradeConfig.Name, upgradeConfig.Spec.Desired.Version).Times(1),
+					mockMetricsClient.EXPECT().UpdateMetricUpgradeStarted(upgradeConfig.Name, upgradeConfig.Spec.Desired.Version).Times(1),
 				)
 				result, err := CommenceUpgrade(mockKubeClient, mockScalerClient, mockMetricsClient, mockMaintClient, upgradeConfig, logger)
 				Expect(err).To(HaveOccurred())

--- a/pkg/osd_cluster_upgrader/upgrader_test.go
+++ b/pkg/osd_cluster_upgrader/upgrader_test.go
@@ -173,7 +173,10 @@ var _ = Describe("ClusterUpgrader", func() {
 		Context("When the cluster's desired version matches the UpgradeConfig's", func() {
 			It("Indicates the upgrade has commenced", func() {
 				expectUpgradeHasCommenced(mockKubeClient, upgradeConfig, nil)
-				mockKubeClient.EXPECT().Update(gomock.Any(), gomock.Any()).Times(0)
+				gomock.InOrder(
+					mockKubeClient.EXPECT().Update(gomock.Any(), gomock.Any()).Times(0),
+					mockMetricsClient.EXPECT().UpdateMetricUpgradeStarted(upgradeConfig.Name, upgradeConfig.Spec.Desired.Version),
+				)
 				result, err := CommenceUpgrade(mockKubeClient, mockScalerClient, mockMetricsClient, mockMaintClient, upgradeConfig, logger)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(BeTrue())
@@ -308,6 +311,9 @@ var _ = Describe("ClusterUpgrader", func() {
 		})
 		It("will not re-perform commencing an upgrade", func() {
 			expectUpgradeHasCommenced(mockKubeClient, upgradeConfig, nil)
+			gomock.InOrder(
+				mockMetricsClient.EXPECT().UpdateMetricUpgradeStarted(upgradeConfig.Name, upgradeConfig.Spec.Desired.Version),
+			)
 			result, err := CommenceUpgrade(mockKubeClient, mockScalerClient, mockMetricsClient, mockMaintClient, upgradeConfig, logger)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeTrue())


### PR DESCRIPTION
Update the starttime stamp to the started marker. Since the start timestamp will be cleared with the pod restarted.
Move the update metric call to the earlier of the func CommenceUpgrade to make sure it will be set after the pod recreated.

The will be conflict with @mrbarge 's PR. Put it here for review firstly, and will rebase later.