### PR TITLE
OSD-4548: Revert CRD version from v1 to v1beta1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ docker-build: build
 .PHONY: generate
 generate:
 	operator-sdk generate k8s
-	operator-sdk generate crds --crd-version v1
+	operator-sdk generate crds
 	openapi-gen --logtostderr=true \
 		-i ./pkg/apis/upgrade/v1alpha1 \
 		-o "" \

--- a/deploy/crds/upgrade.managed.openshift.io_upgradeconfigs_crd.yaml
+++ b/deploy/crds/upgrade.managed.openshift.io_upgradeconfigs_crd.yaml
@@ -1,8 +1,27 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: upgradeconfigs.upgrade.managed.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.desired.version
+    name: desired_version
+    type: string
+  - JSONPath: .status.history[0].phase
+    name: phase
+    type: string
+  - JSONPath: .status.history[0].conditions[0].type
+    name: stage
+    type: string
+  - JSONPath: .status.history[0].conditions[0].status
+    name: status
+    type: string
+  - JSONPath: .status.history[0].conditions[0].reason
+    name: reason
+    type: string
+  - JSONPath: .status.history[0].conditions[0].message
+    name: message
+    type: string
   group: upgrade.managed.openshift.io
   names:
     kind: UpgradeConfig
@@ -12,189 +31,170 @@ spec:
     - upgrade
     singular: upgradeconfig
   scope: Cluster
-  versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.desired.version
-      name: desired_version
-      type: string
-    - jsonPath: .status.history[0].phase
-      name: phase
-      type: string
-    - jsonPath: .status.history[0].conditions[0].type
-      name: stage
-      type: string
-    - jsonPath: .status.history[0].conditions[0].status
-      name: status
-      type: string
-    - jsonPath: .status.history[0].conditions[0].reason
-      name: reason
-      type: string
-    - jsonPath: .status.history[0].conditions[0].message
-      name: message
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: UpgradeConfig is the Schema for the upgradeconfigs API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: UpgradeConfigSpec defines the desired state of UpgradeConfig
-              and upgrade window and freeze window
-            properties:
-              PDBForceDrainTimeout:
-                default: 60
-                description: The maximum grace period granted to a node whose drain
-                  is blocked by a Pod Disruption Budget, before that drain is forced.
-                  Measured in minutes.
-                format: int32
-                type: integer
-              desired:
-                description: Specify the desired OpenShift release
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: UpgradeConfig is the Schema for the upgradeconfigs API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: UpgradeConfigSpec defines the desired state of UpgradeConfig
+            and upgrade window and freeze window
+          properties:
+            PDBForceDrainTimeout:
+              default: 60
+              description: The maximum grace period granted to a node whose drain
+                is blocked by a Pod Disruption Budget, before that drain is forced.
+                Measured in minutes.
+              format: int32
+              type: integer
+            desired:
+              description: Specify the desired OpenShift release
+              properties:
+                channel:
+                  description: Channel we gonna use for upgrades
+                  type: string
+                force:
+                  default: false
+                  description: Force upgrade, default value is False
+                  type: boolean
+                version:
+                  description: Version of openshift release
+                  type: string
+              required:
+              - channel
+              - force
+              - version
+              type: object
+            proceed:
+              default: true
+              description: Given all conditions have passed and cluster is ready to
+                upgrade, proceed governs this decision to continue and commence the
+                upgrade
+              type: boolean
+            subscriptionUpdates:
+              description: This defines the 3rd party operator subscriptions upgrade
+              items:
+                description: SubscriptionUpdate describe the 3rd party operator update
+                  config
                 properties:
                   channel:
-                    description: Channel we gonna use for upgrades
+                    description: Describe the channel for the Subscription
                     type: string
-                  force:
-                    default: false
-                    description: Force upgrade, default value is False
-                    type: boolean
-                  version:
-                    description: Version of openshift release
+                  name:
+                    description: Describe the name of the Subscription
+                    type: string
+                  namespace:
+                    description: Describe the namespace of the Subscription
                     type: string
                 required:
                 - channel
-                - force
-                - version
+                - name
+                - namespace
                 type: object
-              proceed:
-                default: true
-                description: Given all conditions have passed and cluster is ready
-                  to upgrade, proceed governs this decision to continue and commence
-                  the upgrade
-                type: boolean
-              subscriptionUpdates:
-                description: This defines the 3rd party operator subscriptions upgrade
-                items:
-                  description: SubscriptionUpdate describe the 3rd party operator
-                    update config
-                  properties:
-                    channel:
-                      description: Describe the channel for the Subscription
-                      type: string
-                    name:
-                      description: Describe the name of the Subscription
-                      type: string
-                    namespace:
-                      description: Describe the namespace of the Subscription
-                      type: string
-                  required:
-                  - channel
-                  - name
-                  - namespace
-                  type: object
-                type: array
-              type:
-                description: Type indicates the ClusterUpgrader implementation to
-                  use to perform an upgrade of the cluster
-                enum:
-                - OSD
-                type: string
-              upgradeAt:
-                description: Specify the upgrade start time
-                type: string
-            required:
-            - PDBForceDrainTimeout
-            - desired
-            - proceed
-            - type
-            - upgradeAt
-            type: object
-          status:
-            description: UpgradeConfigStatus defines the observed state of UpgradeConfig
-            properties:
-              history:
-                description: This record history of every upgrade
-                items:
-                  description: UpgradeHistory record history of upgrade
-                  properties:
-                    completeTime:
-                      format: date-time
-                      type: string
-                    conditions:
-                      description: Conditions is a set of Condition instances.
-                      items:
-                        properties:
-                          completeTime:
-                            description: Complete time of this condition.
-                            format: date-time
-                            type: string
-                          lastProbeTime:
-                            description: Last time the condition was checked.
-                            format: date-time
-                            type: string
-                          lastTransitionTime:
-                            description: Last time the condition transit from one
-                              status to another.
-                            format: date-time
-                            type: string
-                          message:
-                            description: Human readable message indicating details
-                              about last transition.
-                            type: string
-                          reason:
-                            description: (brief) reason for the condition's last transition.
-                            type: string
-                          startTime:
-                            description: Start time of this condition.
-                            format: date-time
-                            type: string
-                          status:
-                            description: Status of condition, one of True, False,
-                              Unknown
-                            type: string
-                          type:
-                            description: Type of upgrade condition
-                            type: string
-                        required:
-                        - status
-                        - type
-                        type: object
-                      type: array
-                    phase:
-                      default: New
-                      description: This describe the status of the upgrade process
-                      enum:
-                      - New
-                      - Pending
-                      - Upgrading
-                      - Upgraded
-                      - Failed
-                      type: string
-                    startTime:
-                      format: date-time
-                      type: string
-                    version:
-                      description: Desired version of this upgrade
-                      type: string
-                  required:
-                  - phase
-                  type: object
-                type: array
-            type: object
-        type: object
+              type: array
+            type:
+              description: Type indicates the ClusterUpgrader implementation to use
+                to perform an upgrade of the cluster
+              enum:
+              - OSD
+              type: string
+            upgradeAt:
+              description: Specify the upgrade start time
+              type: string
+          required:
+          - PDBForceDrainTimeout
+          - desired
+          - proceed
+          - type
+          - upgradeAt
+          type: object
+        status:
+          description: UpgradeConfigStatus defines the observed state of UpgradeConfig
+          properties:
+            history:
+              description: This record history of every upgrade
+              items:
+                description: UpgradeHistory record history of upgrade
+                properties:
+                  completeTime:
+                    format: date-time
+                    type: string
+                  conditions:
+                    description: Conditions is a set of Condition instances.
+                    items:
+                      properties:
+                        completeTime:
+                          description: Complete time of this condition.
+                          format: date-time
+                          type: string
+                        lastProbeTime:
+                          description: Last time the condition was checked.
+                          format: date-time
+                          type: string
+                        lastTransitionTime:
+                          description: Last time the condition transit from one status
+                            to another.
+                          format: date-time
+                          type: string
+                        message:
+                          description: Human readable message indicating details about
+                            last transition.
+                          type: string
+                        reason:
+                          description: (brief) reason for the condition's last transition.
+                          type: string
+                        startTime:
+                          description: Start time of this condition.
+                          format: date-time
+                          type: string
+                        status:
+                          description: Status of condition, one of True, False, Unknown
+                          type: string
+                        type:
+                          description: Type of upgrade condition
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  phase:
+                    default: New
+                    description: This describe the status of the upgrade process
+                    enum:
+                    - New
+                    - Pending
+                    - Upgrading
+                    - Upgraded
+                    - Failed
+                    type: string
+                  startTime:
+                    format: date-time
+                    type: string
+                  version:
+                    description: Desired version of this upgrade
+                    type: string
+                required:
+                - phase
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
     served: true
     storage: true
-    subresources:
-      status: {}

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -208,11 +208,30 @@ objects:
             name: managed-upgrade-operator
             source: managed-upgrade-operator-catalog
             sourceNamespace: openshift-managed-upgrade-operator
-        - apiVersion: apiextensions.k8s.io/v1
+        - apiVersion: apiextensions.k8s.io/v1beta1
           kind: CustomResourceDefinition
           metadata:
             name: upgradeconfigs.upgrade.managed.openshift.io
           spec:
+            additionalPrinterColumns:
+              - JSONPath: .spec.desired.version
+                name: desired_version
+                type: string
+              - JSONPath: .status.history[0].phase
+                name: phase
+                type: string
+              - JSONPath: .status.history[0].conditions[0].type
+                name: stage
+                type: string
+              - JSONPath: .status.history[0].conditions[0].status
+                name: status
+                type: string
+              - JSONPath: .status.history[0].conditions[0].reason
+                name: reason
+                type: string
+              - JSONPath: .status.history[0].conditions[0].message
+                name: message
+                type: string
             group: upgrade.managed.openshift.io
             names:
               kind: UpgradeConfig
@@ -222,192 +241,179 @@ objects:
                 - upgrade
               singular: upgradeconfig
             scope: Cluster
-            versions:
-              - additionalPrinterColumns:
-                  - jsonPath: .spec.desired.version
-                    name: desired_version
+            subresources:
+              status: {}
+            validation:
+              openAPIV3Schema:
+                description: UpgradeConfig is the Schema for the upgradeconfigs API
+                properties:
+                  apiVersion:
+                    description:
+                      "APIVersion defines the versioned schema of this representation
+                      of an object. Servers should convert recognized schemas to the latest
+                      internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
                     type: string
-                  - jsonPath: .status.history[0].phase
-                    name: phase
+                  kind:
+                    description:
+                      "Kind is a string value representing the REST resource this
+                      object represents. Servers may infer this from the endpoint the client
+                      submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
                     type: string
-                  - jsonPath: .status.history[0].conditions[0].type
-                    name: stage
-                    type: string
-                  - jsonPath: .status.history[0].conditions[0].status
-                    name: status
-                    type: string
-                  - jsonPath: .status.history[0].conditions[0].reason
-                    name: reason
-                    type: string
-                  - jsonPath: .status.history[0].conditions[0].message
-                    name: message
-                    type: string
-                name: v1alpha1
-                schema:
-                  openAPIV3Schema:
-                    description: UpgradeConfig is the Schema for the upgradeconfigs API
+                  metadata:
+                    type: object
+                  spec:
+                    description:
+                      UpgradeConfigSpec defines the desired state of UpgradeConfig
+                      and upgrade window and freeze window
                     properties:
-                      apiVersion:
+                      PDBForceDrainTimeout:
+                        default: 60
                         description:
-                          "APIVersion defines the versioned schema of this representation
-                          of an object. Servers should convert recognized schemas to the latest
-                          internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
-                        type: string
-                      kind:
-                        description:
-                          "Kind is a string value representing the REST resource this
-                          object represents. Servers may infer this from the endpoint the client
-                          submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-                        type: string
-                      metadata:
-                        type: object
-                      spec:
-                        description:
-                          UpgradeConfigSpec defines the desired state of UpgradeConfig
-                          and upgrade window and freeze window
+                          The maximum grace period granted to a node whose drain
+                          is blocked by a Pod Disruption Budget, before that drain is forced.
+                          Measured in minutes.
+                        format: int32
+                        type: integer
+                      desired:
+                        description: Specify the desired OpenShift release
                         properties:
-                          PDBForceDrainTimeout:
-                            default: 60
-                            description:
-                              The maximum grace period granted to a node whose drain
-                              is blocked by a Pod Disruption Budget, before that drain is forced.
-                              Measured in minutes.
-                            format: int32
-                            type: integer
-                          desired:
-                            description: Specify the desired OpenShift release
-                            properties:
-                              channel:
-                                description: Channel we gonna use for upgrades
-                                type: string
-                              force:
-                                default: false
-                                description: Force upgrade, default value is False
-                                type: boolean
-                              version:
-                                description: Version of openshift release
-                                type: string
-                            required:
-                              - channel
-                              - force
-                              - version
-                            type: object
-                          proceed:
-                            default: true
-                            description:
-                              Given all conditions have passed and cluster is ready
-                              to upgrade, proceed governs this decision to continue and commence
-                              the upgrade
-                            type: boolean
-                          subscriptionUpdates:
-                            description: This defines the 3rd party operator subscriptions upgrade
-                            items:
-                              description: SubscriptionUpdate describe the 3rd party operator update config
-                              properties:
-                                channel:
-                                  description: Describe the channel for the Subscription
-                                  type: string
-                                name:
-                                  description: Describe the name of the Subscription
-                                  type: string
-                                namespace:
-                                  description: Describe the namespace of the Subscription
-                                  type: string
-                              required:
-                                - channel
-                                - name
-                                - namespace
-                              type: object
-                            type: array
-                          type:
-                            description: Type indicates the ClusterUpgrader implementation to use to perform an upgrade of the cluster
-                            enum:
-                              - OSD
+                          channel:
+                            description: Channel we gonna use for upgrades
                             type: string
-                          upgradeAt:
-                            description: Specify the upgrade start time
+                          force:
+                            default: false
+                            description: Force upgrade, default value is False
+                            type: boolean
+                          version:
+                            description: Version of openshift release
                             type: string
                         required:
-                          - PDBForceDrainTimeout
-                          - desired
-                          - proceed
-                          - type
-                          - upgradeAt
+                          - channel
+                          - force
+                          - version
                         type: object
-                      status:
-                        description: UpgradeConfigStatus defines the observed state of UpgradeConfig
-                        properties:
-                          history:
-                            description: This record history of every upgrade
-                            items:
-                              description: UpgradeHistory record history of upgrade
-                              properties:
-                                completeTime:
-                                  format: date-time
-                                  type: string
-                                conditions:
-                                  description: Conditions is a set of Condition instances.
-                                  items:
-                                    properties:
-                                      completeTime:
-                                        description: Complete time of this condition.
-                                        format: date-time
-                                        type: string
-                                      lastProbeTime:
-                                        description: Last time the condition was checked.
-                                        format: date-time
-                                        type: string
-                                      lastTransitionTime:
-                                        description: Last time the condition transit from one
-                                          status to another.
-                                        format: date-time
-                                        type: string
-                                      message:
-                                        description: Human readable message indicating details
-                                          about last transition.
-                                        type: string
-                                      reason:
-                                        description: (brief) reason for the condition's last transition.
-                                        type: string
-                                      startTime:
-                                        description: Start time of this condition.
-                                        format: date-time
-                                        type: string
-                                      status:
-                                        description: Status of condition, one of True, False,
-                                          Unknown
-                                        type: string
-                                      type:
-                                        description: Type of upgrade condition
-                                        type: string
-                                    required:
-                                      - status
-                                      - type
-                                    type: object
-                                  type: array
-                                phase:
-                                  default: New
-                                  description: This describe the status of the upgrade process
-                                  enum:
-                                    - New
-                                    - Pending
-                                    - Upgrading
-                                    - Upgraded
-                                    - Failed
-                                  type: string
-                                startTime:
-                                  format: date-time
-                                  type: string
-                                version:
-                                  description: Desired version of this upgrade
-                                  type: string
-                              required:
-                                - phase
-                              type: object
-                            type: array
-                        type: object
+                      proceed:
+                        default: true
+                        description:
+                          Given all conditions have passed and cluster is ready to
+                          upgrade, proceed governs this decision to continue and commence the
+                          upgrade
+                        type: boolean
+                      subscriptionUpdates:
+                        description: This defines the 3rd party operator subscriptions upgrade
+                        items:
+                          description:
+                            SubscriptionUpdate describe the 3rd party operator update
+                            config
+                          properties:
+                            channel:
+                              description: Describe the channel for the Subscription
+                              type: string
+                            name:
+                              description: Describe the name of the Subscription
+                              type: string
+                            namespace:
+                              description: Describe the namespace of the Subscription
+                              type: string
+                          required:
+                            - channel
+                            - name
+                            - namespace
+                          type: object
+                        type: array
+                      type:
+                        description:
+                          Type indicates the ClusterUpgrader implementation to use
+                          to perform an upgrade of the cluster
+                        enum:
+                          - OSD
+                        type: string
+                      upgradeAt:
+                        description: Specify the upgrade start time
+                        type: string
+                    required:
+                      - PDBForceDrainTimeout
+                      - desired
+                      - proceed
+                      - type
+                      - upgradeAt
                     type: object
+                  status:
+                    description: UpgradeConfigStatus defines the observed state of UpgradeConfig
+                    properties:
+                      history:
+                        description: This record history of every upgrade
+                        items:
+                          description: UpgradeHistory record history of upgrade
+                          properties:
+                            completeTime:
+                              format: date-time
+                              type: string
+                            conditions:
+                              description: Conditions is a set of Condition instances.
+                              items:
+                                properties:
+                                  completeTime:
+                                    description: Complete time of this condition.
+                                    format: date-time
+                                    type: string
+                                  lastProbeTime:
+                                    description: Last time the condition was checked.
+                                    format: date-time
+                                    type: string
+                                  lastTransitionTime:
+                                    description:
+                                      Last time the condition transit from one status
+                                      to another.
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    description:
+                                      Human readable message indicating details about
+                                      last transition.
+                                    type: string
+                                  reason:
+                                    description: (brief) reason for the condition's last transition.
+                                    type: string
+                                  startTime:
+                                    description: Start time of this condition.
+                                    format: date-time
+                                    type: string
+                                  status:
+                                    description: Status of condition, one of True, False, Unknown
+                                    type: string
+                                  type:
+                                    description: Type of upgrade condition
+                                    type: string
+                                required:
+                                  - status
+                                  - type
+                                type: object
+                              type: array
+                            phase:
+                              default: New
+                              description: This describe the status of the upgrade process
+                              enum:
+                                - New
+                                - Pending
+                                - Upgrading
+                                - Upgraded
+                                - Failed
+                              type: string
+                            startTime:
+                              format: date-time
+                              type: string
+                            version:
+                              description: Desired version of this upgrade
+                              type: string
+                          required:
+                            - phase
+                          type: object
+                        type: array
+                    type: object
+                type: object
+            version: v1alpha1
+            versions:
+              - name: v1alpha1
                 served: true
                 storage: true
-                subresources:
-                  status: {}


### PR DESCRIPTION
Reverting CRD version from v1 to v1beta1 as per https://issues.redhat.com/browse/OSD-4548 JIRA. 