### PR TITLE
Correcting the scheduled time value - OSD-4845

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -40,7 +40,7 @@ func (s *scheduler) IsReadyToUpgrade(upgradeConfig *upgradev1alpha1.UpgradeConfi
 	} else {
 		// It hasn't reached the upgrade window yet
 		pendingTime := upgradeTime.Sub(now)
-		log.Infof("Upgrade is scheduled in %d hours %d mins", int(pendingTime.Hours()), int(pendingTime.Minutes()))
+		log.Infof("Upgrade is scheduled in %d hours %d mins", int(pendingTime.Hours()), int(pendingTime.Minutes())-(int(pendingTime.Hours())*60))
 	}
 
 	return SchedulerResult{IsReady: false, IsBreached: false}


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation/test/refactor)_
bug

### What this PR does / why we need it?
This PR fixes the scheduled time value to have the correct minutes info. 

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-4845

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [DONE ] Tested latest changes against a cluster
{"level":"info","ts":1598264888.415682,"logger":"controller_upgradeconfig","msg":"Checking if cluster can commence upgrade.","Request.Namespace":"managed-upgrade-operator","Request.Name":"example-upgrade-config"}
INFO[0049] Upgrade is scheduled in 13 hours 31 mins      source="scheduler.go:43"
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

