### PR TITLE
OSD-4781 fix maintenance window alerting bugs

### DIFF
--- a/pkg/maintenance/maintenance.go
+++ b/pkg/maintenance/maintenance.go
@@ -10,7 +10,9 @@ import (
 type Maintenance interface {
 	StartControlPlane(endsAt time.Time, version string, ignoredAlerts []string) error
 	SetWorker(endsAt time.Time, version string) error
-	End() error
+	EndControlPlane() error
+	EndWorker() error
+	EndSilences(comment string) error
 	IsActive() (bool, error)
 }
 

--- a/pkg/maintenance/maintenance_test.go
+++ b/pkg/maintenance/maintenance_test.go
@@ -54,7 +54,11 @@ var _ = Describe("Alert Manager Maintenance Client", func() {
 					ID:        &activeSilenceId,
 					Status:    &amv2Models.SilenceStatus{State:&activeSilenceStatus},
 					Silence:   amv2Models.Silence{
-						Comment: &activeSilenceComment,
+						Comment:   &activeSilenceComment,
+						CreatedBy: &testCreatedByOperator,
+						EndsAt:    &testEnd,
+						Matchers:  createDefaultMatchers(),
+						StartsAt:  &testNow,
 					},
 				},
 			},
@@ -115,8 +119,8 @@ var _ = Describe("Alert Manager Maintenance Client", func() {
 	// Updating an existing worker silence
 	Context("Updating a worker silence", func() {
 		It("Should update a silence if one already exists", func() {
-			silenceClient.EXPECT().Update(gomock.Any(), gomock.Any())
 			silenceClient.EXPECT().List(gomock.Any()).Return(&testActiveSilences, nil)
+			silenceClient.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
 			end := time.Now().Add(90 * time.Minute)
 			amm := alertManagerMaintenance{client: silenceClient}
 			err := amm.SetWorker(end, testVersion)
@@ -156,7 +160,7 @@ var _ = Describe("Alert Manager Maintenance Client", func() {
 
 			silenceClient.EXPECT().List(gomock.Any()).Return(&activeSilences, nil)
 			amm := alertManagerMaintenance{client: silenceClient}
-			err := amm.End()
+			err := amm.EndSilences("")
 			Expect(err).Should(Not(HaveOccurred()))
 		})
 		It("Should find maintenances created by the operator and not return an error", func() {
@@ -181,7 +185,7 @@ var _ = Describe("Alert Manager Maintenance Client", func() {
 			silenceClient.EXPECT().List(gomock.Any()).Return(&activeSilences, nil)
 			silenceClient.EXPECT().Delete(testId).Return(nil)
 			amm := alertManagerMaintenance{client: silenceClient}
-			err := amm.End()
+			err := amm.EndSilences("")
 			Expect(err).Should(Not(HaveOccurred()))
 		})
 	})

--- a/pkg/maintenance/mocks/maintenance.go
+++ b/pkg/maintenance/mocks/maintenance.go
@@ -33,18 +33,46 @@ func (m *MockMaintenance) EXPECT() *MockMaintenanceMockRecorder {
 	return m.recorder
 }
 
-// End mocks base method
-func (m *MockMaintenance) End() error {
+// EndControlPlane mocks base method
+func (m *MockMaintenance) EndControlPlane() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "End")
+	ret := m.ctrl.Call(m, "EndControlPlane")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// End indicates an expected call of End
-func (mr *MockMaintenanceMockRecorder) End() *gomock.Call {
+// EndControlPlane indicates an expected call of EndControlPlane
+func (mr *MockMaintenanceMockRecorder) EndControlPlane() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "End", reflect.TypeOf((*MockMaintenance)(nil).End))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EndControlPlane", reflect.TypeOf((*MockMaintenance)(nil).EndControlPlane))
+}
+
+// EndSilences mocks base method
+func (m *MockMaintenance) EndSilences(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EndSilences", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EndSilences indicates an expected call of EndSilences
+func (mr *MockMaintenanceMockRecorder) EndSilences(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EndSilences", reflect.TypeOf((*MockMaintenance)(nil).EndSilences), arg0)
+}
+
+// EndWorker mocks base method
+func (m *MockMaintenance) EndWorker() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EndWorker")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EndWorker indicates an expected call of EndWorker
+func (mr *MockMaintenanceMockRecorder) EndWorker() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EndWorker", reflect.TypeOf((*MockMaintenance)(nil).EndWorker))
 }
 
 // IsActive mocks base method

--- a/pkg/osd_cluster_upgrader/upgrader.go
+++ b/pkg/osd_cluster_upgrader/upgrader.go
@@ -222,7 +222,7 @@ func CreateControlPlaneMaintWindow(c client.Client, cfg *osdUpgradeConfig, scale
 
 // RemoveControlPlaneMaintWindow removes the maintenance window for control plane
 func RemoveControlPlaneMaintWindow(c client.Client, cfg *osdUpgradeConfig, scaler scaler.Scaler, metricsClient metrics.Metrics, m maintenance.Maintenance, upgradeConfig *upgradev1alpha1.UpgradeConfig, logger logr.Logger) (bool, error) {
-	err := m.End()
+	err := m.EndControlPlane()
 	if err != nil {
 		return false, err
 	}
@@ -261,7 +261,7 @@ func CreateWorkerMaintWindow(c client.Client, cfg *osdUpgradeConfig, scaler scal
 	totalWorkerMaintenanceDuration := waitTimePeriod + actionTimePeriod
 
 	endTime := time.Now().Add(totalWorkerMaintenanceDuration)
-	logger.Info(fmt.Sprintf("Creating worker node maintenace for %d remaining nodes", pendingWorkerCount))
+	logger.Info(fmt.Sprintf( "Creating worker node maintenace for %d remaining nodes, ending at %v", pendingWorkerCount, endTime))
 	err = m.SetWorker(endTime, upgradeConfig.Spec.Desired.Version)
 	if err != nil {
 		return false, err
@@ -297,6 +297,8 @@ func AllWorkersUpgraded(c client.Client, cfg *osdUpgradeConfig, scaler scaler.Sc
 		if !silenceActive {
 			logger.Info("Worker upgrade timeout.")
 			metricsClient.UpdateMetricUpgradeWorkerTimeout(upgradeConfig.Name, upgradeConfig.Spec.Desired.Version)
+		} else {
+			metricsClient.ResetMetricUpgradeWorkerTimeout(upgradeConfig.Name, upgradeConfig.Spec.Desired.Version)
 		}
 		return false, nil
 	}
@@ -413,7 +415,7 @@ func performUpgradeVerification(c client.Client, logger logr.Logger) (bool, erro
 
 // RemoveMaintWindows removes all the maintenance windows we created during the upgrade
 func RemoveMaintWindow(c client.Client, cfg *osdUpgradeConfig, scaler scaler.Scaler, metricsClient metrics.Metrics, m maintenance.Maintenance, upgradeConfig *upgradev1alpha1.UpgradeConfig, logger logr.Logger) (bool, error) {
-	err := m.End()
+	err := m.EndWorker()
 	if err != nil {
 		return false, err
 	}

--- a/pkg/osd_cluster_upgrader/upgrader_maintenance_window_test.go
+++ b/pkg/osd_cluster_upgrader/upgrader_maintenance_window_test.go
@@ -64,13 +64,13 @@ var _ = Describe("ClusterUpgrader maintenance window tests", func() {
 
 	Context("When removing a control plane maintenance window", func() {
 		It("Asks the maintenance client to do so", func() {
-			mockMaintClient.EXPECT().End()
+			mockMaintClient.EXPECT().EndControlPlane()
 			result, err := RemoveControlPlaneMaintWindow(mockKubeClient, config, mockScaler, mockMetricsClient, mockMaintClient, upgradeConfig, logger)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeTrue())
 		})
 		It("Indicates when creating the maintenance window has failed", func() {
-			mockMaintClient.EXPECT().End().Return(fmt.Errorf("fake error"))
+			mockMaintClient.EXPECT().EndControlPlane().Return(fmt.Errorf("fake error"))
 			result, err := RemoveControlPlaneMaintWindow(mockKubeClient, config, mockScaler, mockMetricsClient, mockMaintClient, upgradeConfig, logger)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(BeFalse())
@@ -138,13 +138,13 @@ var _ = Describe("ClusterUpgrader maintenance window tests", func() {
 
 	Context("When removing a worker maintenance window", func() {
 		It("Asks the maintenance client to do so", func() {
-			mockMaintClient.EXPECT().End()
+			mockMaintClient.EXPECT().EndWorker()
 			result, err := RemoveMaintWindow(mockKubeClient, config, mockScaler, mockMetricsClient, mockMaintClient, upgradeConfig, logger)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeTrue())
 		})
 		It("Indicates when creating the maintenance window has failed", func() {
-			mockMaintClient.EXPECT().End().Return(fmt.Errorf("fake error"))
+			mockMaintClient.EXPECT().EndWorker().Return(fmt.Errorf("fake error"))
 			result, err := RemoveMaintWindow(mockKubeClient, config, mockScaler, mockMetricsClient, mockMaintClient, upgradeConfig, logger)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(BeFalse())

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.0.1"
+	Version = "1.0.0"
 )


### PR DESCRIPTION
This PR separates out the cancellation of Control Plane and Worker maintenance windows rather than having one all-encompassing 'end all windows' function. It is hoped that this will address a very sporadic issue being observed where occasionally during worker upgrades MUO thinks there are no active worker silences and triggers a "worker node upgrade" timeout alert. This issue is described more in OSD-4781.