### PR TITLE
OSD-4971 Wait for TargetDown for post-verification

### DIFF
--- a/pkg/metrics/mocks/metrics.go
+++ b/pkg/metrics/mocks/metrics.go
@@ -34,6 +34,21 @@ func (m *MockMetrics) EXPECT() *MockMetricsMockRecorder {
 	return m.recorder
 }
 
+// IsAlertFiring mocks base method
+func (m *MockMetrics) IsAlertFiring(arg0 string, arg1 []string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsAlertFiring", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsAlertFiring indicates an expected call of IsAlertFiring
+func (mr *MockMetricsMockRecorder) IsAlertFiring(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAlertFiring", reflect.TypeOf((*MockMetrics)(nil).IsAlertFiring), arg0, arg1)
+}
+
 // IsMetricControlPlaneEndTimeSet mocks base method
 func (m *MockMetrics) IsMetricControlPlaneEndTimeSet(arg0, arg1 string) (bool, error) {
 	m.ctrl.T.Helper()

--- a/pkg/osd_cluster_upgrader/upgrader.go
+++ b/pkg/osd_cluster_upgrader/upgrader.go
@@ -375,11 +375,11 @@ func performUpgradeVerification(c client.Client, metricsClient metrics.Metrics, 
 	}
 	readyRs := 0
 	totalRs := 0
-	for _, replica := range replicaSetList.Items {
+	for _, replicaSet := range replicaSetList.Items {
 		for _, namespacePrefix := range namespacePrefixesToCheck {
-			if strings.HasPrefix(replica.Namespace, namespacePrefix) {
+			if strings.HasPrefix(replicaSet.Namespace, namespacePrefix) {
 				totalRs = totalRs + 1
-				if replica.Status.ReadyReplicas == replica.Status.Replicas {
+				if replicaSet.Status.ReadyReplicas == replicaSet.Status.Replicas {
 					readyRs = readyRs + 1
 				}
 			}
@@ -391,25 +391,25 @@ func performUpgradeVerification(c client.Client, metricsClient metrics.Metrics, 
 	}
 
 	// Verify all Daemonsets in the default, kube* and openshift* namespaces are satisfied
-	dsList := &appsv1.DaemonSetList{}
-	err = c.List(context.TODO(), dsList)
+	daemonSetList := &appsv1.DaemonSetList{}
+	err = c.List(context.TODO(), daemonSetList)
 	if err != nil {
 		return false, err
 	}
 	readyDS := 0
 	totalDS := 0
-	for _, ds := range dsList.Items {
+	for _, daemonSet := range daemonSetList.Items {
 		for _, namespacePrefix := range namespacePrefixesToCheck {
-			if strings.HasPrefix(ds.Namespace, namespacePrefix) {
+			if strings.HasPrefix(daemonSet.Namespace, namespacePrefix) {
 				totalDS = totalDS + 1
-				if ds.Status.DesiredNumberScheduled == ds.Status.NumberReady {
+				if daemonSet.Status.DesiredNumberScheduled == daemonSet.Status.NumberReady {
 					readyDS = readyDS + 1
 				}
 			}
 		}
 	}
 	if totalDS != readyDS {
-		logger.Info(fmt.Sprintf("not all daemonset are ready:expected number :%v , ready number %v", len(dsList.Items), readyDS))
+		logger.Info(fmt.Sprintf("not all daemonset are ready:expected number :%v , ready number %v", len(daemonSetList.Items), readyDS))
 		return false, nil
 	}
 


### PR DESCRIPTION
### What type of PR is this?

Feature

### What this PR does / why we need it?

TargetDown is a common alert to occur during worker upgrades, and often will still be firing at the point at which the worker maintenance window is torn down. This PR adjusts the logic of the post-upgrade verification to wait for no TargetDown alerts to be firing before it considers the phase complete. 

Additionally, the "updating" of worker windows has been changed to create a new window first, then delete the existing window, rather than attempt to edit an active window in-place (which ultimately results in the same behaviour).

### Which Jira/Github issue(s) this PR fixes?

OSD-4971

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [X] Ran `make generate` command locally to validate code changes


