### PR TITLE
Ignore the health check alert during health check

### DIFF
--- a/deploy/managed-upgrade-operator-config.yaml
+++ b/deploy/managed-upgrade-operator-config.yaml
@@ -25,3 +25,4 @@ data:
       - DNSErrors05MinSRE
       - MetricsClientSendFailingSRE
       - UpgradeNodeScalingFailedSRE
+      - UpgradeClusterCheckFailedSRE


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
Ignore the UpgradeClusterCheckFailedSRE during a cluster health check, otherwise, once the alert fires the upgrade is permanently blocked at this step.
