### PR TITLE
OSD-4962 Upgrade Operator should not alert on equal versions

### DIFF
--- a/pkg/controller/upgradeconfig/upgradeconfig_controller.go
+++ b/pkg/controller/upgradeconfig/upgradeconfig_controller.go
@@ -160,8 +160,12 @@ func (r *ReconcileUpgradeConfig) Reconcile(request reconcile.Request) (reconcile
 			metricsClient.UpdateMetricValidationFailed(instance.Name)
 			return reconcile.Result{}, nil
 		}
-		reqLogger.Info("UpgradeConfig validated.")
 		metricsClient.UpdateMetricValidationSucceeded(instance.Name)
+		if !validatorResult.IsAvailableUpdate {
+			reqLogger.Info(validatorResult.Message)
+			return reconcile.Result{}, nil
+		}
+		reqLogger.Info("UpgradeConfig validated and confirmed for upgrade.")
 
 		cfm := r.configManagerBuilder.New(r.client, request.Namespace)
 		cfg := &config{}

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -128,12 +128,13 @@ var _ = Describe("Validation of UpgradeConfig CR", func() {
 		})
 		Context("Comparing versions", func() {
 			Context("When desired version is less then current version", func() {
-				It("Returns proceed as false", func() {
+				It("Indicates a downgrade", func() {
 					// Set desired < current
 					desiredVersion, _ := semver.Parse("4.4.4")
 					currentVersion, _ := semver.Parse("4.4.5")
-					proceed := compareVersions(desiredVersion, currentVersion, testLogger)
-					Expect(proceed).Should(BeFalse())
+					versionCompare, err := compareVersions(desiredVersion, currentVersion, testLogger)
+					Expect(versionCompare).Should(Equal(VersionDowngrade))
+					Expect(err).Should(BeNil())
 				})
 			})
 			Context("When desired version is equal to current version", func() {
@@ -141,8 +142,9 @@ var _ = Describe("Validation of UpgradeConfig CR", func() {
 					// Set desired == current
 					desiredVersion, _ := semver.Parse("4.4.4")
 					currentVersion, _ := semver.Parse("4.4.4")
-					proceed := compareVersions(desiredVersion, currentVersion, testLogger)
-					Expect(proceed).Should(BeFalse())
+					versionCompare, err := compareVersions(desiredVersion, currentVersion, testLogger)
+					Expect(versionCompare).Should(Equal(VersionEqual))
+					Expect(err).Should(BeNil())
 				})
 			})
 			Context("When desired version is greater then current version", func() {
@@ -150,8 +152,9 @@ var _ = Describe("Validation of UpgradeConfig CR", func() {
 					// Set desired == current
 					desiredVersion, _ := semver.Parse("4.4.5")
 					currentVersion, _ := semver.Parse("4.4.4")
-					proceed := compareVersions(desiredVersion, currentVersion, testLogger)
-					Expect(proceed).Should(BeTrue())
+					versionCompare, err := compareVersions(desiredVersion, currentVersion, testLogger)
+					Expect(versionCompare).Should(Equal(VersionUpgrade))
+					Expect(err).Should(BeNil())
 				})
 			})
 


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
I'm proposing we change the logic when an UpgradeConfig contains a version that is less than or equal to the cluster's current version.

Currently this will trigger the ValidationFailed metric, which pages SRE. Any cluster that receives an UpgradeConfig like that will start alerting, and I don't think this is valid behaviour worthy of an alert.

Instead, let validation failures occur for proper, actionable examples - a (greater-than) version that has no edge, or a version that can't be parsed.

### Which Jira/Github issue(s) this PR fixes?

OSD-4962

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster

