### PR TITLE
OSD-4930 add new alerts to ignore

### DIFF
--- a/deploy/managed-upgrade-operator-config.yaml
+++ b/deploy/managed-upgrade-operator-config.yaml
@@ -12,6 +12,8 @@ data:
         - etcdMembersDown
         - KubeDeploymentReplicasMismatch
         - ClusterOperatorDown
+        - MachineWithNoRunningPhase
+        - ClusterOperatorDegraded
     scale:
       timeOut: 30
     upgradeWindow:


### PR DESCRIPTION
This adds Critical alert ignores for

- MachineWithNoRunningPhase
- ClusterOperatorDegraded

as observed during the 4.4.16 upgrade cycle.