### PR TITLE
OSD-4750 wait for channel sync

### DIFF
--- a/pkg/osd_cluster_upgrader/upgrader.go
+++ b/pkg/osd_cluster_upgrader/upgrader.go
@@ -174,16 +174,10 @@ func CommenceUpgrade(c client.Client, cfg *osdUpgradeConfig, scaler scaler.Scale
 	// Move the cluster to the same channel first
 	if cv.Spec.Channel != desired.Channel {
 		logger.Info(fmt.Sprintf("Moving cluster from Channel %s to Channel %s", cv.Spec.Channel, desired.Channel))
-		cv.Spec.Channel = upgradeConfig.Spec.Desired.Channel
+		cv.Spec.Channel = desired.Channel
 		err = c.Update(context.TODO(), cv)
-		if err != nil {
-			return false, err
-		}
-		// Refresh getting the cluster version
-		cv, err = GetClusterVersion(c)
-		if err != nil {
-			return false, err
-		}
+		// Always give a chance for re-reconcile and a CVO sync to occur
+		return false, err
 	}
 
 	// The CVO may need time sync the version before launching the upgrade

--- a/pkg/osd_cluster_upgrader/upgrader_test.go
+++ b/pkg/osd_cluster_upgrader/upgrader_test.go
@@ -57,13 +57,20 @@ var _ = Describe("ClusterUpgrader", func() {
 			Items: []configv1.ClusterVersion{{
 				Spec: configv1.ClusterVersionSpec{
 					DesiredUpdate: &configv1.Update{Version: upgradeConfig.Spec.Desired.Version + "different"},
-					Channel:       upgradeConfig.Spec.Desired.Channel + "different",
+					Channel:       upgradeConfig.Spec.Desired.Channel,
 				},
 				Status: configv1.ClusterVersionStatus{
 					Conditions: []configv1.ClusterOperatorStatusCondition{
 						{
 							Type:   configv1.OperatorAvailable,
 							Status: configv1.ConditionTrue,
+						},
+					},
+					AvailableUpdates: []configv1.Update{
+						{
+							Version: upgradeConfig.Spec.Desired.Version,
+							Image:   "quay.io/this-doesnt-exist",
+							Force:   false,
 						},
 					},
 				},
@@ -190,6 +197,32 @@ var _ = Describe("ClusterUpgrader", func() {
 				Expect(result).To(BeFalse())
 			})
 		})
+
+		Context("When the cluster is not on the same channel as the UpgradeConfig", func() {
+			It("Updates the cluster's update channel", func() {
+				clusterVersionList := &configv1.ClusterVersionList{
+					Items: []configv1.ClusterVersion{
+						{
+							Spec: configv1.ClusterVersionSpec{
+								Channel: upgradeConfig.Spec.Desired.Channel + "not-the-same",
+								DesiredUpdate: nil,
+							},
+						},
+					},
+				}
+				expectUpgradeCommenced(mockKubeClient, clusterVersionList, nil)
+				util.ExpectGetClusterVersion(mockKubeClient, clusterVersionList, nil)
+				gomock.InOrder(
+					mockKubeClient.EXPECT().Update(gomock.Any(), gomock.Any()),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, *clusterVersionList),
+				)
+				result, err := CommenceUpgrade(mockKubeClient, config, mockScalerClient, mockMetricsClient, mockMaintClient, upgradeConfig, logger)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+
+			})
+		})
+
 		Context("When the cluster's desired version matches the UpgradeConfig's", func() {
 			It("Indicates the upgrade has commenced", func() {
 				expectUpgradeHasCommenced(mockKubeClient, upgradeConfig, nil)
@@ -205,7 +238,17 @@ var _ = Describe("ClusterUpgrader", func() {
 					Items: []configv1.ClusterVersion{
 						{
 							Spec: configv1.ClusterVersionSpec{
+								Channel: upgradeConfig.Spec.Desired.Channel,
 								DesiredUpdate: nil,
+							},
+							Status: configv1.ClusterVersionStatus{
+								AvailableUpdates: []configv1.Update{
+									{
+										Version: upgradeConfig.Spec.Desired.Version,
+										Image:   "quay.io/this-doesnt-exist",
+										Force:   false,
+									},
+								},
 							},
 						},
 					},
@@ -234,10 +277,19 @@ var _ = Describe("ClusterUpgrader", func() {
 					Items: []configv1.ClusterVersion{
 						{
 							Spec: configv1.ClusterVersionSpec{
+								Channel: upgradeConfig.Spec.Desired.Channel,
 								DesiredUpdate: &configv1.Update{
 									Version: "something different",
 								},
-								Channel: "something different",
+							},
+							Status: configv1.ClusterVersionStatus{
+								AvailableUpdates: []configv1.Update{
+									{
+										Version: upgradeConfig.Spec.Desired.Version,
+										Image:   "quay.io/this-doesnt-exist",
+										Force:   false,
+									},
+								},
 							},
 						},
 					},
@@ -603,6 +655,13 @@ func expectUpgradeHasNotCommenced(m *mocks.MockClient, u *upgradev1alpha1.Upgrad
 						Status: configv1.ConditionTrue,
 					},
 				},
+				AvailableUpdates: []configv1.Update{
+					{
+						Version: u.Spec.Desired.Version,
+						Image:   "quay.io/this-doesnt-exist",
+						Force:   false,
+					},
+				},
 			},
 		}}}
 	expectUpgradeCommenced(m, cvList, withErr)
@@ -620,6 +679,13 @@ func expectUpgradeHasCommenced(m *mocks.MockClient, u *upgradev1alpha1.UpgradeCo
 					{
 						Type:   configv1.OperatorProgressing,
 						Status: configv1.ConditionTrue,
+					},
+				},
+				AvailableUpdates: []configv1.Update{
+					{
+						Version: u.Spec.Desired.Version,
+						Image:   "quay.io/this-doesnt-exist",
+						Force:   false,
 					},
 				},
 			},

--- a/pkg/osd_cluster_upgrader/upgrader_test.go
+++ b/pkg/osd_cluster_upgrader/upgrader_test.go
@@ -213,8 +213,11 @@ var _ = Describe("ClusterUpgrader", func() {
 				expectUpgradeCommenced(mockKubeClient, clusterVersionList, nil)
 				util.ExpectGetClusterVersion(mockKubeClient, clusterVersionList, nil)
 				gomock.InOrder(
-					mockKubeClient.EXPECT().Update(gomock.Any(), gomock.Any()),
-					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, *clusterVersionList),
+					mockKubeClient.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(
+						func(ctx context.Context, cv *configv1.ClusterVersion) error {
+							Expect(cv.Spec.Channel).To(Equal(upgradeConfig.Spec.Desired.Channel))
+							return nil
+						}),
 				)
 				result, err := CommenceUpgrade(mockKubeClient, config, mockScalerClient, mockMetricsClient, mockMaintClient, upgradeConfig, logger)
 				Expect(err).NotTo(HaveOccurred())
@@ -245,7 +248,7 @@ var _ = Describe("ClusterUpgrader", func() {
 								AvailableUpdates: []configv1.Update{
 									{
 										Version: upgradeConfig.Spec.Desired.Version,
-										Image:   "quay.io/this-doesnt-exist",
+										Image:   "quay.io/dummy-image-for-test",
 										Force:   false,
 									},
 								},
@@ -286,7 +289,7 @@ var _ = Describe("ClusterUpgrader", func() {
 								AvailableUpdates: []configv1.Update{
 									{
 										Version: upgradeConfig.Spec.Desired.Version,
-										Image:   "quay.io/this-doesnt-exist",
+										Image:   "quay.io/dummy-image-for-test",
 										Force:   false,
 									},
 								},
@@ -658,7 +661,7 @@ func expectUpgradeHasNotCommenced(m *mocks.MockClient, u *upgradev1alpha1.Upgrad
 				AvailableUpdates: []configv1.Update{
 					{
 						Version: u.Spec.Desired.Version,
-						Image:   "quay.io/this-doesnt-exist",
+						Image:   "quay.io/dummy-image-for-test",
 						Force:   false,
 					},
 				},
@@ -684,7 +687,7 @@ func expectUpgradeHasCommenced(m *mocks.MockClient, u *upgradev1alpha1.UpgradeCo
 				AvailableUpdates: []configv1.Update{
 					{
 						Version: u.Spec.Desired.Version,
-						Image:   "quay.io/this-doesnt-exist",
+						Image:   "quay.io/dummy-image-for-test",
 						Force:   false,
 					},
 				},


### PR DESCRIPTION
If the Upgrade Operator must change the cluster's channel to effect an upgrade, it will not proceed until CVO has been given a chance to sync the channel's available updates and verify the desired version's presence.

A test case has also been added to cover this logic step.

Tested successfully on a cluster upgrade jump from 4.3.25 to 4.4.11\

Refs OSD-4750