### PR TITLE
Lockdown watch namespace

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -41,7 +41,9 @@ spec:
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
-              value: ""
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: POD_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
### What this PR does / why we need it?
Ensures the operator only watches on the ns its deployed too
