### PR TITLE
Adding make generate changes for validation package

### DIFF
--- a/pkg/validation/mockValidationBuilder.go
+++ b/pkg/validation/mockValidationBuilder.go
@@ -6,6 +6,7 @@ package validation
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	validation "github.com/openshift/managed-upgrade-operator/pkg/validation"
 	reflect "reflect"
 )
 
@@ -33,10 +34,10 @@ func (m *MockValidationBuilder) EXPECT() *MockValidationBuilderMockRecorder {
 }
 
 // NewClient mocks base method
-func (m *MockValidationBuilder) NewClient() (Validator, error) {
+func (m *MockValidationBuilder) NewClient() (validation.Validator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewClient")
-	ret0, _ := ret[0].(Validator)
+	ret0, _ := ret[0].(validation.Validator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
Reverted this commit as part of https://github.com/openshift/managed-upgrade-operator/pull/78 and raising separate PR since #78 would require separate effort. 

The change in this PR is result of running `make generate` locally after a rebase since it was missed as part of some other PR. #78 is intended to address this gap for long term.