### PR TITLE
Move history to reconciler and remove extra conditions

### DIFF
--- a/pkg/cluster_upgrader_builder/cluster_upgrader_builder.go
+++ b/pkg/cluster_upgrader_builder/cluster_upgrader_builder.go
@@ -12,7 +12,7 @@ import (
 // Interface describing the functions of a cluster upgrader.
 //go:generate mockgen -destination=mocks/cluster_upgrader.go -package=mocks github.com/openshift/managed-upgrade-operator/pkg/cluster_upgrader_builder ClusterUpgrader
 type ClusterUpgrader interface {
-	UpgradeCluster(upgradeConfig *upgradev1alpha1.UpgradeConfig, logger logr.Logger) error
+	UpgradeCluster(upgradeConfig *upgradev1alpha1.UpgradeConfig, logger logr.Logger) (upgradev1alpha1.UpgradePhase, *upgradev1alpha1.UpgradeCondition, error)
 }
 
 //go:generate mockgen -destination=mocks/cluster_upgrader_builder.go -package=mocks github.com/openshift/managed-upgrade-operator/pkg/cluster_upgrader_builder ClusterUpgraderBuilder

--- a/pkg/cluster_upgrader_builder/mocks/cluster_upgrader.go
+++ b/pkg/cluster_upgrader_builder/mocks/cluster_upgrader.go
@@ -35,11 +35,13 @@ func (m *MockClusterUpgrader) EXPECT() *MockClusterUpgraderMockRecorder {
 }
 
 // UpgradeCluster mocks base method
-func (m *MockClusterUpgrader) UpgradeCluster(arg0 *v1alpha1.UpgradeConfig, arg1 logr.Logger) error {
+func (m *MockClusterUpgrader) UpgradeCluster(arg0 *v1alpha1.UpgradeConfig, arg1 logr.Logger) (v1alpha1.UpgradePhase, *v1alpha1.UpgradeCondition, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradeCluster", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(v1alpha1.UpgradePhase)
+	ret1, _ := ret[1].(*v1alpha1.UpgradeCondition)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // UpgradeCluster indicates an expected call of UpgradeCluster

--- a/pkg/controller/upgradeconfig/upgradeconfig_controller_test.go
+++ b/pkg/controller/upgradeconfig/upgradeconfig_controller_test.go
@@ -160,16 +160,15 @@ var _ = Describe("UpgradeConfigController", func() {
 					It("Adds it successfully", func() {
 						matcher := testStructs.NewUpgradeConfigMatcher()
 						util.ExpectGetClusterVersion(mockKubeClient, clusterVersionList, nil)
-						gomock.InOrder(
-							mockKubeClient.EXPECT().Get(gomock.Any(), upgradeConfigName, gomock.Any()).SetArg(2, *upgradeConfig).Times(1),
-							mockKubeClient.EXPECT().Status().Return(mockUpdater).AnyTimes(),
-							mockUpdater.EXPECT().Update(gomock.Any(), matcher).AnyTimes(),
-							mockValidationBuilder.EXPECT().NewClient().Return(mockValidator, nil),
-							mockValidator.EXPECT().IsValidUpgradeConfig(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil),
-							mockMetricsClient.EXPECT().UpdateMetricValidationSucceeded(gomock.Any()),
-							mockClusterUpgraderBuilder.EXPECT().NewClient(gomock.Any(), gomock.Any(), upgradeConfig.Spec.Type).Return(mockClusterUpgrader, nil),
-							mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any()).Times(1),
-						)
+
+						mockKubeClient.EXPECT().Get(gomock.Any(), upgradeConfigName, gomock.Any()).SetArg(2, *upgradeConfig).Times(1)
+						mockKubeClient.EXPECT().Status().Return(mockUpdater).Times(3)
+						mockUpdater.EXPECT().Update(gomock.Any(), matcher).Times(3)
+						mockValidationBuilder.EXPECT().NewClient().Return(mockValidator, nil)
+						mockValidator.EXPECT().IsValidUpgradeConfig(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
+						mockMetricsClient.EXPECT().UpdateMetricValidationSucceeded(gomock.Any())
+						mockClusterUpgraderBuilder.EXPECT().NewClient(gomock.Any(), gomock.Any(), upgradeConfig.Spec.Type).Return(mockClusterUpgrader, nil)
+						mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any()).Times(1).Return(upgradev1alpha1.UpgradePhaseUpgrading, &upgradev1alpha1.UpgradeCondition{}, nil)
 						_, err := reconciler.Reconcile(reconcile.Request{NamespacedName: upgradeConfigName})
 						Expect(err).NotTo(HaveOccurred())
 						Expect(matcher.ActualUpgradeConfig.Status.History).To(ContainElement(
@@ -218,18 +217,20 @@ var _ = Describe("UpgradeConfigController", func() {
 					})
 					It("Invokes the upgrader", func() {
 						util.ExpectGetClusterVersion(mockKubeClient, clusterVersionList, nil)
-						gomock.InOrder(
-							mockKubeClient.EXPECT().Get(gomock.Any(), upgradeConfigName, gomock.Any()).SetArg(2, *upgradeConfig).Times(1),
-							mockValidationBuilder.EXPECT().NewClient().Return(mockValidator, nil),
-							mockValidator.EXPECT().IsValidUpgradeConfig(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil),
-							mockMetricsClient.EXPECT().UpdateMetricValidationSucceeded(gomock.Any()),
-							mockClusterUpgraderBuilder.EXPECT().NewClient(gomock.Any(), gomock.Any(), upgradeConfig.Spec.Type).Return(mockClusterUpgrader, nil),
-							mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any()).Times(1),
-						)
+						mockKubeClient.EXPECT().Get(gomock.Any(), upgradeConfigName, gomock.Any()).SetArg(2, *upgradeConfig).Times(1)
+						mockKubeClient.EXPECT().Status().Return(mockUpdater).Times(3)
+						mockUpdater.EXPECT().Update(gomock.Any(), gomock.Any()).Times(3)
+						mockValidationBuilder.EXPECT().NewClient().Return(mockValidator, nil)
+						mockValidator.EXPECT().IsValidUpgradeConfig(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
+						mockMetricsClient.EXPECT().UpdateMetricValidationSucceeded(gomock.Any())
+						mockClusterUpgraderBuilder.EXPECT().NewClient(gomock.Any(), gomock.Any(), upgradeConfig.Spec.Type).Return(mockClusterUpgrader, nil)
+						mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any()).Times(1).Return(upgradev1alpha1.UpgradePhaseUpgraded, &upgradev1alpha1.UpgradeCondition{Message: "test passed"}, nil)
 						result, err := reconciler.Reconcile(reconcile.Request{NamespacedName: upgradeConfigName})
 						Expect(err).NotTo(HaveOccurred())
 						Expect(result.Requeue).To(BeFalse())
 						Expect(result.RequeueAfter).To(BeZero())
+						Expect(upgradeConfig.Status.History.GetHistory("a version").Phase == upgradev1alpha1.UpgradePhaseUpgraded).To(BeTrue())
+						Expect(upgradeConfig.Status.History.GetHistory("a version").Conditions[0].Message == "test passed").To(BeTrue())
 					})
 				})
 			})
@@ -294,14 +295,16 @@ var _ = Describe("UpgradeConfigController", func() {
 						})
 						It("Invokes the upgrader", func() {
 							util.ExpectGetClusterVersion(mockKubeClient, clusterVersionList, nil)
-							gomock.InOrder(
-								mockKubeClient.EXPECT().Get(gomock.Any(), upgradeConfigName, gomock.Any()).SetArg(2, *upgradeConfig).Times(1),
-								mockValidationBuilder.EXPECT().NewClient().Return(mockValidator, nil),
-								mockValidator.EXPECT().IsValidUpgradeConfig(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil),
-								mockMetricsClient.EXPECT().UpdateMetricValidationSucceeded(gomock.Any()),
-								mockClusterUpgraderBuilder.EXPECT().NewClient(gomock.Any(), gomock.Any(), upgradeConfig.Spec.Type).Return(mockClusterUpgrader, nil),
-								mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any()).Times(1),
-							)
+							mockKubeClient.EXPECT().Get(gomock.Any(), upgradeConfigName, gomock.Any()).SetArg(2, *upgradeConfig).Times(1)
+							mockKubeClient.EXPECT().Status().Return(mockUpdater).Times(3)
+							mockUpdater.EXPECT().Update(gomock.Any(), gomock.Any()).Times(3)
+							mockValidationBuilder.EXPECT().NewClient().Return(mockValidator, nil)
+							mockValidator.EXPECT().IsValidUpgradeConfig(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
+							mockMetricsClient.EXPECT().UpdateMetricValidationSucceeded(gomock.Any())
+							mockClusterUpgraderBuilder.EXPECT().NewClient(gomock.Any(), gomock.Any(), upgradeConfig.Spec.Type).Return(mockClusterUpgrader, nil)
+							mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any()).Times(1).Return(upgradev1alpha1.UpgradePhaseUpgrading, &upgradev1alpha1.UpgradeCondition{}, nil)
+							mockKubeClient.EXPECT().Status().AnyTimes().Return(mockUpdater)
+							mockUpdater.EXPECT().Update(gomock.Any(), gomock.Any()).AnyTimes()
 							result, err := reconciler.Reconcile(reconcile.Request{NamespacedName: upgradeConfigName})
 							Expect(err).NotTo(HaveOccurred())
 							Expect(result.Requeue).To(BeFalse())
@@ -330,16 +333,18 @@ var _ = Describe("UpgradeConfigController", func() {
 
 						It("reacts accordingly", func() {
 							util.ExpectGetClusterVersion(mockKubeClient, clusterVersionList, nil)
-							gomock.InOrder(
-								mockKubeClient.EXPECT().Get(gomock.Any(), upgradeConfigName, gomock.Any()).SetArg(2, *upgradeConfig).Times(1),
-								mockValidationBuilder.EXPECT().NewClient().Return(mockValidator, nil),
-								mockValidator.EXPECT().IsValidUpgradeConfig(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil),
-								mockMetricsClient.EXPECT().UpdateMetricValidationSucceeded(gomock.Any()),
-								mockClusterUpgraderBuilder.EXPECT().NewClient(gomock.Any(), gomock.Any(), upgradeConfig.Spec.Type).Return(mockClusterUpgrader, nil),
-								mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any()).Times(1).Return(fakeError),
-							)
+							mockKubeClient.EXPECT().Get(gomock.Any(), upgradeConfigName, gomock.Any()).SetArg(2, *upgradeConfig).Times(1)
+							mockKubeClient.EXPECT().Status().Return(mockUpdater).Times(3)
+							mockUpdater.EXPECT().Update(gomock.Any(), gomock.Any()).Times(3)
+							mockValidationBuilder.EXPECT().NewClient().Return(mockValidator, nil)
+							mockValidator.EXPECT().IsValidUpgradeConfig(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
+							mockMetricsClient.EXPECT().UpdateMetricValidationSucceeded(gomock.Any())
+							mockClusterUpgraderBuilder.EXPECT().NewClient(gomock.Any(), gomock.Any(), upgradeConfig.Spec.Type).Return(mockClusterUpgrader, nil)
+							mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any()).Times(1).Return(upgradev1alpha1.UpgradePhaseUpgrading, &upgradev1alpha1.UpgradeCondition{}, fakeError)
+							mockKubeClient.EXPECT().Status().AnyTimes().Return(mockUpdater)
+							mockUpdater.EXPECT().Update(gomock.Any(), gomock.Any()).AnyTimes()
 							result, err := reconciler.Reconcile(reconcile.Request{NamespacedName: upgradeConfigName})
-							Expect(err).NotTo(HaveOccurred())
+							Expect(err).To(HaveOccurred())
 							Expect(result.Requeue).To(BeFalse())
 							Expect(result.RequeueAfter).To(BeZero())
 						})
@@ -440,7 +445,9 @@ var _ = Describe("UpgradeConfigController", func() {
 						gomock.InOrder(
 							mockKubeClient.EXPECT().Get(gomock.Any(), upgradeConfigName, gomock.Any()).SetArg(2, *upgradeConfig).Times(1),
 							mockClusterUpgraderBuilder.EXPECT().NewClient(gomock.Any(), gomock.Any(), upgradeConfig.Spec.Type).Return(mockClusterUpgrader, nil),
-							mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any()).Times(1),
+							mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any()).Times(1).Return(upgradev1alpha1.UpgradePhaseUpgrading, &upgradev1alpha1.UpgradeCondition{}, nil),
+							mockKubeClient.EXPECT().Status().AnyTimes().Return(mockUpdater),
+							mockUpdater.EXPECT().Update(gomock.Any(), gomock.Any()).AnyTimes(),
 						)
 						result, err := reconciler.Reconcile(reconcile.Request{NamespacedName: upgradeConfigName})
 						Expect(err).NotTo(HaveOccurred())
@@ -455,10 +462,12 @@ var _ = Describe("UpgradeConfigController", func() {
 						gomock.InOrder(
 							mockKubeClient.EXPECT().Get(gomock.Any(), upgradeConfigName, gomock.Any()).SetArg(2, *upgradeConfig).Times(1),
 							mockClusterUpgraderBuilder.EXPECT().NewClient(gomock.Any(), gomock.Any(), upgradeConfig.Spec.Type).Return(mockClusterUpgrader, nil),
-							mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any()).Times(1).Return(fakeError),
+							mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any()).Times(1).Return(upgradev1alpha1.UpgradePhaseUpgrading, &upgradev1alpha1.UpgradeCondition{}, fakeError),
+							mockKubeClient.EXPECT().Status().AnyTimes().Return(mockUpdater),
+							mockUpdater.EXPECT().Update(gomock.Any(), gomock.Any()).AnyTimes(),
 						)
 						result, err := reconciler.Reconcile(reconcile.Request{NamespacedName: upgradeConfigName})
-						Expect(err).NotTo(HaveOccurred())
+						Expect(err).To(HaveOccurred())
 						Expect(result.Requeue).To(BeFalse())
 						Expect(result.RequeueAfter).To(BeZero())
 					})


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-4497

Fixes a few things.

- ClusterUpgraders are now plugable components so to keep the history status updating consistent I have moved it to the reconciler. ClusterUpgraders will report their status and condition.
- We only display the one condition in our printer columns so moving to just saving the current one (Status gets very unreadable after a few upgrades) Condition reports the "the latest available observations of an object’s state"
- Test updates

