### PR TITLE
OSD-4668 operator needs PDB RBAC permissions

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -98,4 +98,11 @@ rules:
   - servicemonitors
   verbs:
   - '*'
-
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
Fixes OSD-4668 and adds RBAC permissions to act on poddisruptionbudget resources.
