### PR TITLE
OSD-5003 OSD-5013 reset node drain and improve verification logs

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -43,6 +43,7 @@ type Metrics interface {
 	UpdateMetricUpgradeWorkerTimeout(string, string)
 	ResetMetricUpgradeWorkerTimeout(string, string)
 	UpdateMetricNodeDrainFailed(string)
+	ResetMetricNodeDrainFailed(string)
 	IsMetricUpgradeStartTimeSet(upgradeConfigName string, version string) (bool, error)
 	IsMetricControlPlaneEndTimeSet(upgradeConfigName string, version string) (bool, error)
 	IsMetricNodeUpgradeEndTimeSet(upgradeConfigName string, version string) (bool, error)
@@ -255,6 +256,12 @@ func (c *Counter) UpdateMetricNodeDrainFailed(upgradeConfigName string) {
 	metricNodeDrainFailed.With(prometheus.Labels{
 		nameLabel: upgradeConfigName}).Set(
 		float64(1))
+}
+
+func (c *Counter) ResetMetricNodeDrainFailed(upgradeConfigName string) {
+	metricNodeDrainFailed.With(prometheus.Labels{
+		nameLabel: upgradeConfigName}).Set(
+		float64(0))
 }
 
 func (c *Counter) IsMetricUpgradeStartTimeSet(upgradeConfigName string, version string) (bool, error) {

--- a/pkg/metrics/mocks/metrics.go
+++ b/pkg/metrics/mocks/metrics.go
@@ -109,6 +109,18 @@ func (mr *MockMetricsMockRecorder) Query(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Query", reflect.TypeOf((*MockMetrics)(nil).Query), arg0)
 }
 
+// ResetMetricNodeDrainFailed mocks base method
+func (m *MockMetrics) ResetMetricNodeDrainFailed(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ResetMetricNodeDrainFailed", arg0)
+}
+
+// ResetMetricNodeDrainFailed indicates an expected call of ResetMetricNodeDrainFailed
+func (mr *MockMetricsMockRecorder) ResetMetricNodeDrainFailed(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetMetricNodeDrainFailed", reflect.TypeOf((*MockMetrics)(nil).ResetMetricNodeDrainFailed), arg0)
+}
+
 // ResetMetricUpgradeControlPlaneTimeout mocks base method
 func (m *MockMetrics) ResetMetricUpgradeControlPlaneTimeout(arg0, arg1 string) {
 	m.ctrl.T.Helper()

--- a/pkg/osd_cluster_upgrader/upgrader.go
+++ b/pkg/osd_cluster_upgrader/upgrader.go
@@ -282,6 +282,7 @@ func AllWorkersUpgraded(c client.Client, cfg *osdUpgradeConfig, scaler scaler.Sc
 		metricsClient.UpdateMetricNodeDrainFailed(upgradeConfig.Name)
 		return false, nil
 	}
+	metricsClient.ResetMetricNodeDrainFailed(upgradeConfig.Name)
 
 	okUpgrade, errUpgrade := nodesUpgraded(c, "worker", logger)
 	if errUpgrade != nil {
@@ -386,7 +387,7 @@ func performUpgradeVerification(c client.Client, metricsClient metrics.Metrics, 
 		}
 	}
 	if totalRs != readyRs {
-		logger.Info(fmt.Sprintf("not all replicaset are ready:expected number :%v , ready number %v", len(replicaSetList.Items), readyRs))
+		logger.Info(fmt.Sprintf("not all replicaset are ready:expected number :%v , ready number %v", totalRs, readyRs))
 		return false, nil
 	}
 
@@ -409,7 +410,7 @@ func performUpgradeVerification(c client.Client, metricsClient metrics.Metrics, 
 		}
 	}
 	if totalDS != readyDS {
-		logger.Info(fmt.Sprintf("not all daemonset are ready:expected number :%v , ready number %v", len(daemonSetList.Items), readyDS))
+		logger.Info(fmt.Sprintf("not all daemonset are ready:expected number :%v , ready number %v", totalDS, readyDS))
 		return false, nil
 	}
 
@@ -424,6 +425,7 @@ func performUpgradeVerification(c client.Client, metricsClient metrics.Metrics, 
 		return false, fmt.Errorf("can't query for alerts: %v", err)
 	}
 	if isTargetDownFiring {
+		logger.Info(fmt.Sprintf("TargetDown alerts are still firing in namespaces %v", namespacePrefixesAsRegex))
 		return false, nil
 	}
 

--- a/pkg/osd_cluster_upgrader/upgrader_test.go
+++ b/pkg/osd_cluster_upgrader/upgrader_test.go
@@ -344,6 +344,7 @@ var _ = Describe("ClusterUpgrader", func() {
 			It("Indicates that all workers are upgraded", func() {
 				gomock.InOrder(
 					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).Times(2),
+					mockMetricsClient.EXPECT().ResetMetricNodeDrainFailed(upgradeConfig.Name),
 					mockKubeClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "worker"}, gomock.Any()).SetArg(2, *configPool),
 					mockMaintClient.EXPECT().IsActive(),
 					mockMetricsClient.EXPECT().IsMetricNodeUpgradeEndTimeSet(upgradeConfig.Name, upgradeConfig.Spec.Desired.Version),
@@ -365,6 +366,7 @@ var _ = Describe("ClusterUpgrader", func() {
 			It("Indicates that all workers are not upgraded", func() {
 				gomock.InOrder(
 					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).Times(2),
+					mockMetricsClient.EXPECT().ResetMetricNodeDrainFailed(upgradeConfig.Name),
 					mockMaintClient.EXPECT().IsActive(),
 					mockMetricsClient.EXPECT().UpdateMetricUpgradeWorkerTimeout(upgradeConfig.Name, upgradeConfig.Spec.Desired.Version),
 				)


### PR DESCRIPTION
### What type of PR is this?

Bug

### What this PR does / why we need it?

- Improves log verbosity and accuracy during post upgrade verification
- Resets node drain failure alert if node drain failures aren't detected

### Which Jira/Github issue(s) this PR fixes?

OSD-5003
OSD-5013

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Ran `make generate` command locally to validate code changes

