### PR TITLE
OSD-4548: Removing defaults from CRD as not supported in v1beta1

### DIFF
--- a/deploy/crds/upgrade.managed.openshift.io_upgradeconfigs_crd.yaml
+++ b/deploy/crds/upgrade.managed.openshift.io_upgradeconfigs_crd.yaml
@@ -54,7 +54,6 @@ spec:
             and upgrade window and freeze window
           properties:
             PDBForceDrainTimeout:
-              default: 60
               description: The maximum grace period granted to a node whose drain
                 is blocked by a Pod Disruption Budget, before that drain is forced.
                 Measured in minutes.
@@ -67,7 +66,6 @@ spec:
                   description: Channel we gonna use for upgrades
                   type: string
                 force:
-                  default: false
                   description: Force upgrade, default value is False
                   type: boolean
                 version:
@@ -79,7 +77,6 @@ spec:
               - version
               type: object
             proceed:
-              default: true
               description: Given all conditions have passed and cluster is ready to
                 upgrade, proceed governs this decision to continue and commence the
                 upgrade
@@ -172,7 +169,6 @@ spec:
                       type: object
                     type: array
                   phase:
-                    default: New
                     description: This describe the status of the upgrade process
                     enum:
                     - New

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -267,7 +267,6 @@ objects:
                       and upgrade window and freeze window
                     properties:
                       PDBForceDrainTimeout:
-                        default: 60
                         description:
                           The maximum grace period granted to a node whose drain
                           is blocked by a Pod Disruption Budget, before that drain is forced.
@@ -281,7 +280,6 @@ objects:
                             description: Channel we gonna use for upgrades
                             type: string
                           force:
-                            default: false
                             description: Force upgrade, default value is False
                             type: boolean
                           version:
@@ -293,7 +291,6 @@ objects:
                           - version
                         type: object
                       proceed:
-                        default: true
                         description:
                           Given all conditions have passed and cluster is ready to
                           upgrade, proceed governs this decision to continue and commence the
@@ -391,7 +388,6 @@ objects:
                                 type: object
                               type: array
                             phase:
-                              default: New
                               description: This describe the status of the upgrade process
                               enum:
                                 - New

--- a/pkg/apis/upgrade/v1alpha1/upgradeconfig_types.go
+++ b/pkg/apis/upgrade/v1alpha1/upgradeconfig_types.go
@@ -21,11 +21,9 @@ type UpgradeConfigSpec struct {
 	// Specify the upgrade start time
 	UpgradeAt string `json:"upgradeAt"`
 
-	// +kubebuilder:default:=60
 	// The maximum grace period granted to a node whose drain is blocked by a Pod Disruption Budget, before that drain is forced. Measured in minutes.
 	PDBForceDrainTimeout int32 `json:"PDBForceDrainTimeout"`
 
-	// +kubebuilder:default:=true
 	// Given all conditions have passed and cluster is ready to upgrade, proceed governs this decision to continue and commence the upgrade
 	Proceed bool `json:"proceed"`
 
@@ -54,7 +52,6 @@ type UpgradeHistory struct {
 	//Desired version of this upgrade
 	Version string `json:"version,omitempty"`
 	// +kubebuilder:validation:Enum={"New","Pending","Upgrading","Upgraded", "Failed"}
-	// +kubebuilder:default:="New"
 	// This describe the status of the upgrade process
 	Phase UpgradePhase `json:"phase"`
 
@@ -155,7 +152,6 @@ type Update struct {
 	Version string `json:"version"`
 	// Channel we gonna use for upgrades
 	Channel string `json:"channel"`
-	// +kubebuilder:default:=false
 	// Force upgrade, default value is False
 	Force bool `json:"force"`
 }


### PR DESCRIPTION
After reverting the CRD version from v1 to v1beta1, the creation of CRD failed with below error:
```
$ oc create -f https://raw.githubusercontent.com/openshift/managed-upgrade-operator/master/deploy/crds/upgrade.managed.openshift.io_upgradeconfigs_crd.yaml
The CustomResourceDefinition "upgradeconfigs.upgrade.managed.openshift.io" is invalid: 
* spec.validation.openAPIV3Schema.properties[status].properties[history].items.properties[phase].default: Forbidden: must not be set
* spec.validation.openAPIV3Schema.properties[spec].properties[proceed].default: Forbidden: must not be set
* spec.validation.openAPIV3Schema.properties[spec].properties[PDBForceDrainTimeout].default: Forbidden: must not be set
* spec.validation.openAPIV3Schema.properties[spec].properties[desired].properties[force].default: Forbidden: must not be set
```
This PR is to remove the "defaults" from CRD as it is not supported as part of v1beta1 version of CRD. Seems this CRD version change wasn't handled by operator-sdk. 

Checked creation of CRD and it works fine as expected on OCP 4.4. This PR is part of https://issues.redhat.com/browse/OSD-4548. 