### PR TITLE
OSD-4529 compute worker window with PDB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ generate:
 		-r "-"
 	go generate pkg/cluster_upgrader_builder/cluster_upgrader_builder.go
 	go generate pkg/maintenance/maintenance.go
+	go generate pkg/maintenance/alertManagerSilenceClient.go
 	go generate pkg/metrics/metrics.go
 	go generate pkg/scaler/scaler.go
 	go generate pkg/validation/validation.go

--- a/pkg/maintenance/alertManagerSilenceMock.go
+++ b/pkg/maintenance/alertManagerSilenceMock.go
@@ -77,3 +77,17 @@ func (mr *MockAlertManagerSilencerMockRecorder) List(arg0 interface{}) *gomock.C
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockAlertManagerSilencer)(nil).List), arg0)
 }
+
+// Update mocks base method
+func (m *MockAlertManagerSilencer) Update(arg0 string, arg1 strfmt.DateTime) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Update", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Update indicates an expected call of Update
+func (mr *MockAlertManagerSilencerMockRecorder) Update(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockAlertManagerSilencer)(nil).Update), arg0, arg1)
+}

--- a/pkg/maintenance/maintenance.go
+++ b/pkg/maintenance/maintenance.go
@@ -9,7 +9,7 @@ import (
 //go:generate mockgen -destination=mocks/maintenance.go -package=mocks github.com/openshift/managed-upgrade-operator/pkg/maintenance Maintenance
 type Maintenance interface {
 	StartControlPlane(endsAt time.Time, version string) error
-	StartWorker(endsAt time.Time, version string) error
+	SetWorker(endsAt time.Time, version string) error
 	End() error
 	IsActive() (bool, error)
 }

--- a/pkg/maintenance/mocks/maintenance.go
+++ b/pkg/maintenance/mocks/maintenance.go
@@ -76,16 +76,16 @@ func (mr *MockMaintenanceMockRecorder) StartControlPlane(arg0, arg1 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartControlPlane", reflect.TypeOf((*MockMaintenance)(nil).StartControlPlane), arg0, arg1)
 }
 
-// StartWorker mocks base method
-func (m *MockMaintenance) StartWorker(arg0 time.Time, arg1 string) error {
+// SetWorker mocks base method
+func (m *MockMaintenance) SetWorker(arg0 time.Time, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StartWorker", arg0, arg1)
+	ret := m.ctrl.Call(m, "SetWorker", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// StartWorker indicates an expected call of StartWorker
-func (mr *MockMaintenanceMockRecorder) StartWorker(arg0, arg1 interface{}) *gomock.Call {
+// SetWorker indicates an expected call of SetWorker
+func (mr *MockMaintenanceMockRecorder) StartOrUpdateWorker(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartWorker", reflect.TypeOf((*MockMaintenance)(nil).StartWorker), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWorker", reflect.TypeOf((*MockMaintenance)(nil).SetWorker), arg0, arg1)
 }

--- a/pkg/osd_cluster_upgrader/upgrader.go
+++ b/pkg/osd_cluster_upgrader/upgrader.go
@@ -225,11 +225,24 @@ func CreateWorkerMaintWindow(c client.Client, cfg *osdUpgradeConfig, scaler scal
 		return true, nil
 	}
 
+	// We use the maximum of the PDB drain timeout and node drain timeout to compute a 'worst case' wait time
+	pdbForceDrainTimeout := time.Duration(upgradeConfig.Spec.PDBForceDrainTimeout) * time.Minute
+	nodeDrainTimeout := time.Duration(cfg.NodeDrain.TimeOut) * time.Minute
+	waitTimePeriod := time.Duration(pendingWorkerCount) * pdbForceDrainTimeout
+	if pdbForceDrainTimeout < nodeDrainTimeout {
+		waitTimePeriod = time.Duration(pendingWorkerCount) * nodeDrainTimeout
+	}
+
+	// Action time is the expected time taken to upgrade a worker node
 	maintenanceDurationPerNode := cfg.GetWorkerNodeDuration()
-	workerMaintenanceExpectedDuration := time.Duration(pendingWorkerCount) * maintenanceDurationPerNode
-	endTime := time.Now().Add(workerMaintenanceExpectedDuration)
+	actionTimePeriod := time.Duration(pendingWorkerCount) * maintenanceDurationPerNode
+
+	// Our worker maintenance window is a combination of 'wait time' and 'action time'
+	totalWorkerMaintenanceDuration := waitTimePeriod + actionTimePeriod
+
+	endTime := time.Now().Add(totalWorkerMaintenanceDuration)
 	logger.Info(fmt.Sprintf("Creating worker node maintenace for %d remaining nodes", pendingWorkerCount))
-	err = m.StartWorker(endTime, upgradeConfig.Spec.Desired.Version)
+	err = m.SetWorker(endTime, upgradeConfig.Spec.Desired.Version)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/osd_cluster_upgrader/upgrader_maintenance_window_test.go
+++ b/pkg/osd_cluster_upgrader/upgrader_maintenance_window_test.go
@@ -99,7 +99,7 @@ var _ = Describe("ClusterUpgrader maintenance window tests", func() {
 			configPool.Status.MachineCount = 3
 			configPool.Status.UpdatedMachineCount = 1
 			mockKubeClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "worker"}, gomock.Any()).SetArg(2, *configPool)
-			mockMaintClient.EXPECT().StartWorker(gomock.Any(), upgradeConfig.Spec.Desired.Version)
+			mockMaintClient.EXPECT().StartOrUpdateWorker(gomock.Any(), upgradeConfig.Spec.Desired.Version)
 			result, err := CreateWorkerMaintWindow(mockKubeClient, config, mockScaler, mockMetricsClient, mockMaintClient, upgradeConfig, logger)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeTrue())
@@ -110,7 +110,7 @@ var _ = Describe("ClusterUpgrader maintenance window tests", func() {
 			configPool.Status.UpdatedMachineCount = 1
 			fakeError := fmt.Errorf("fake error")
 			mockKubeClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "worker"}, gomock.Any()).SetArg(2, *configPool)
-			mockMaintClient.EXPECT().StartWorker(gomock.Any(), upgradeConfig.Spec.Desired.Version).Return(fakeError)
+			mockMaintClient.EXPECT().StartOrUpdateWorker(gomock.Any(), upgradeConfig.Spec.Desired.Version).Return(fakeError)
 			result, err := CreateWorkerMaintWindow(mockKubeClient, config, mockScaler, mockMetricsClient, mockMaintClient, upgradeConfig, logger)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(Equal(fakeError))


### PR DESCRIPTION
This PR accomplishes two goals:
- Incorporate sizing of worker maintenance window based on PDB Drain Timeout settings
- Dynamically adjust the size of the worker maintenance window as workers upgrade.

The sizing of the worker maintenance is outlined in OSD-4529.

This PR has been successfully tested on a cluster upgrade and the maintenance window observed to be updated accordingly.