### PR TITLE
OSD-4781 fix maintenance window alerting bugs

### DIFF
--- a/pkg/maintenance/alertManagerSilenceClient.go
+++ b/pkg/maintenance/alertManagerSilenceClient.go
@@ -42,7 +42,6 @@ func (ams *alertManagerSilenceClient) Create(matchers amv2Models.Matchers, start
 	if err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/pkg/maintenance/alertmanagerMaintenance.go
+++ b/pkg/maintenance/alertmanagerMaintenance.go
@@ -24,6 +24,8 @@ var (
 	alertManagerRouteName          = "alertmanager-main"
 	alertManagerServiceAccountName = "prometheus-k8s"
 	alertManagerBasePath           = "/api/v2/"
+	controlPlaneSilenceCommentId   = "OSD control plane"
+	workerSilenceCommentId         = "OSD worker node"
 )
 
 type alertManagerMaintenanceBuilder struct{}
@@ -93,8 +95,8 @@ func getAuthentication(c client.Client) (runtime.ClientAuthInfoWriter, error) {
 // Start a control plane maintenance in Alertmanager for version
 // Time is converted to UTC
 func (amm *alertManagerMaintenance) StartControlPlane(endsAt time.Time, version string, ignoredCriticalAlerts []string) error {
-	defaultComment := fmt.Sprintf("Silence for OSD control plane upgrade to version %s", version)
-	criticalAlertComment := fmt.Sprintf("Silence for critical alerts during OSD control plane upgrade to version %s", version)
+	defaultComment := fmt.Sprintf("Silence for %s upgrade to version %s", controlPlaneSilenceCommentId, version)
+	criticalAlertComment := fmt.Sprintf("Silence for critical alerts during %s upgrade to version %s", controlPlaneSilenceCommentId, version)
 	mList, err := amm.client.List([]string{})
 	if err != nil {
 		return err
@@ -132,7 +134,7 @@ func (amm *alertManagerMaintenance) StartControlPlane(endsAt time.Time, version 
 // Start a worker node maintenance in Alertmanager for version
 // Time is converted to UTC
 func (amm *alertManagerMaintenance) SetWorker(endsAt time.Time, version string) error {
-	comment := fmt.Sprintf("Silence for OSD worker node upgrade to version %s", version)
+	comment := fmt.Sprintf("Silence for %s upgrade to version %s", workerSilenceCommentId, version)
 	mList, err := amm.client.List([]string{})
 	if err != nil {
 		return err
@@ -141,12 +143,8 @@ func (amm *alertManagerMaintenance) SetWorker(endsAt time.Time, version string) 
 
 	end := strfmt.DateTime(endsAt.UTC())
 	if exists {
-		// Create a new silence and remove the old one
-		err = amm.client.Create(createDefaultMatchers(), *silence.StartsAt, end, config.OperatorName, comment)
-		if err != nil {
-			return err
-		}
-		err = amm.client.Delete(*silence.ID)
+		// Update the silence end time
+		err = amm.client.Update(*silence.ID, end)
 		if err != nil {
 			return err
 		}
@@ -161,8 +159,20 @@ func (amm *alertManagerMaintenance) SetWorker(endsAt time.Time, version string) 
 	return nil
 }
 
-// End all active maintenances created by managed-upgrade-operator in Alertmanager
-func (amm *alertManagerMaintenance) End() error {
+// End all active control plane maintenances created by managed-upgrade-operator in Alertmanager
+func (amm *alertManagerMaintenance) EndControlPlane() error {
+	return amm.EndSilences(controlPlaneSilenceCommentId)
+}
+
+// End all active worker maintenances created by managed-upgrade-operator in Alertmanager
+func (amm *alertManagerMaintenance) EndWorkers() error {
+	return amm.EndSilences(workerSilenceCommentId)
+}
+
+// End all active control plane maintenances created by managed-upgrade-operator in Alertmanager
+// that have a comment field containing the supplied value
+func (amm *alertManagerMaintenance) EndSilences(comment string) error {
+
 	silences, err := amm.client.List([]string{})
 	if err != nil {
 		return err
@@ -170,7 +180,8 @@ func (amm *alertManagerMaintenance) End() error {
 
 	var deleteErrors *multierror.Error
 	for _, s := range silences.Payload {
-		if *s.CreatedBy == config.OperatorName && *s.Status.State == amv2Models.SilenceStatusStateActive {
+		if *s.CreatedBy == config.OperatorName &&
+			*s.Status.State == amv2Models.SilenceStatusStateActive && strings.Contains(*s.Comment, comment) {
 			err := amm.client.Delete(*s.ID)
 			if err != nil {
 				deleteErrors = multierror.Append(deleteErrors, err)

--- a/pkg/maintenance/alertmanagerMaintenance.go
+++ b/pkg/maintenance/alertmanagerMaintenance.go
@@ -141,7 +141,15 @@ func (amm *alertManagerMaintenance) SetWorker(endsAt time.Time, version string) 
 
 	end := strfmt.DateTime(endsAt.UTC())
 	if exists {
-		err = amm.client.Update(*silence.ID, end)
+		// Create a new silence and remove the old one
+		err = amm.client.Create(createDefaultMatchers(), *silence.StartsAt, end, config.OperatorName, comment)
+		if err != nil {
+			return err
+		}
+		err = amm.client.Delete(*silence.ID)
+		if err != nil {
+			return err
+		}
 	} else {
 		now := strfmt.DateTime(time.Now().UTC())
 		err = amm.client.Create(createDefaultMatchers(), now, end, config.OperatorName, comment)

--- a/pkg/maintenance/maintenance.go
+++ b/pkg/maintenance/maintenance.go
@@ -10,7 +10,9 @@ import (
 type Maintenance interface {
 	StartControlPlane(endsAt time.Time, version string, ignoredAlerts []string) error
 	SetWorker(endsAt time.Time, version string) error
-	End() error
+	EndControlPlane() error
+	EndWorkers() error
+	EndSilences(comment string) error
 	IsActive() (bool, error)
 }
 

--- a/pkg/maintenance/maintenance_test.go
+++ b/pkg/maintenance/maintenance_test.go
@@ -120,8 +120,7 @@ var _ = Describe("Alert Manager Maintenance Client", func() {
 	Context("Updating a worker silence", func() {
 		It("Should update a silence if one already exists", func() {
 			silenceClient.EXPECT().List(gomock.Any()).Return(&testActiveSilences, nil)
-			silenceClient.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			silenceClient.EXPECT().Delete(gomock.Any())
+			silenceClient.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
 			end := time.Now().Add(90 * time.Minute)
 			amm := alertManagerMaintenance{client: silenceClient}
 			err := amm.SetWorker(end, testVersion)
@@ -161,7 +160,7 @@ var _ = Describe("Alert Manager Maintenance Client", func() {
 
 			silenceClient.EXPECT().List(gomock.Any()).Return(&activeSilences, nil)
 			amm := alertManagerMaintenance{client: silenceClient}
-			err := amm.End()
+			err := amm.EndSilences("")
 			Expect(err).Should(Not(HaveOccurred()))
 		})
 		It("Should find maintenances created by the operator and not return an error", func() {
@@ -186,7 +185,7 @@ var _ = Describe("Alert Manager Maintenance Client", func() {
 			silenceClient.EXPECT().List(gomock.Any()).Return(&activeSilences, nil)
 			silenceClient.EXPECT().Delete(testId).Return(nil)
 			amm := alertManagerMaintenance{client: silenceClient}
-			err := amm.End()
+			err := amm.EndSilences("")
 			Expect(err).Should(Not(HaveOccurred()))
 		})
 	})

--- a/pkg/maintenance/maintenance_test.go
+++ b/pkg/maintenance/maintenance_test.go
@@ -54,7 +54,11 @@ var _ = Describe("Alert Manager Maintenance Client", func() {
 					ID:        &activeSilenceId,
 					Status:    &amv2Models.SilenceStatus{State:&activeSilenceStatus},
 					Silence:   amv2Models.Silence{
-						Comment: &activeSilenceComment,
+						Comment:   &activeSilenceComment,
+						CreatedBy: &testCreatedByOperator,
+						EndsAt:    &testEnd,
+						Matchers:  createDefaultMatchers(),
+						StartsAt:  &testNow,
 					},
 				},
 			},
@@ -115,8 +119,9 @@ var _ = Describe("Alert Manager Maintenance Client", func() {
 	// Updating an existing worker silence
 	Context("Updating a worker silence", func() {
 		It("Should update a silence if one already exists", func() {
-			silenceClient.EXPECT().Update(gomock.Any(), gomock.Any())
 			silenceClient.EXPECT().List(gomock.Any()).Return(&testActiveSilences, nil)
+			silenceClient.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			silenceClient.EXPECT().Delete(gomock.Any())
 			end := time.Now().Add(90 * time.Minute)
 			amm := alertManagerMaintenance{client: silenceClient}
 			err := amm.SetWorker(end, testVersion)

--- a/pkg/maintenance/mocks/maintenance.go
+++ b/pkg/maintenance/mocks/maintenance.go
@@ -33,18 +33,46 @@ func (m *MockMaintenance) EXPECT() *MockMaintenanceMockRecorder {
 	return m.recorder
 }
 
-// End mocks base method
-func (m *MockMaintenance) End() error {
+// EndControlPlane mocks base method
+func (m *MockMaintenance) EndControlPlane() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "End")
+	ret := m.ctrl.Call(m, "EndControlPlane")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// End indicates an expected call of End
-func (mr *MockMaintenanceMockRecorder) End() *gomock.Call {
+// EndControlPlane indicates an expected call of EndControlPlane
+func (mr *MockMaintenanceMockRecorder) EndControlPlane() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "End", reflect.TypeOf((*MockMaintenance)(nil).End))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EndControlPlane", reflect.TypeOf((*MockMaintenance)(nil).EndControlPlane))
+}
+
+// EndSilences mocks base method
+func (m *MockMaintenance) EndSilences(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EndSilences", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EndSilences indicates an expected call of EndSilences
+func (mr *MockMaintenanceMockRecorder) EndSilences(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EndSilences", reflect.TypeOf((*MockMaintenance)(nil).EndSilences), arg0)
+}
+
+// EndWorkers mocks base method
+func (m *MockMaintenance) EndWorkers() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EndWorkers")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EndWorkers indicates an expected call of EndWorkers
+func (mr *MockMaintenanceMockRecorder) EndWorkers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EndWorkers", reflect.TypeOf((*MockMaintenance)(nil).EndWorkers))
 }
 
 // IsActive mocks base method

--- a/pkg/osd_cluster_upgrader/upgrader_maintenance_window_test.go
+++ b/pkg/osd_cluster_upgrader/upgrader_maintenance_window_test.go
@@ -64,13 +64,13 @@ var _ = Describe("ClusterUpgrader maintenance window tests", func() {
 
 	Context("When removing a control plane maintenance window", func() {
 		It("Asks the maintenance client to do so", func() {
-			mockMaintClient.EXPECT().End()
+			mockMaintClient.EXPECT().EndControlPlane()
 			result, err := RemoveControlPlaneMaintWindow(mockKubeClient, config, mockScaler, mockMetricsClient, mockMaintClient, upgradeConfig, logger)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeTrue())
 		})
 		It("Indicates when creating the maintenance window has failed", func() {
-			mockMaintClient.EXPECT().End().Return(fmt.Errorf("fake error"))
+			mockMaintClient.EXPECT().EndControlPlane().Return(fmt.Errorf("fake error"))
 			result, err := RemoveControlPlaneMaintWindow(mockKubeClient, config, mockScaler, mockMetricsClient, mockMaintClient, upgradeConfig, logger)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(BeFalse())
@@ -138,13 +138,13 @@ var _ = Describe("ClusterUpgrader maintenance window tests", func() {
 
 	Context("When removing a worker maintenance window", func() {
 		It("Asks the maintenance client to do so", func() {
-			mockMaintClient.EXPECT().End()
+			mockMaintClient.EXPECT().EndWorkers()
 			result, err := RemoveMaintWindow(mockKubeClient, config, mockScaler, mockMetricsClient, mockMaintClient, upgradeConfig, logger)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeTrue())
 		})
 		It("Indicates when creating the maintenance window has failed", func() {
-			mockMaintClient.EXPECT().End().Return(fmt.Errorf("fake error"))
+			mockMaintClient.EXPECT().EndWorkers().Return(fmt.Errorf("fake error"))
 			result, err := RemoveMaintWindow(mockKubeClient, config, mockScaler, mockMetricsClient, mockMaintClient, upgradeConfig, logger)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(BeFalse())


### PR DESCRIPTION
This PR separates out the cancellation of Control Plane and Worker maintenance windows rather than having one all-encompassing 'end all windows' function. It is hoped that this will address a very sporadic issue being observed where occasionally during worker upgrades MUO thinks there are no active worker silences and triggers a "worker node upgrade" timeout alert. This issue is described more in OSD-4781.