### PR TITLE
Adding log messages for isReadyToUpgrade validation

### DIFF
--- a/pkg/controller/upgradeconfig/upgradeconfig_controller.go
+++ b/pkg/controller/upgradeconfig/upgradeconfig_controller.go
@@ -236,7 +236,7 @@ func isReadyToUpgrade(upgradeConfig *upgradev1alpha1.UpgradeConfig, metricsClien
 	}
 	upgradeTime, err := time.Parse(time.RFC3339, upgradeConfig.Spec.UpgradeAt)
 	if err != nil {
-		log.Error(err, "Failed to parse spec.upgradeAt", upgradeConfig.Spec.UpgradeAt)
+		log.Error(err, "failed to parse spec.upgradeAt", upgradeConfig.Spec.UpgradeAt)
 		return false
 	}
 	now := time.Now()
@@ -247,7 +247,7 @@ func isReadyToUpgrade(upgradeConfig *upgradev1alpha1.UpgradeConfig, metricsClien
 		}
 		// We are past the maximum allowed time to commence upgrading
 		// TODO Need prior validation of UpgradeConfig at API level to avoid infinite error loop
-		log.Error(nil, "Field spec.upgradeAt cannot have backdated time")
+		log.Error(nil, "field spec.upgradeAt cannot have backdated time")
 		metricsClient.UpdateMetricUpgradeWindowBreached(upgradeConfig.Name)
 	} else {
 		// It hasn't reached the upgrade window yet

--- a/pkg/controller/upgradeconfig/upgradeconfig_controller.go
+++ b/pkg/controller/upgradeconfig/upgradeconfig_controller.go
@@ -28,6 +28,11 @@ var (
 	log = logf.Log.WithName("controller_upgradeconfig")
 )
 
+const (
+	// UpgradeGraceWindow is the number of minutes after UpgradeAt time when an upgrade is allowed to commence
+	UpgradeGraceWindow = 60
+)
+
 // Add creates a new UpgradeConfig Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
@@ -226,25 +231,29 @@ func (r *ReconcileUpgradeConfig) upgradeCluster(upgrader cub.ClusterUpgrader, uc
 // checks whether it's time to upgrade based on the spec.upgradeAt timestamp
 func isReadyToUpgrade(upgradeConfig *upgradev1alpha1.UpgradeConfig, metricsClient metrics.Metrics) bool {
 	if !upgradeConfig.Spec.Proceed {
-		log.Info("upgrade cannot be proceed", "proceed", upgradeConfig.Spec.Proceed)
+		log.Info("Upgrade cannot proceed", "proceed", upgradeConfig.Spec.Proceed)
 		return false
 	}
 	upgradeTime, err := time.Parse(time.RFC3339, upgradeConfig.Spec.UpgradeAt)
 	if err != nil {
-		log.Error(err, "failed to parse spec.upgradeAt", upgradeConfig.Spec.UpgradeAt)
+		log.Error(err, "Failed to parse spec.upgradeAt", upgradeConfig.Spec.UpgradeAt)
 		return false
 	}
 	now := time.Now()
 	if now.After(upgradeTime) {
 		// Is the current time within the allowable upgrade window
-		if upgradeTime.Add(60 * time.Minute).After(now) {
+		if upgradeTime.Add(UpgradeGraceWindow * time.Minute).After(now) {
 			return true
 		}
 		// We are past the maximum allowed time to commence upgrading
+		// TODO Need prior validation of UpgradeConfig at API level to avoid infinite error loop
+		log.Error(nil, "Field spec.upgradeAt cannot have backdated time")
 		metricsClient.UpdateMetricUpgradeWindowBreached(upgradeConfig.Name)
 	} else {
 		// It hasn't reached the upgrade window yet
 		metricsClient.UpdateMetricUpgradeWindowNotBreached(upgradeConfig.Name)
+		pendingTime := upgradeTime.Sub(now)
+		log.Info("Upgrade is scheduled after", "hours", int(pendingTime.Hours()))
 	}
 
 	return false


### PR DESCRIPTION
The logging message "[Checking if cluster can commence upgrade](https://github.com/openshift/managed-upgrade-operator/blob/master/pkg/controller/upgradeconfig/upgradeconfig_controller.go#L163)" kept on repeating without mentioning what it is checking and for how long. Added relevant logging messages to address it.

NOTE: 
1. If upgrade window is breached, the controller would atleast log error messages for now but I think a validating webhook is better in this case.
2. For now, the remaining time for upgrade is displayed in hours.

