### PR TITLE
OSD-4666 fix recording of controlplane timeout metric

### DIFF
--- a/pkg/osd_cluster_upgrader/upgrader.go
+++ b/pkg/osd_cluster_upgrader/upgrader.go
@@ -431,10 +431,12 @@ func ControlPlaneUpgraded(c client.Client, cfg *osdUpgradeConfig, scaler scaler.
 	var upgradeStartTime metav1.Time
 	var controlPlaneCompleteTime *metav1.Time
 	for _, c := range clusterVersion.Status.History {
-		if c.State == configv1.CompletedUpdate && c.Version == upgradeConfig.Spec.Desired.Version {
-			isCompleted = true
+		if c.Version == upgradeConfig.Spec.Desired.Version {
 			upgradeStartTime = c.StartedTime
-			controlPlaneCompleteTime = c.CompletionTime
+			if c.State == configv1.CompletedUpdate {
+				isCompleted = true
+				controlPlaneCompleteTime = c.CompletionTime
+			}
 		}
 	}
 


### PR DESCRIPTION
Addresses OSD-4666 where the Control Plane timeout metric is not being set when it should have been.
Also adds a test to test for this. (we didn't have one)
