### PR TITLE
Adding PR template to standardize PR info

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+### What type of PR is this?
+_(bug/feature/cleanup/documentation/test/refactor)_
+
+
+### What this PR does / why we need it?
+
+### Which Jira/Github issue(s) this PR fixes?
+
+_Fixes #_
+
+### Special notes for your reviewer:
+
+### Pre-checks (if applicable):
+- [ ] Tested latest changes against a cluster
+- [ ] Ran `make generate` command locally to validate code changes
+- [ ] Included documentation changes with PR
+


### PR DESCRIPTION
The PR addresses https://issues.redhat.com/browse/OSD-4415. The main intention for this PR is to make sure that when more people start working on the operator, we have enough details and prerequisites in place.

The overall template is referred from:
https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md