### PR TITLE
Improve PR check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,4 +36,5 @@ run:
 
 .PHONY: lint
 lint:
+	golangci-lint cache clean
 	golangci-lint run

--- a/hack/app_sre_pr_check.sh
+++ b/hack/app_sre_pr_check.sh
@@ -5,13 +5,27 @@
 set -exv
 
 CURRENT_DIR=$(dirname "$0")
+BASE_IMG="managed-upgrade-operator"
+IMG="${BASE_IMG}:latest"
 
+# Validate YAML files
 python "$CURRENT_DIR"/validate_yaml.py "$CURRENT_DIR"/../deploy/crds
 if [ "$?" != "0" ]; then
     exit 1
 fi
 
-BASE_IMG="managed-upgrade-operator"
-IMG="${BASE_IMG}:latest"
+# Generate API changes and validate
+make generate
 
+MAKE_DIFFERENCE=$(git status --porcelain)
+
+if [ -n "${MAKE_DIFFERENCE}" ]; then
+	echo "Pull Request has modified changes. Please run ./hack/app_sre_pr_check.sh locally and commit changes"
+	git diff --exit-code
+fi
+
+# Run golangci-lint lint test on code
+make lint
+
+# Build Docker image
 BUILD_CMD="docker build" IMG="$IMG" make docker-build

--- a/pkg/validation/mockValidationBuilder.go
+++ b/pkg/validation/mockValidationBuilder.go
@@ -6,6 +6,7 @@ package validation
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	validation "github.com/openshift/managed-upgrade-operator/pkg/validation"
 	reflect "reflect"
 )
 
@@ -33,10 +34,10 @@ func (m *MockValidationBuilder) EXPECT() *MockValidationBuilderMockRecorder {
 }
 
 // NewClient mocks base method
-func (m *MockValidationBuilder) NewClient() (Validator, error) {
+func (m *MockValidationBuilder) NewClient() (validation.Validator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewClient")
-	ret0, _ := ret[0].(Validator)
+	ret0, _ := ret[0].(validation.Validator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/validation/mockValidationBuilder.go
+++ b/pkg/validation/mockValidationBuilder.go
@@ -6,7 +6,6 @@ package validation
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	validation "github.com/openshift/managed-upgrade-operator/pkg/validation"
 	reflect "reflect"
 )
 
@@ -34,10 +33,10 @@ func (m *MockValidationBuilder) EXPECT() *MockValidationBuilderMockRecorder {
 }
 
 // NewClient mocks base method
-func (m *MockValidationBuilder) NewClient() (validation.Validator, error) {
+func (m *MockValidationBuilder) NewClient() (Validator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewClient")
-	ret0, _ := ret[0].(validation.Validator)
+	ret0, _ := ret[0].(Validator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
Add checks to app-sre PR script to run `make generate` and `make lint` for every PR that is raised. It should fail if any local changes found after `make generate` command. `golangci-lint cache clean` is added for local run of `make lint` command failures.