### PR TITLE
Osd 4699 scaling blocked

### DIFF
--- a/pkg/controller/upgradeconfig/config.go
+++ b/pkg/controller/upgradeconfig/config.go
@@ -10,7 +10,7 @@ type config struct {
 }
 
 type upgradeWindow struct {
-	TimeOut time.Duration `yaml:"timeOut"`
+	TimeOut int `yaml:"timeOut"`
 }
 
 func (cfg *config) IsValid() error {
@@ -19,4 +19,8 @@ func (cfg *config) IsValid() error {
 	}
 
 	return nil
+}
+
+func (cfg *config) GetUpgradeWindowTimeOutDuration() time.Duration {
+	return time.Duration(cfg.UpgradeWindow.TimeOut) * time.Minute
 }

--- a/pkg/controller/upgradeconfig/upgradeconfig_controller.go
+++ b/pkg/controller/upgradeconfig/upgradeconfig_controller.go
@@ -173,7 +173,7 @@ func (r *ReconcileUpgradeConfig) Reconcile(request reconcile.Request) (reconcile
 		}
 
 		reqLogger.Info("Checking if cluster can commence upgrade.")
-		ready := r.scheduler.IsReadyToUpgrade(instance, metricsClient, cfg.UpgradeWindow.TimeOut)
+		ready := r.scheduler.IsReadyToUpgrade(instance, metricsClient, cfg.GetUpgradeWindowTimeOutDuration())
 		if ready {
 			upgrader, err := r.clusterUpgraderBuilder.NewClient(r.client, cfm, metricsClient, instance.Spec.Type)
 			if err != nil {

--- a/pkg/osd_cluster_upgrader/config.go
+++ b/pkg/osd_cluster_upgrader/config.go
@@ -12,16 +12,16 @@ type osdUpgradeConfig struct {
 }
 
 type maintenanceConfig struct {
-	ControlPlaneTime time.Duration `yaml:"controlPlaneTime"`
-	WorkerNodeTime   time.Duration `yaml:"workerNodeTime"`
+	ControlPlaneTime int `yaml:"controlPlaneTime"`
+	WorkerNodeTime   int `yaml:"workerNodeTime"`
 }
 
 type scaleConfig struct {
-	TimeOut time.Duration `yaml:"timeOut"`
+	TimeOut int `yaml:"timeOut"`
 }
 
 type nodeDrain struct {
-	TimeOut time.Duration `yaml:"timeOut"`
+	TimeOut int `yaml:"timeOut"`
 }
 
 func (cfg *osdUpgradeConfig) IsValid() error {
@@ -39,4 +39,20 @@ func (cfg *osdUpgradeConfig) IsValid() error {
 	}
 
 	return nil
+}
+
+func (cfg *osdUpgradeConfig) GetControlPlaneDuration() time.Duration {
+	return time.Duration(cfg.Maintenance.ControlPlaneTime) * time.Minute
+}
+
+func (cfg *osdUpgradeConfig) GetWorkerNodeDuration() time.Duration {
+	return time.Duration(cfg.Maintenance.WorkerNodeTime) * time.Minute
+}
+
+func (cfg *osdUpgradeConfig) GetScaleDuration() time.Duration {
+	return time.Duration(cfg.Scale.TimeOut) * time.Minute
+}
+
+func (cfg *osdUpgradeConfig) GetNodeDrainDuration() time.Duration {
+	return time.Duration(cfg.NodeDrain.TimeOut) * time.Minute
 }

--- a/pkg/osd_cluster_upgrader/upgrader.go
+++ b/pkg/osd_cluster_upgrader/upgrader.go
@@ -142,7 +142,7 @@ func EnsureExtraUpgradeWorkers(c client.Client, cfg *osdUpgradeConfig, s scaler.
 		return true, nil
 	}
 
-	isScaled, err := s.EnsureScaleUpNodes(c, cfg.Scale.TimeOut*time.Minute, logger)
+	isScaled, err := s.EnsureScaleUpNodes(c, cfg.GetScaleDuration(), logger)
 	if err != nil {
 		if scaler.IsScaleTimeOutError(err) {
 			metricsClient.UpdateMetricScalingFailed(upgradeConfig.Name)
@@ -194,7 +194,7 @@ func CommenceUpgrade(c client.Client, cfg *osdUpgradeConfig, scaler scaler.Scale
 
 // CreateControlPlaneMaintWindow creates the maintenance window for control plane
 func CreateControlPlaneMaintWindow(c client.Client, cfg *osdUpgradeConfig, scaler scaler.Scaler, metricsClient metrics.Metrics, m maintenance.Maintenance, upgradeConfig *upgradev1alpha1.UpgradeConfig, logger logr.Logger) (bool, error) {
-	endTime := time.Now().Add(cfg.Maintenance.ControlPlaneTime * time.Minute)
+	endTime := time.Now().Add(cfg.GetControlPlaneDuration())
 	err := m.StartControlPlane(endTime, upgradeConfig.Spec.Desired.Version)
 	if err != nil {
 		return false, err
@@ -228,7 +228,7 @@ func CreateWorkerMaintWindow(c client.Client, cfg *osdUpgradeConfig, scaler scal
 		return true, nil
 	}
 
-	maintenanceDurationPerNode := cfg.Maintenance.WorkerNodeTime * time.Minute
+	maintenanceDurationPerNode := cfg.GetWorkerNodeDuration()
 	workerMaintenanceExpectedDuration := time.Duration(pendingWorkerCount) * maintenanceDurationPerNode
 	endTime := time.Now().Add(workerMaintenanceExpectedDuration)
 	logger.Info(fmt.Sprintf("Creating worker node maintenace for %d remaining nodes", pendingWorkerCount))
@@ -242,7 +242,7 @@ func CreateWorkerMaintWindow(c client.Client, cfg *osdUpgradeConfig, scaler scal
 
 // AllWorkersUpgraded checks whether all the worker nodes are ready with new config
 func AllWorkersUpgraded(c client.Client, cfg *osdUpgradeConfig, scaler scaler.Scaler, metricsClient metrics.Metrics, m maintenance.Maintenance, upgradeConfig *upgradev1alpha1.UpgradeConfig, logger logr.Logger) (bool, error) {
-	okDrain, errDrain := nodeDrained(c, cfg.NodeDrain.TimeOut*time.Minute, upgradeConfig, logger)
+	okDrain, errDrain := nodeDrained(c, cfg.GetNodeDrainDuration(), upgradeConfig, logger)
 	if errDrain != nil {
 		return false, errDrain
 	}
@@ -440,7 +440,7 @@ func ControlPlaneUpgraded(c client.Client, cfg *osdUpgradeConfig, scaler scaler.
 		}
 	}
 
-	upgradeTimeout := cfg.Maintenance.ControlPlaneTime * time.Minute
+	upgradeTimeout := cfg.GetControlPlaneDuration()
 	if !upgradeStartTime.IsZero() && controlPlaneCompleteTime == nil && time.Now().After(upgradeStartTime.Add(upgradeTimeout)) {
 		logger.Info("Control plane upgrade timeout")
 		metricsClient.UpdateMetricUpgradeControlPlaneTimeout(upgradeConfig.Name, upgradeConfig.Spec.Desired.Version)

--- a/pkg/osd_cluster_upgrader/upgrader.go
+++ b/pkg/osd_cluster_upgrader/upgrader.go
@@ -492,7 +492,7 @@ func (cu osdClusterUpgrader) UpgradeCluster(upgradeConfig *upgradev1alpha1.Upgra
 // * critical alerts
 // * degraded operators (if there are critical alerts only)
 func performClusterHealthCheck(c client.Client, metricsClient metrics.Metrics, logger logr.Logger) (bool, error) {
-	alerts, err := metricsClient.Query("ALERTS{alertstate=\"firing\",severity=\"critical\",namespace=~\"^openshift.*|^kube.*|^default$\",namespace!=\"openshift-customer-monitoring\",alertname!=\"ClusterUpgradingSRE\",alertname!=\"DNSErrors05MinSRE\",alertname!=\"MetricsClientSendFailingSRE\"}")
+	alerts, err := metricsClient.Query("ALERTS{alertstate=\"firing\",severity=\"critical\",namespace=~\"^openshift.*|^kube.*|^default$\",namespace!=\"openshift-customer-monitoring\",alertname!=\"ClusterUpgradingSRE\",alertname!=\"DNSErrors05MinSRE\",alertname!=\"MetricsClientSendFailingSRE\",alertname!=\"UpgradeNodeScalingFailedSRE\"}")
 	if err != nil {
 		return false, fmt.Errorf("Unable to query critical alerts: %s", err)
 	}

--- a/pkg/osd_cluster_upgrader/upgrader_test.go
+++ b/pkg/osd_cluster_upgrader/upgrader_test.go
@@ -186,7 +186,7 @@ var _ = Describe("ClusterUpgrader", func() {
 
 	Context("Scaling", func() {
 		It("Should scale up extra nodes and set success metric on successful scaling", func() {
-			mockScalerClient.EXPECT().EnsureScaleUpNodes(gomock.Any(), config.Scale.TimeOut*time.Minute, gomock.Any()).Return(true, nil)
+			mockScalerClient.EXPECT().EnsureScaleUpNodes(gomock.Any(), config.GetScaleDuration(), gomock.Any()).Return(true, nil)
 			mockMetricsClient.EXPECT().UpdateMetricScalingSucceeded(gomock.Any())
 			expectUpgradeHasNotCommenced(mockKubeClient, upgradeConfig, nil)
 			ok, err := EnsureExtraUpgradeWorkers(mockKubeClient, config, mockScalerClient, mockMetricsClient, mockMaintClient, upgradeConfig, logger)
@@ -194,7 +194,7 @@ var _ = Describe("ClusterUpgrader", func() {
 			Expect(ok).To(BeTrue())
 		})
 		It("Should set failed metric on scaling time out", func() {
-			mockScalerClient.EXPECT().EnsureScaleUpNodes(gomock.Any(), config.Scale.TimeOut*time.Minute, gomock.Any()).Return(false, scaler.NewScaleTimeOutError("test scale timed out"))
+			mockScalerClient.EXPECT().EnsureScaleUpNodes(gomock.Any(), config.GetScaleDuration(), gomock.Any()).Return(false, scaler.NewScaleTimeOutError("test scale timed out"))
 			mockMetricsClient.EXPECT().UpdateMetricScalingFailed(gomock.Any())
 			expectUpgradeHasNotCommenced(mockKubeClient, upgradeConfig, nil)
 			ok, err := EnsureExtraUpgradeWorkers(mockKubeClient, config, mockScalerClient, mockMetricsClient, mockMaintClient, upgradeConfig, logger)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -32,7 +32,7 @@ func (s *scheduler) IsReadyToUpgrade(upgradeConfig *upgradev1alpha1.UpgradeConfi
 	now := time.Now()
 	if now.After(upgradeTime) {
 		// Is the current time within the allowable upgrade window
-		if upgradeTime.Add(timeOut * time.Minute).After(now) {
+		if upgradeTime.Add(timeOut).After(now) {
 			return true
 		}
 		// We are past the maximum allowed time to commence upgrading


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSD-4699

- Ignoring `UpgradeNodeScalingFailedSRE` alert in pre health checks. Once the timeout error is resolved we want to be able to continue the upgrade
- Changed the type in the config to int and added functions to get the duration (* time.Minute) to ensure the corrrect duration is set
- test fixes and new test for checking the ignored alerts