### PR TITLE
Alert on node drain controller

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -46,5 +46,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: OPERATOR_NAME
               value: "managed-upgrade-operator"

--- a/docs/development.md
+++ b/docs/development.md
@@ -56,7 +56,7 @@ $ oc new-project managed-upgrade-operator
 * Run the operator via the Operator SDK:
 
 ```
-$ operator-sdk run --local --watch-namespace=""
+$ OPERATOR_NAMESPACE=managed-upgrade-operator operator-sdk run --local --watch-namespace=""
 ``` 
 
 (`make run` will also work here)

--- a/pkg/configmanager/config.go
+++ b/pkg/configmanager/config.go
@@ -3,14 +3,15 @@ package configmanager
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/managed-upgrade-operator/config"
 
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/managed-upgrade-operator/config"
 )
 
-var (
+const (
 	CONFIG_MAP_NAME = config.OperatorName + "-config"
 	CONFIG_PATH     = "config.yaml"
 )

--- a/pkg/controller/add_nodekeeper.go
+++ b/pkg/controller/add_nodekeeper.go
@@ -1,0 +1,10 @@
+package controller
+
+import (
+	"github.com/openshift/managed-upgrade-operator/pkg/controller/nodekeeper"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, nodekeeper.Add)
+}

--- a/pkg/controller/nodekeeper/config.go
+++ b/pkg/controller/nodekeeper/config.go
@@ -1,0 +1,19 @@
+package nodekeeper
+
+import (
+	"fmt"
+
+	"github.com/openshift/managed-upgrade-operator/pkg/machinery"
+)
+
+type nodeKeeperConfig struct {
+	NodeDrain machinery.NodeDrain `yaml:"nodeDrain"`
+}
+
+func (nkc *nodeKeeperConfig) IsValid() error {
+	if nkc.NodeDrain.Timeout < 0 {
+		return fmt.Errorf("Config nodeDrain timeOut is invalid")
+	}
+
+	return nil
+}

--- a/pkg/controller/nodekeeper/ignoremaster_predicate.go
+++ b/pkg/controller/nodekeeper/ignoremaster_predicate.go
@@ -1,0 +1,38 @@
+package nodekeeper
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/openshift/managed-upgrade-operator/pkg/machinery"
+)
+
+var IgnoreMasterPredicate = predicate.Funcs{
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		newNode, ok := e.MetaNew.(*corev1.Node)
+		if !ok {
+			return false
+		}
+		nodeLabels := newNode.GetLabels()
+		return !hasMasterLabel(nodeLabels)
+	},
+	// Create is required to avoid reconciliation at controller initialisation.
+	CreateFunc: func(e event.CreateEvent) bool {
+		nodeLabels := e.Meta.GetLabels()
+		return !hasMasterLabel(nodeLabels)
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		nodeLabels := e.Meta.GetLabels()
+		return !hasMasterLabel(nodeLabels)
+	},
+	GenericFunc: func(e event.GenericEvent) bool {
+		nodeLabels := e.Meta.GetLabels()
+		return !hasMasterLabel(nodeLabels)
+	},
+}
+
+func hasMasterLabel(nodeLabels map[string]string) bool {
+	_, ok := nodeLabels[machinery.MasterLabel]
+	return ok
+}

--- a/pkg/controller/nodekeeper/ignoremaster_predicate_test.go
+++ b/pkg/controller/nodekeeper/ignoremaster_predicate_test.go
@@ -1,0 +1,70 @@
+package nodekeeper
+
+import (
+	"github.com/openshift/managed-upgrade-operator/pkg/machinery"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NodeKeeperController IgnoreMasterPredicate", func() {
+
+	var (
+		masterNode    *corev1.Node
+		notMasterNode *corev1.Node
+	)
+
+	BeforeEach(func() {
+		masterNode = &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					machinery.MasterLabel: "",
+				},
+			},
+		}
+		notMasterNode = &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{},
+			},
+		}
+	})
+
+	Context("IgnoreMasterPredicate", func() {
+		It("Update ignores master nodes", func() {
+			result := IgnoreMasterPredicate.UpdateFunc(event.UpdateEvent{MetaNew: masterNode})
+			Expect(result).To(BeFalse())
+		})
+		It("Create ignores master nodes", func() {
+			result := IgnoreMasterPredicate.CreateFunc(event.CreateEvent{Meta: masterNode.GetObjectMeta()})
+			Expect(result).To(BeFalse())
+		})
+		It("Delete ignores master nodes", func() {
+			result := IgnoreMasterPredicate.DeleteFunc(event.DeleteEvent{Meta: masterNode.GetObjectMeta()})
+			Expect(result).To(BeFalse())
+		})
+		It("Generic ignores master nodes", func() {
+			result := IgnoreMasterPredicate.GenericFunc(event.GenericEvent{Meta: masterNode.GetObjectMeta()})
+			Expect(result).To(BeFalse())
+		})
+
+		It("Update allows non master nodes", func() {
+			result := IgnoreMasterPredicate.UpdateFunc(event.UpdateEvent{MetaNew: notMasterNode})
+			Expect(result).To(BeTrue())
+		})
+		It("Create allows non master nodes", func() {
+			result := IgnoreMasterPredicate.CreateFunc(event.CreateEvent{Meta: notMasterNode.GetObjectMeta()})
+			Expect(result).To(BeTrue())
+		})
+		It("Delete allows non master nodes", func() {
+			result := IgnoreMasterPredicate.DeleteFunc(event.DeleteEvent{Meta: notMasterNode.GetObjectMeta()})
+			Expect(result).To(BeTrue())
+		})
+		It("Generic allows non master nodes", func() {
+			result := IgnoreMasterPredicate.GenericFunc(event.GenericEvent{Meta: notMasterNode.GetObjectMeta()})
+			Expect(result).To(BeTrue())
+		})
+	})
+})

--- a/pkg/controller/nodekeeper/nodekeeper_controller.go
+++ b/pkg/controller/nodekeeper/nodekeeper_controller.go
@@ -1,0 +1,195 @@
+package nodekeeper
+
+import (
+	"context"
+	"fmt"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"os"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	upgradev1alpha1 "github.com/openshift/managed-upgrade-operator/pkg/apis/upgrade/v1alpha1"
+	"github.com/openshift/managed-upgrade-operator/pkg/configmanager"
+	"github.com/openshift/managed-upgrade-operator/pkg/machinery"
+	"github.com/openshift/managed-upgrade-operator/pkg/metrics"
+)
+
+var log = logf.Log.WithName("controller_nodekeeper")
+
+// Add creates a new NodeKeeper Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileNodeKeeper{
+		client:               mgr.GetClient(),
+		configManagerBuilder: configmanager.NewBuilder(),
+		machinery:            machinery.NewMachinery(),
+		metricsClientBuilder: metrics.NewBuilder(),
+		scheme:               mgr.GetScheme(),
+	}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("nodekeeper-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to primary resource Node, status change will not trigger a reconcile
+	err = c.Watch(
+		&source.Kind{Type: &corev1.Node{}},
+		&handler.EnqueueRequestForObject{},
+		IgnoreMasterPredicate)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// blank assignment to verify that ReconcileNodeKeeper implements reconcile.Reconciler
+var _ reconcile.Reconciler = &ReconcileNodeKeeper{}
+
+// ReconcileNodeKeeper reconciles a NodeKeeper object
+type ReconcileNodeKeeper struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client               client.Client
+	configManagerBuilder configmanager.ConfigManagerBuilder
+	machinery            machinery.Machinery
+	metricsClientBuilder metrics.MetricsBuilder
+	scheme               *runtime.Scheme
+}
+
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *ReconcileNodeKeeper) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := log.WithValues("Request.Name", request.Name)
+
+	operatorNamespace, err := getOperatorNamespace()
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	uc, err := getUpgradeConfigCR(r.client, operatorNamespace)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	upgradeResult, err := r.machinery.IsUpgrading(r.client, "worker")
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	history := uc.Status.History.GetHistory(uc.Spec.Desired.Version)
+	if !(history.Phase == upgradev1alpha1.UpgradePhaseUpgrading && upgradeResult.IsUpgrading) {
+		return reconcile.Result{}, nil
+	}
+
+	// Fetch the Node instance
+	node := &corev1.Node{}
+	err = r.client.Get(context.TODO(), request.NamespacedName, node)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	result := isDraining(node)
+	metricsClient, err := r.metricsClientBuilder.NewClient(r.client)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if !result.IsDraining {
+		metricsClient.ResetMetricNodeDrainFailed(node.Name)
+		return reconcile.Result{}, nil
+	}
+
+	cfm := r.configManagerBuilder.New(r.client, operatorNamespace)
+	cfg := &nodeKeeperConfig{}
+	err = cfm.Into(cfg)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	isNodeDrainTimedOut := result.StartTime != nil && result.StartTime.Add(cfg.NodeDrain.GetDuration()).Before(metav1.Now().Time)
+
+	if isNodeDrainTimedOut {
+		reqLogger.Info(fmt.Sprintf("Node drain timed out %s. Alerting.", node.Name))
+		metricsClient.UpdateMetricNodeDrainFailed(node.Name)
+		return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
+	}
+
+	return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
+}
+
+// getOperatorNamespace retrieves the operators namespace from an environment
+// variable and returns it to the caller.
+func getOperatorNamespace() (string, error) {
+	envVarOperatorNamespace := "OPERATOR_NAMESPACE"
+	ns, found := os.LookupEnv(envVarOperatorNamespace)
+	if !found {
+		return "", fmt.Errorf("%s must be set", envVarOperatorNamespace)
+	}
+	return ns, nil
+}
+
+func getUpgradeConfigCR(c client.Client, ns string) (*upgradev1alpha1.UpgradeConfig, error) {
+	uCList := &upgradev1alpha1.UpgradeConfigList{}
+
+	err := c.List(context.TODO(), uCList, &client.ListOptions{Namespace: ns})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, uC := range uCList.Items {
+		return &uC, nil
+	}
+
+	return nil, errors.NewNotFound(schema.GroupResource{Group: upgradev1alpha1.SchemeGroupVersion.Group, Resource: "UpgradeConfig"}, "UpgradeConfig")
+}
+
+type isDrainResult struct {
+	IsDraining bool
+	StartTime  *metav1.Time
+}
+
+func isDraining(node *corev1.Node) isDrainResult {
+	var drainStartedAtTime *metav1.Time
+	isDraining := false
+	if node.Spec.Unschedulable && len(node.Spec.Taints) > 0 {
+		for _, n := range node.Spec.Taints {
+			if n.Effect == corev1.TaintEffectNoSchedule {
+				isDraining = true
+				drainStartedAtTime = n.TimeAdded
+			}
+		}
+	}
+
+	return isDrainResult{
+		IsDraining: isDraining,
+		StartTime:  drainStartedAtTime,
+	}
+}

--- a/pkg/controller/nodekeeper/nodekeeper_controller_test.go
+++ b/pkg/controller/nodekeeper/nodekeeper_controller_test.go
@@ -1,0 +1,167 @@
+package nodekeeper
+
+import (
+	"os"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	upgradev1alpha1 "github.com/openshift/managed-upgrade-operator/pkg/apis/upgrade/v1alpha1"
+	configMocks "github.com/openshift/managed-upgrade-operator/pkg/configmanager/mocks"
+	"github.com/openshift/managed-upgrade-operator/pkg/machinery"
+	mockMachinery "github.com/openshift/managed-upgrade-operator/pkg/machinery/mocks"
+	mockMetrics "github.com/openshift/managed-upgrade-operator/pkg/metrics/mocks"
+	"github.com/openshift/managed-upgrade-operator/util/mocks"
+	testStructs "github.com/openshift/managed-upgrade-operator/util/mocks/structs"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NodeKeeperController", func() {
+	var (
+		reconciler               *ReconcileNodeKeeper
+		mockCtrl                 *gomock.Controller
+		mockKubeClient           *mocks.MockClient
+		mockConfigManagerBuilder *configMocks.MockConfigManagerBuilder
+		mockConfigManager        *configMocks.MockConfigManager
+		mockMachineryClient      *mockMachinery.MockMachinery
+		mockMetricsBuilder       *mockMetrics.MockMetricsBuilder
+		mockMetricsClient        *mockMetrics.MockMetrics
+		testNodeName             types.NamespacedName
+		upgradeConfigName        types.NamespacedName
+		upgradeConfigList        upgradev1alpha1.UpgradeConfigList
+		config                   nodeKeeperConfig
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockKubeClient = mocks.NewMockClient(mockCtrl)
+		mockConfigManagerBuilder = configMocks.NewMockConfigManagerBuilder(mockCtrl)
+		mockConfigManager = configMocks.NewMockConfigManager(mockCtrl)
+		mockMachineryClient = mockMachinery.NewMockMachinery(mockCtrl)
+		mockMetricsBuilder = mockMetrics.NewMockMetricsBuilder(mockCtrl)
+		mockMetricsClient = mockMetrics.NewMockMetrics(mockCtrl)
+		testNodeName = types.NamespacedName{
+			Name: "test-node-1",
+		}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	JustBeforeEach(func() {
+		reconciler = &ReconcileNodeKeeper{
+			mockKubeClient,
+			mockConfigManagerBuilder,
+			mockMachineryClient,
+			mockMetricsBuilder,
+			runtime.NewScheme(),
+		}
+	})
+
+	Context("Reconcile", func() {
+		BeforeEach(func() {
+			ns := "openshift-managed-upgrade-operator"
+			upgradeConfigName = types.NamespacedName{
+				Name:      "test-upgradeconfig",
+				Namespace: ns,
+			}
+			_ = os.Setenv("OPERATOR_NAMESPACE", ns)
+		})
+		Context("When to check nodes", func() {
+			It("should not check node if not in upgrade phase", func() {
+				uc := *testStructs.NewUpgradeConfigBuilder().WithNamespacedName(upgradeConfigName).WithPhase(upgradev1alpha1.UpgradePhasePending).GetUpgradeConfig()
+				upgradeConfigList = upgradev1alpha1.UpgradeConfigList{
+					Items: []upgradev1alpha1.UpgradeConfig{uc},
+				}
+				gomock.InOrder(
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, upgradeConfigList).Return(nil),
+					mockMachineryClient.EXPECT().IsUpgrading(gomock.Any(), "worker").Return(&machinery.UpgradingResult{IsUpgrading: true}, nil),
+					mockKubeClient.EXPECT().Get(gomock.Any(), testNodeName, gomock.Any()).Times(0),
+				)
+				_, err := reconciler.Reconcile(reconcile.Request{NamespacedName: testNodeName})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("should not check node if machines are not upgrading", func() {
+				uc := *testStructs.NewUpgradeConfigBuilder().WithNamespacedName(upgradeConfigName).WithPhase(upgradev1alpha1.UpgradePhaseUpgrading).GetUpgradeConfig()
+				upgradeConfigList = upgradev1alpha1.UpgradeConfigList{
+					Items: []upgradev1alpha1.UpgradeConfig{uc},
+				}
+				gomock.InOrder(
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, upgradeConfigList).Return(nil),
+					mockMachineryClient.EXPECT().IsUpgrading(gomock.Any(), "worker").Return(&machinery.UpgradingResult{IsUpgrading: false}, nil),
+					mockKubeClient.EXPECT().Get(gomock.Any(), testNodeName, gomock.Any()).Times(0),
+				)
+				_, err := reconciler.Reconcile(reconcile.Request{NamespacedName: testNodeName})
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("Alerting for node drain problems", func() {
+			BeforeEach(func() {
+				uc := *testStructs.NewUpgradeConfigBuilder().WithNamespacedName(upgradeConfigName).WithPhase(upgradev1alpha1.UpgradePhaseUpgrading).GetUpgradeConfig()
+				upgradeConfigList = upgradev1alpha1.UpgradeConfigList{
+					Items: []upgradev1alpha1.UpgradeConfig{uc},
+				}
+				config = nodeKeeperConfig{
+					NodeDrain: machinery.NodeDrain{
+						Timeout: 5,
+					},
+				}
+			})
+			It("should alert when a node drain takes too long", func() {
+				testNode := corev1.Node{
+					Spec: corev1.NodeSpec{
+						Unschedulable: true,
+						Taints: []corev1.Taint{
+							{Effect: corev1.TaintEffectNoSchedule,
+								TimeAdded: &metav1.Time{Time: time.Now().Add(-10 * time.Minute)},
+							},
+						},
+					},
+				}
+
+				gomock.InOrder(
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, upgradeConfigList).Return(nil),
+					mockMachineryClient.EXPECT().IsUpgrading(gomock.Any(), "worker").Return(&machinery.UpgradingResult{IsUpgrading: true}, nil),
+					mockKubeClient.EXPECT().Get(gomock.Any(), testNodeName, gomock.Any()).SetArg(2, testNode).Return(nil),
+					mockMetricsBuilder.EXPECT().NewClient(gomock.Any()).Return(mockMetricsClient, nil),
+					mockConfigManagerBuilder.EXPECT().New(gomock.Any(), gomock.Any()).Return(mockConfigManager),
+					mockConfigManager.EXPECT().Into(gomock.Any()).SetArg(0, config),
+					mockMetricsClient.EXPECT().UpdateMetricNodeDrainFailed(gomock.Any()).Times(1),
+					mockMetricsClient.EXPECT().ResetMetricNodeDrainFailed(gomock.Any()).Times(0),
+				)
+				result, err := reconciler.Reconcile(reconcile.Request{NamespacedName: testNodeName})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Requeue).To(BeFalse())
+				Expect(result.RequeueAfter).To(Not(BeNil()))
+			})
+			It("should reset any alerts once node is not draining", func() {
+				testNode := corev1.Node{
+					Spec: corev1.NodeSpec{
+						Unschedulable: false,
+					},
+				}
+				gomock.InOrder(
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, upgradeConfigList).Return(nil),
+					mockMachineryClient.EXPECT().IsUpgrading(gomock.Any(), "worker").Return(&machinery.UpgradingResult{IsUpgrading: true}, nil),
+					mockKubeClient.EXPECT().Get(gomock.Any(), testNodeName, gomock.Any()).SetArg(2, testNode).Return(nil),
+					mockMetricsBuilder.EXPECT().NewClient(gomock.Any()).Return(mockMetricsClient, nil),
+					mockMetricsClient.EXPECT().ResetMetricNodeDrainFailed(gomock.Any()).Times(1),
+					mockMetricsClient.EXPECT().UpdateMetricNodeDrainFailed(gomock.Any()).Times(0),
+				)
+				result, err := reconciler.Reconcile(reconcile.Request{NamespacedName: testNodeName})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Requeue).To(BeFalse())
+				Expect(result.RequeueAfter).To(BeZero())
+			})
+		})
+	})
+})

--- a/pkg/controller/nodekeeper/nodekeeper_suite_test.go
+++ b/pkg/controller/nodekeeper/nodekeeper_suite_test.go
@@ -1,0 +1,13 @@
+package nodekeeper
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestUpgradeConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "NodeKeeperController Suite")
+}

--- a/pkg/machinery/config.go
+++ b/pkg/machinery/config.go
@@ -1,0 +1,13 @@
+package machinery
+
+import (
+	"time"
+)
+
+type NodeDrain struct {
+	Timeout int `yaml:"timeOut"`
+}
+
+func (nd *NodeDrain) GetDuration() time.Duration {
+	return time.Duration(nd.Timeout) * time.Minute
+}

--- a/pkg/machinery/machinery.go
+++ b/pkg/machinery/machinery.go
@@ -5,6 +5,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	MasterLabel = "node-role.kubernetes.io/master"
+)
+
 //go:generate mockgen -destination=mocks/machinery.go -package=mocks github.com/openshift/managed-upgrade-operator/pkg/machinery Machinery
 type Machinery interface {
 	IsUpgrading(c client.Client, nodeType string) (*UpgradingResult, error)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -21,6 +21,7 @@ const (
 	metricsTag   = "upgradeoperator"
 	nameLabel    = "upgradeconfig_name"
 	versionLabel = "version"
+	nodeLabel = "node_name"
 )
 
 //go:generate mockgen -destination=mocks/metrics.go -package=mocks github.com/openshift/managed-upgrade-operator/pkg/metrics Metrics
@@ -155,7 +156,7 @@ var (
 		Subsystem: metricsTag,
 		Name:      "node_drain_timeout",
 		Help:      "Node cannot be drained successfully in time.",
-	}, []string{nameLabel})
+	}, []string{nodeLabel})
 )
 
 func init() {
@@ -252,15 +253,15 @@ func (c *Counter) ResetMetricUpgradeWorkerTimeout(upgradeConfigName, version str
 		float64(0))
 }
 
-func (c *Counter) UpdateMetricNodeDrainFailed(upgradeConfigName string) {
+func (c *Counter) UpdateMetricNodeDrainFailed(nodeName string) {
 	metricNodeDrainFailed.With(prometheus.Labels{
-		nameLabel: upgradeConfigName}).Set(
+		nodeLabel: nodeName}).Set(
 		float64(1))
 }
 
-func (c *Counter) ResetMetricNodeDrainFailed(upgradeConfigName string) {
+func (c *Counter) ResetMetricNodeDrainFailed(nodeName string) {
 	metricNodeDrainFailed.With(prometheus.Labels{
-		nameLabel: upgradeConfigName}).Set(
+		nodeLabel: nodeName}).Set(
 		float64(0))
 }
 

--- a/pkg/osd_cluster_upgrader/config.go
+++ b/pkg/osd_cluster_upgrader/config.go
@@ -3,13 +3,15 @@ package osd_cluster_upgrader
 import (
 	"fmt"
 	"time"
+
+	"github.com/openshift/managed-upgrade-operator/pkg/machinery"
 )
 
 type osdUpgradeConfig struct {
-	Maintenance maintenanceConfig `yaml:"maintenance"`
-	Scale       scaleConfig       `yaml:"scale"`
-	NodeDrain   nodeDrain         `yaml:"nodeDrain"`
-	HealthCheck healthCheck       `yaml:"healthCheck"`
+	Maintenance maintenanceConfig   `yaml:"maintenance"`
+	Scale       scaleConfig         `yaml:"scale"`
+	NodeDrain   machinery.NodeDrain `yaml:"nodeDrain"`
+	HealthCheck healthCheck         `yaml:"healthCheck"`
 }
 
 type maintenanceConfig struct {
@@ -48,10 +50,6 @@ type scaleConfig struct {
 	TimeOut int `yaml:"timeOut"`
 }
 
-type nodeDrain struct {
-	TimeOut int `yaml:"timeOut"`
-}
-
 type healthCheck struct {
 	IgnoredCriticals []string `yaml:"ignoredCriticals"`
 }
@@ -63,7 +61,7 @@ func (cfg *osdUpgradeConfig) IsValid() error {
 	if cfg.Scale.TimeOut <= 0 {
 		return fmt.Errorf("Config scale timeOut is invalid")
 	}
-	if cfg.NodeDrain.TimeOut <= 0 {
+	if cfg.NodeDrain.Timeout <= 0 {
 		return fmt.Errorf("Config nodeDrain timeOut is invalid")
 	}
 
@@ -72,8 +70,4 @@ func (cfg *osdUpgradeConfig) IsValid() error {
 
 func (cfg *osdUpgradeConfig) GetScaleDuration() time.Duration {
 	return time.Duration(cfg.Scale.TimeOut) * time.Minute
-}
-
-func (cfg *osdUpgradeConfig) GetNodeDrainDuration() time.Duration {
-	return time.Duration(cfg.NodeDrain.TimeOut) * time.Minute
 }

--- a/pkg/osd_cluster_upgrader/upgrader.go
+++ b/pkg/osd_cluster_upgrader/upgrader.go
@@ -11,7 +11,6 @@ import (
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -248,7 +247,7 @@ func CreateWorkerMaintWindow(c client.Client, cfg *osdUpgradeConfig, scaler scal
 	pendingWorkerCount := upgradingResult.MachineCount - upgradingResult.UpdatedCount
 	// We use the maximum of the PDB drain timeout and node drain timeout to compute a 'worst case' wait time
 	pdbForceDrainTimeout := time.Duration(upgradeConfig.Spec.PDBForceDrainTimeout) * time.Minute
-	nodeDrainTimeout := cfg.GetNodeDrainDuration()
+	nodeDrainTimeout := cfg.NodeDrain.GetDuration()
 	waitTimePeriod := time.Duration(pendingWorkerCount) * pdbForceDrainTimeout
 	if pdbForceDrainTimeout < nodeDrainTimeout {
 		waitTimePeriod = time.Duration(pendingWorkerCount) * nodeDrainTimeout
@@ -273,18 +272,6 @@ func CreateWorkerMaintWindow(c client.Client, cfg *osdUpgradeConfig, scaler scal
 
 // AllWorkersUpgraded checks whether all the worker nodes are ready with new config
 func AllWorkersUpgraded(c client.Client, cfg *osdUpgradeConfig, scaler scaler.Scaler, metricsClient metrics.Metrics, m maintenance.Maintenance, cvClient cv.ClusterVersion, upgradeConfig *upgradev1alpha1.UpgradeConfig, machinery machinery.Machinery, logger logr.Logger) (bool, error) {
-	okDrain, errDrain := nodeDrained(c, cfg.GetNodeDrainDuration(), upgradeConfig, logger)
-	if errDrain != nil {
-		return false, errDrain
-	}
-
-	if !okDrain {
-		logger.Info("Node drain timeout.")
-		metricsClient.UpdateMetricNodeDrainFailed(upgradeConfig.Name)
-		return false, nil
-	}
-	metricsClient.ResetMetricNodeDrainFailed(upgradeConfig.Name)
-
 	upgradingResult, errUpgrade := machinery.IsUpgrading(c, "worker")
 	if errUpgrade != nil {
 		return false, errUpgrade
@@ -622,39 +609,3 @@ func hasUpgradeCommenced(cvClient cv.ClusterVersion, uc *upgradev1alpha1.Upgrade
 	return true, nil
 }
 
-// nodeDrained checks if the nodes are being drained successfully during the upgrade
-func nodeDrained(c client.Client, drainTimeOut time.Duration, uc *upgradev1alpha1.UpgradeConfig, logger logr.Logger) (bool, error) {
-
-	podDisruptionBudgetAtLimit := false
-	pdbList := &policyv1beta1.PodDisruptionBudgetList{}
-	errPDB := c.List(context.TODO(), pdbList)
-	if errPDB != nil {
-		return false, errPDB
-	}
-	for _, pdb := range pdbList.Items {
-		if pdb.Status.DesiredHealthy == pdb.Status.ExpectedPods {
-			podDisruptionBudgetAtLimit = true
-		}
-	}
-
-	var drainStarted metav1.Time
-	nodeList := &corev1.NodeList{}
-	errNode := c.List(context.TODO(), nodeList)
-	if errNode != nil {
-		return false, errNode
-	}
-	for _, node := range nodeList.Items {
-		if node.Spec.Unschedulable && len(node.Spec.Taints) > 0 {
-			for _, n := range node.Spec.Taints {
-				if n.Effect == corev1.TaintEffectNoSchedule {
-					drainStarted = *n.TimeAdded
-					if drainStarted.Add(drainTimeOut).Before(metav1.Now().Time) && !podDisruptionBudgetAtLimit {
-						logger.Info(fmt.Sprintf("The node cannot be drained within %d minutes.", int64(drainTimeOut)))
-						return false, nil
-					}
-				}
-			}
-		}
-	}
-	return true, nil
-}

--- a/pkg/osd_cluster_upgrader/upgrader_test.go
+++ b/pkg/osd_cluster_upgrader/upgrader_test.go
@@ -340,8 +340,6 @@ var _ = Describe("ClusterUpgrader", func() {
 		Context("When all workers are upgraded", func() {
 			It("Indicates that all workers are upgraded", func() {
 				gomock.InOrder(
-					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).Times(2),
-					mockMetricsClient.EXPECT().ResetMetricNodeDrainFailed(upgradeConfig.Name),
 					mockMachineryClient.EXPECT().IsUpgrading(gomock.Any(), "worker").Return(&machinery.UpgradingResult{IsUpgrading: false}, nil),
 					mockMaintClient.EXPECT().IsActive(),
 					mockMetricsClient.EXPECT().IsMetricNodeUpgradeEndTimeSet(upgradeConfig.Name, upgradeConfig.Spec.Desired.Version),
@@ -356,8 +354,6 @@ var _ = Describe("ClusterUpgrader", func() {
 		Context("When all workers are not upgraded", func() {
 			It("Indicates that all workers are not upgraded", func() {
 				gomock.InOrder(
-					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).Times(2),
-					mockMetricsClient.EXPECT().ResetMetricNodeDrainFailed(upgradeConfig.Name),
 					mockMachineryClient.EXPECT().IsUpgrading(gomock.Any(), "worker").Return(&machinery.UpgradingResult{IsUpgrading: true}, nil),
 					mockMaintClient.EXPECT().IsActive(),
 					mockMetricsClient.EXPECT().UpdateMetricUpgradeWorkerTimeout(upgradeConfig.Name, upgradeConfig.Spec.Desired.Version),

--- a/pkg/scaler/machineSetScaler.go
+++ b/pkg/scaler/machineSetScaler.go
@@ -12,6 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/managed-upgrade-operator/pkg/machinery"
 )
 
 const (
@@ -180,7 +182,7 @@ func (s *machineSetScaler) EnsureScaleDownNodes(c client.Client, logger logr.Log
 	// Desired replicas should match worker and infra count of nodes.
 	nonMasterNodes := &corev1.NodeList{}
 	err = c.List(context.TODO(), nonMasterNodes, []client.ListOption{
-		NotMatchingLabels{"node-role.kubernetes.io/master": ""},
+		NotMatchingLabels{machinery.MasterLabel: ""},
 	}...)
 	if err != nil {
 		logger.Error(err, "failed to list nodes")

--- a/pkg/scaler/scaling_test.go
+++ b/pkg/scaler/scaling_test.go
@@ -3,8 +3,9 @@ package scaler
 import (
 	"context"
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
@@ -13,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/openshift/managed-upgrade-operator/pkg/machinery"
 	"github.com/openshift/managed-upgrade-operator/util/mocks"
 
 	. "github.com/onsi/ginkgo"
@@ -443,7 +445,7 @@ var _ = Describe("Node scaling tests", func() {
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
-								"node-role.kubernetes.io/master": "",
+								machinery.MasterLabel: "",
 							},
 						},
 						Status: corev1.NodeStatus{
@@ -474,7 +476,7 @@ var _ = Describe("Node scaling tests", func() {
 					NotMatchingLabels{LABEL_UPGRADE: "true"},
 				}).SetArg(1, *originalMachineSets),
 				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
-					NotMatchingLabels{"node-role.kubernetes.io/master": ""},
+					NotMatchingLabels{machinery.MasterLabel: ""},
 				}).SetArg(1, *nodes),
 			)
 			result, err := scaler.EnsureScaleDownNodes(mockKubeClient, logger)


### PR DESCRIPTION
### What type of PR is this?
Refactor

### What this PR does / why we need it?
To really watch on nodes draining this needs to happen per node and in parallel to master machineconfigpools as workers update at the same time as masters
This PR uses the sdk controller pattern to watch for node events and will alert if a node drain times out.
This is the first step in implementing enhanced node draining and should be feature parity with the previous implementation.
Using the controller pattern allows us to control draining outside of upgraders.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-4716
This does not implement the force drain as mention in the above jira, that will be a follow on PR

### Special notes for your reviewer:
Basic ask is to alert SRE if a operator initiated worker node passes our node drain timeout configured in managed-upgrade-operator-config configmap

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make generate` command locally to validate code changes
- [x] Included documentation changes with PR

