### PR TITLE
fix the worker maint logic to stop keep creating maint

### DIFF
--- a/pkg/maintenance/maintenance.go
+++ b/pkg/maintenance/maintenance.go
@@ -9,7 +9,7 @@ import (
 //go:generate mockgen -destination=mocks/maintenance.go -package=mocks github.com/openshift/managed-upgrade-operator/pkg/maintenance Maintenance
 type Maintenance interface {
 	StartControlPlane(endsAt time.Time, version string, ignoredAlerts []string) error
-	SetWorker(endsAt time.Time, version string) error
+	SetWorker(endsAt time.Time, version string, count int32) error
 	EndControlPlane() error
 	EndWorker() error
 	EndSilences(comment string) error

--- a/pkg/maintenance/maintenance_test.go
+++ b/pkg/maintenance/maintenance_test.go
@@ -3,7 +3,6 @@ package maintenance
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/go-openapi/strfmt"
@@ -49,7 +48,7 @@ var _ = Describe("Alert Manager Maintenance Client", func() {
 
 		activeSilenceId      = "test-id"
 		activeSilenceStatus  = amv2Models.SilenceStatusStateActive
-		activeSilenceComment = "Silence for OSD with " + strconv.Itoa(int(testWorkerCount)) + " worker node upgrade to version " + testVersion
+		activeSilenceComment = fmt.Sprintf("Silence for OSD with %d worker node upgrade to version %s", testWorkerCount, testVersion)
 		testActiveSilences   = []amv2Models.GettableSilence{
 			{
 				ID:     &activeSilenceId,

--- a/pkg/maintenance/mocks/maintenance.go
+++ b/pkg/maintenance/mocks/maintenance.go
@@ -91,17 +91,17 @@ func (mr *MockMaintenanceMockRecorder) IsActive() *gomock.Call {
 }
 
 // SetWorker mocks base method
-func (m *MockMaintenance) SetWorker(arg0 time.Time, arg1 string) error {
+func (m *MockMaintenance) SetWorker(arg0 time.Time, arg1 string, arg2 int32) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetWorker", arg0, arg1)
+	ret := m.ctrl.Call(m, "SetWorker", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetWorker indicates an expected call of SetWorker
-func (mr *MockMaintenanceMockRecorder) SetWorker(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMaintenanceMockRecorder) SetWorker(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWorker", reflect.TypeOf((*MockMaintenance)(nil).SetWorker), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWorker", reflect.TypeOf((*MockMaintenance)(nil).SetWorker), arg0, arg1, arg2)
 }
 
 // StartControlPlane mocks base method

--- a/pkg/osd_cluster_upgrader/upgrader.go
+++ b/pkg/osd_cluster_upgrader/upgrader.go
@@ -246,8 +246,10 @@ func CreateWorkerMaintWindow(c client.Client, cfg *osdUpgradeConfig, scaler scal
 
 	pendingWorkerCount := upgradingResult.MachineCount - upgradingResult.UpdatedCount
 	if pendingWorkerCount < 1 {
+		logger.Info(fmt.Sprintf("No worker node left for upgrading."))
 		return true, nil
 	}
+
 	// We use the maximum of the PDB drain timeout and node drain timeout to compute a 'worst case' wait time
 	pdbForceDrainTimeout := time.Duration(upgradeConfig.Spec.PDBForceDrainTimeout) * time.Minute
 	nodeDrainTimeout := cfg.NodeDrain.GetDuration()

--- a/pkg/osd_cluster_upgrader/upgrader.go
+++ b/pkg/osd_cluster_upgrader/upgrader.go
@@ -246,7 +246,7 @@ func CreateWorkerMaintWindow(c client.Client, cfg *osdUpgradeConfig, scaler scal
 
 	pendingWorkerCount := upgradingResult.MachineCount - upgradingResult.UpdatedCount
 	if pendingWorkerCount < 1 {
-		logger.Info(fmt.Sprintf("No worker node left for upgrading."))
+		logger.Info("No worker node left for upgrading.")
 		return true, nil
 	}
 

--- a/pkg/osd_cluster_upgrader/upgrader_maintenance_window_test.go
+++ b/pkg/osd_cluster_upgrader/upgrader_maintenance_window_test.go
@@ -101,7 +101,7 @@ var _ = Describe("ClusterUpgrader maintenance window tests", func() {
 	Context("When creating a worker maintenance window", func() {
 		It("Asks the maintenance client to do so", func() {
 			mockMachineryClient.EXPECT().IsUpgrading(gomock.Any(), "worker").Return(&machinery.UpgradingResult{IsUpgrading: true}, nil)
-			mockMaintClient.EXPECT().SetWorker(gomock.Any(), upgradeConfig.Spec.Desired.Version)
+			mockMaintClient.EXPECT().SetWorker(gomock.Any(), upgradeConfig.Spec.Desired.Version, gomock.Any())
 			result, err := CreateWorkerMaintWindow(mockKubeClient, config, mockScaler, mockMetricsClient, mockMaintClient, mockCVClient, upgradeConfig, mockMachineryClient, logger)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeTrue())
@@ -109,7 +109,7 @@ var _ = Describe("ClusterUpgrader maintenance window tests", func() {
 		It("Indicates when creating the maintenance window has failed", func() {
 			fakeError := fmt.Errorf("fake error")
 			mockMachineryClient.EXPECT().IsUpgrading(gomock.Any(), "worker").Return(&machinery.UpgradingResult{IsUpgrading: true}, nil)
-			mockMaintClient.EXPECT().SetWorker(gomock.Any(), upgradeConfig.Spec.Desired.Version).Return(fakeError)
+			mockMaintClient.EXPECT().SetWorker(gomock.Any(), upgradeConfig.Spec.Desired.Version, gomock.Any()).Return(fakeError)
 			result, err := CreateWorkerMaintWindow(mockKubeClient, config, mockScaler, mockMetricsClient, mockMaintClient, mockCVClient, upgradeConfig, mockMachineryClient, logger)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(Equal(fakeError))

--- a/pkg/osd_cluster_upgrader/upgrader_maintenance_window_test.go
+++ b/pkg/osd_cluster_upgrader/upgrader_maintenance_window_test.go
@@ -100,7 +100,7 @@ var _ = Describe("ClusterUpgrader maintenance window tests", func() {
 
 	Context("When creating a worker maintenance window", func() {
 		It("Asks the maintenance client to do so", func() {
-			mockMachineryClient.EXPECT().IsUpgrading(gomock.Any(), "worker").Return(&machinery.UpgradingResult{IsUpgrading: true}, nil)
+			mockMachineryClient.EXPECT().IsUpgrading(gomock.Any(), "worker").Return(&machinery.UpgradingResult{IsUpgrading: true, MachineCount: 4, UpdatedCount: 2}, nil)
 			mockMaintClient.EXPECT().SetWorker(gomock.Any(), upgradeConfig.Spec.Desired.Version, gomock.Any())
 			result, err := CreateWorkerMaintWindow(mockKubeClient, config, mockScaler, mockMetricsClient, mockMaintClient, mockCVClient, upgradeConfig, mockMachineryClient, logger)
 			Expect(err).NotTo(HaveOccurred())
@@ -108,12 +108,18 @@ var _ = Describe("ClusterUpgrader maintenance window tests", func() {
 		})
 		It("Indicates when creating the maintenance window has failed", func() {
 			fakeError := fmt.Errorf("fake error")
-			mockMachineryClient.EXPECT().IsUpgrading(gomock.Any(), "worker").Return(&machinery.UpgradingResult{IsUpgrading: true}, nil)
+			mockMachineryClient.EXPECT().IsUpgrading(gomock.Any(), "worker").Return(&machinery.UpgradingResult{IsUpgrading: true, MachineCount: 4, UpdatedCount: 2}, nil)
 			mockMaintClient.EXPECT().SetWorker(gomock.Any(), upgradeConfig.Spec.Desired.Version, gomock.Any()).Return(fakeError)
 			result, err := CreateWorkerMaintWindow(mockKubeClient, config, mockScaler, mockMetricsClient, mockMaintClient, mockCVClient, upgradeConfig, mockMachineryClient, logger)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(Equal(fakeError))
 			Expect(result).To(BeFalse())
+		})
+		It("Skip creating maintenance window if no pending worker node left", func() {
+			mockMachineryClient.EXPECT().IsUpgrading(gomock.Any(), "worker").Return(&machinery.UpgradingResult{IsUpgrading: true, MachineCount: 4, UpdatedCount: 4}, nil)
+			result, err := CreateWorkerMaintWindow(mockKubeClient, config, mockScaler, mockMetricsClient, mockMaintClient, mockCVClient, upgradeConfig, mockMachineryClient, logger)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
 		})
 		It("Does not proceed if isUpgrading check fails", func() {
 			mockMachineryClient.EXPECT().IsUpgrading(gomock.Any(), "worker").Return(nil, fmt.Errorf("fake error"))


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
fixes OSD-5090


### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

