### PR TITLE
Revert "Ignore mocks for code coverage analysis"

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -24,6 +24,3 @@ comment:
   layout: "reach,diff,flags,tree"
   behavior: default
   require_changes: no
-
-ignore:
-  - "**/mocks/*.go"


### PR DESCRIPTION
This reverts commit 6b2f36973cc9a2fe74c577deaa2cfbc0a692d60f.