### PR TITLE
Ignore mocks for code coverage analysis

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -24,3 +24,6 @@ comment:
   layout: "reach,diff,flags,tree"
   behavior: default
   require_changes: no
+
+ignore:
+  - "**/mocks/*.go"


### PR DESCRIPTION
We don't need code coverage of our auto-generated mocks, so let's ignore them for CodeCov