### PR TITLE
ignore the logging component in the health check

### DIFF
--- a/deploy/managed-upgrade-operator-config.yaml
+++ b/deploy/managed-upgrade-operator-config.yaml
@@ -29,7 +29,7 @@ data:
     verification:
       ignoredNamespaces:
       - openshift-logging
-      namespacePrefixToCheck:
+      namespacePrefixesToCheck:
       - openshift
       - kube
       - default

--- a/deploy/managed-upgrade-operator-config.yaml
+++ b/deploy/managed-upgrade-operator-config.yaml
@@ -26,3 +26,10 @@ data:
       - MetricsClientSendFailingSRE
       - UpgradeNodeScalingFailedSRE
       - UpgradeClusterCheckFailedSRE
+    verification:
+      ignoredNamespaces:
+      - openshift-logging
+      namespacePrefixToCheck:
+      - openshift
+      - kube
+      - default

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -48,7 +48,7 @@ type Metrics interface {
 	IsMetricUpgradeStartTimeSet(upgradeConfigName string, version string) (bool, error)
 	IsMetricControlPlaneEndTimeSet(upgradeConfigName string, version string) (bool, error)
 	IsMetricNodeUpgradeEndTimeSet(upgradeConfigName string, version string) (bool, error)
-	IsAlertFiring(alert string, namespaces []string) (bool, error)
+	IsAlertFiring(alert string, checkedNS, ignoredNS []string) (bool, error)
 	Query(query string) (*AlertResponse, error)
 	ResetMetrics()
 }
@@ -340,9 +340,10 @@ func (c *Counter) UpdateMetricUpgradeWindowBreached(upgradeConfigName string) {
 		float64(1))
 }
 
-func (c *Counter) IsAlertFiring(alert string, namespaces []string) (bool, error) {
-	cpMetrics, err := c.Query(fmt.Sprintf(`ALERTS{alertstate="firing",alertname="%s",namespace=~"^$|%s"}`,
-		alert, strings.Join(namespaces, "|")))
+func (c *Counter) IsAlertFiring(alert string, checkedNS, ignoredNS []string) (bool, error) {
+	cpMetrics, err := c.Query(fmt.Sprintf(`ALERTS{alertstate="firing",alertname="%s",namespace=~"^$|%s",namespace!="%s"}`,
+		alert, strings.Join(checkedNS, "|"), strings.Join(ignoredNS, "|")))
+
 	if err != nil {
 		return false, err
 	}

--- a/pkg/metrics/mocks/metrics.go
+++ b/pkg/metrics/mocks/metrics.go
@@ -35,18 +35,18 @@ func (m *MockMetrics) EXPECT() *MockMetricsMockRecorder {
 }
 
 // IsAlertFiring mocks base method
-func (m *MockMetrics) IsAlertFiring(arg0 string, arg1 []string) (bool, error) {
+func (m *MockMetrics) IsAlertFiring(arg0 string, arg1, arg2 []string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsAlertFiring", arg0, arg1)
+	ret := m.ctrl.Call(m, "IsAlertFiring", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // IsAlertFiring indicates an expected call of IsAlertFiring
-func (mr *MockMetricsMockRecorder) IsAlertFiring(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMetricsMockRecorder) IsAlertFiring(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAlertFiring", reflect.TypeOf((*MockMetrics)(nil).IsAlertFiring), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAlertFiring", reflect.TypeOf((*MockMetrics)(nil).IsAlertFiring), arg0, arg1, arg2)
 }
 
 // IsMetricControlPlaneEndTimeSet mocks base method

--- a/pkg/osd_cluster_upgrader/config.go
+++ b/pkg/osd_cluster_upgrader/config.go
@@ -8,10 +8,11 @@ import (
 )
 
 type osdUpgradeConfig struct {
-	Maintenance maintenanceConfig `yaml:"maintenance"`
-	Scale       scaleConfig       `yaml:"scale"`
-	NodeDrain   drain.NodeDrain   `yaml:"nodeDrain"`
-	HealthCheck healthCheck       `yaml:"healthCheck"`
+	Maintenance  maintenanceConfig   `yaml:"maintenance"`
+	Scale        scaleConfig         `yaml:"scale"`
+	NodeDrain    machinery.NodeDrain `yaml:"nodeDrain"`
+	HealthCheck  healthCheck         `yaml:"healthCheck"`
+	Verification verification        `yaml:"verification"`
 }
 
 type maintenanceConfig struct {
@@ -44,6 +45,11 @@ type scaleConfig struct {
 
 type healthCheck struct {
 	IgnoredCriticals []string `yaml:"ignoredCriticals"`
+}
+
+type verification struct {
+	IgnoredNamespaces      []string `yaml:"ignoredNamespaces"`
+	NamespacePrefixToCheck []string `yaml:"namespacePrefixToCheck"`
 }
 
 func (cfg *osdUpgradeConfig) IsValid() error {

--- a/pkg/osd_cluster_upgrader/config.go
+++ b/pkg/osd_cluster_upgrader/config.go
@@ -48,8 +48,8 @@ type healthCheck struct {
 }
 
 type verification struct {
-	IgnoredNamespaces      []string `yaml:"ignoredNamespaces"`
-	NamespacePrefixToCheck []string `yaml:"namespacePrefixToCheck"`
+	IgnoredNamespaces        []string `yaml:"ignoredNamespaces"`
+	NamespacePrefixesToCheck []string `yaml:"namespacePrefixesToCheck"`
 }
 
 func (cfg *osdUpgradeConfig) IsValid() error {

--- a/pkg/osd_cluster_upgrader/config.go
+++ b/pkg/osd_cluster_upgrader/config.go
@@ -8,11 +8,11 @@ import (
 )
 
 type osdUpgradeConfig struct {
-	Maintenance  maintenanceConfig   `yaml:"maintenance"`
-	Scale        scaleConfig         `yaml:"scale"`
-	NodeDrain    machinery.NodeDrain `yaml:"nodeDrain"`
-	HealthCheck  healthCheck         `yaml:"healthCheck"`
-	Verification verification        `yaml:"verification"`
+	Maintenance  maintenanceConfig `yaml:"maintenance"`
+	Scale        scaleConfig       `yaml:"scale"`
+	NodeDrain    drain.NodeDrain   `yaml:"nodeDrain"`
+	HealthCheck  healthCheck       `yaml:"healthCheck"`
+	Verification verification      `yaml:"verification"`
 }
 
 type maintenanceConfig struct {

--- a/pkg/osd_cluster_upgrader/upgrader.go
+++ b/pkg/osd_cluster_upgrader/upgrader.go
@@ -532,7 +532,7 @@ func performClusterHealthCheck(c client.Client, metricsClient metrics.Metrics, c
 	if len(ic) > 0 {
 		icQuery = `,alertname!="` + strings.Join(ic, `",alertname!="`) + `"`
 	}
-	healthCheckQuery := `ALERTS{alertstate="firing",severity="critical",namespace=~"^openshift.*|^kube.*|^default$",namespace!="openshift-customer-monitoring",pod!~"^elasticsearch-.*",service!="fluentd"` + icQuery + "}"
+	healthCheckQuery := `ALERTS{alertstate="firing",severity="critical",namespace=~"^openshift.*|^kube.*|^default$",namespace!="openshift-customer-monitoring|openshift-logging"` + icQuery + "}"
 	alerts, err := metricsClient.Query(healthCheckQuery)
 	if err != nil {
 		return false, fmt.Errorf("Unable to query critical alerts: %s", err)

--- a/pkg/osd_cluster_upgrader/upgrader.go
+++ b/pkg/osd_cluster_upgrader/upgrader.go
@@ -347,7 +347,7 @@ func UpdateSubscriptions(c client.Client, cfg *osdUpgradeConfig, scaler scaler.S
 
 // PostUpgradeVerification run the verification steps which defined in performUpgradeVerification
 func PostUpgradeVerification(c client.Client, cfg *osdUpgradeConfig, scaler scaler.Scaler, metricsClient metrics.Metrics, m maintenance.Maintenance, cvClient cv.ClusterVersion, upgradeConfig *upgradev1alpha1.UpgradeConfig, machinery machinery.Machinery, logger logr.Logger) (bool, error) {
-	ok, err := performUpgradeVerification(c, metricsClient, logger)
+	ok, err := performUpgradeVerification(c, cfg, metricsClient, logger)
 	if err != nil || !ok {
 		metricsClient.UpdateMetricClusterVerificationFailed(upgradeConfig.Name)
 		return false, err
@@ -358,9 +358,10 @@ func PostUpgradeVerification(c client.Client, cfg *osdUpgradeConfig, scaler scal
 }
 
 // performPostUpgradeVerification verifies all replicasets are at expected counts and all daemonsets are at expected counts
-func performUpgradeVerification(c client.Client, metricsClient metrics.Metrics, logger logr.Logger) (bool, error) {
+func performUpgradeVerification(c client.Client, cfg *osdUpgradeConfig, metricsClient metrics.Metrics, logger logr.Logger) (bool, error) {
 
-	namespacePrefixesToCheck := []string{"default", "kube", "openshift"}
+	namespacePrefixesToCheck := cfg.Verification.NamespacePrefixToCheck
+	namespaceToIgnore := cfg.Verification.IgnoredNamespaces
 
 	// Verify all ReplicaSets in the default, kube* and openshfit* namespaces are satisfied
 	replicaSetList := &appsv1.ReplicaSetList{}
@@ -372,10 +373,12 @@ func performUpgradeVerification(c client.Client, metricsClient metrics.Metrics, 
 	totalRs := 0
 	for _, replicaSet := range replicaSetList.Items {
 		for _, namespacePrefix := range namespacePrefixesToCheck {
-			if strings.HasPrefix(replicaSet.Namespace, namespacePrefix) {
-				totalRs = totalRs + 1
-				if replicaSet.Status.ReadyReplicas == replicaSet.Status.Replicas {
-					readyRs = readyRs + 1
+			for _, ingoredNS := range namespaceToIgnore {
+				if strings.HasPrefix(replicaSet.Namespace, namespacePrefix) && replicaSet.Namespace != ingoredNS {
+					totalRs = totalRs + 1
+					if replicaSet.Status.ReadyReplicas == replicaSet.Status.Replicas {
+						readyRs = readyRs + 1
+					}
 				}
 			}
 		}
@@ -395,10 +398,12 @@ func performUpgradeVerification(c client.Client, metricsClient metrics.Metrics, 
 	totalDS := 0
 	for _, daemonSet := range daemonSetList.Items {
 		for _, namespacePrefix := range namespacePrefixesToCheck {
-			if strings.HasPrefix(daemonSet.Namespace, namespacePrefix) {
-				totalDS = totalDS + 1
-				if daemonSet.Status.DesiredNumberScheduled == daemonSet.Status.NumberReady {
-					readyDS = readyDS + 1
+			for _, ignoredNS := range namespaceToIgnore {
+				if strings.HasPrefix(daemonSet.Namespace, namespacePrefix) && daemonSet.Namespace != ignoredNS {
+					totalDS = totalDS + 1
+					if daemonSet.Status.DesiredNumberScheduled == daemonSet.Status.NumberReady {
+						readyDS = readyDS + 1
+					}
 				}
 			}
 		}
@@ -411,10 +416,12 @@ func performUpgradeVerification(c client.Client, metricsClient metrics.Metrics, 
 	// If daemonsets and replicasets are satisfied, any active TargetDown alerts will eventually go away.
 	// Wait for that to occur before declaring the verification complete.
 	namespacePrefixesAsRegex := make([]string, 0)
+	namespaceIgnoreAlert := make([]string, 0)
 	for _, namespacePrefix := range namespacePrefixesToCheck {
 		namespacePrefixesAsRegex = append(namespacePrefixesAsRegex, fmt.Sprintf("^%s-.*", namespacePrefix))
 	}
-	isTargetDownFiring, err := metricsClient.IsAlertFiring("TargetDown", namespacePrefixesAsRegex)
+	namespaceIgnoreAlert = append(namespaceIgnoreAlert, namespaceToIgnore...)
+	isTargetDownFiring, err := metricsClient.IsAlertFiring("TargetDown", namespacePrefixesAsRegex, namespaceIgnoreAlert)
 	if err != nil {
 		return false, fmt.Errorf("can't query for alerts: %v", err)
 	}
@@ -525,7 +532,7 @@ func performClusterHealthCheck(c client.Client, metricsClient metrics.Metrics, c
 	if len(ic) > 0 {
 		icQuery = `,alertname!="` + strings.Join(ic, `",alertname!="`) + `"`
 	}
-	healthCheckQuery := `ALERTS{alertstate="firing",severity="critical",namespace=~"^openshift.*|^kube.*|^default$",namespace!="openshift-customer-monitoring"` + icQuery + "}"
+	healthCheckQuery := `ALERTS{alertstate="firing",severity="critical",namespace=~"^openshift.*|^kube.*|^default$",namespace!="openshift-customer-monitoring",pod!~"^elasticsearch-.*",service!="fluentd"` + icQuery + "}"
 	alerts, err := metricsClient.Query(healthCheckQuery)
 	if err != nil {
 		return false, fmt.Errorf("Unable to query critical alerts: %s", err)

--- a/pkg/osd_cluster_upgrader/upgrader.go
+++ b/pkg/osd_cluster_upgrader/upgrader.go
@@ -532,7 +532,7 @@ func performClusterHealthCheck(c client.Client, metricsClient metrics.Metrics, c
 	if len(ic) > 0 {
 		icQuery = `,alertname!="` + strings.Join(ic, `",alertname!="`) + `"`
 	}
-	healthCheckQuery := `ALERTS{alertstate="firing",severity="critical",namespace=~"^openshift.*|^kube.*|^default$",namespace!="openshift-customer-monitoring|openshift-logging"` + icQuery + "}"
+	healthCheckQuery := `ALERTS{alertstate="firing",severity="critical",namespace=~"^openshift.*|^kube.*|^default$",namespace!="openshift-customer-monitoring",namespace!="openshift-logging"` + icQuery + "}"
 	alerts, err := metricsClient.Query(healthCheckQuery)
 	if err != nil {
 		return false, fmt.Errorf("Unable to query critical alerts: %s", err)

--- a/pkg/osd_cluster_upgrader/upgrader.go
+++ b/pkg/osd_cluster_upgrader/upgrader.go
@@ -360,7 +360,7 @@ func PostUpgradeVerification(c client.Client, cfg *osdUpgradeConfig, scaler scal
 // performPostUpgradeVerification verifies all replicasets are at expected counts and all daemonsets are at expected counts
 func performUpgradeVerification(c client.Client, cfg *osdUpgradeConfig, metricsClient metrics.Metrics, logger logr.Logger) (bool, error) {
 
-	namespacePrefixesToCheck := cfg.Verification.NamespacePrefixToCheck
+	namespacePrefixesToCheck := cfg.Verification.NamespacePrefixesToCheck
 	namespaceToIgnore := cfg.Verification.IgnoredNamespaces
 
 	// Verify all ReplicaSets in the default, kube* and openshfit* namespaces are satisfied

--- a/pkg/osd_cluster_upgrader/upgrader_verification_test.go
+++ b/pkg/osd_cluster_upgrader/upgrader_verification_test.go
@@ -69,6 +69,7 @@ var _ = Describe("ClusterUpgrader verification and health tests", func() {
 			},
 			NodeDrain: drain.NodeDrain{
 				ExpectedNodeDrainTime: 8,
+			},
 			Verification: verification{
 				IgnoredNamespaces:        []string{"kube-test1"},
 				NamespacePrefixesToCheck: []string{"openshift", "default"},

--- a/pkg/osd_cluster_upgrader/upgrader_verification_test.go
+++ b/pkg/osd_cluster_upgrader/upgrader_verification_test.go
@@ -70,8 +70,8 @@ var _ = Describe("ClusterUpgrader verification and health tests", func() {
 			NodeDrain: drain.NodeDrain{
 				ExpectedNodeDrainTime: 8,
 			Verification: verification{
-				IgnoredNamespaces:      []string{"kube-test1"},
-				NamespacePrefixToCheck: []string{"openshift", "default"},
+				IgnoredNamespaces:        []string{"kube-test1"},
+				NamespacePrefixesToCheck: []string{"openshift", "default"},
 			},
 		}
 	})


### PR DESCRIPTION
### What type of PR is this?
feature


### What this PR does / why we need it?
_Fixes OSD-5017

### Special notes for your reviewer:
Replace https://github.com/openshift/managed-upgrade-operator/pull/138

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

