### PR TITLE
Update yq syntax and fix saas file location

### DIFF
--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -28,7 +28,7 @@ REMOVED_VERSIONS=""
 if [[ "$REMOVE_UNDEPLOYED" == true ]]; then
     DEPLOYED_HASH=$(
         curl -s "https://gitlab.cee.redhat.com/service/app-interface/raw/master/data/services/osd-operators/cicd/saas/saas-${_OPERATOR_NAME}.yaml" | \
-            docker run --rm -i quay.io/app-sre/yq -r '.resourceTemplates[]|select(.name="managed-upgrade-operator").targets[]|select(.namespace["$ref"]=="/services/osd-operators/namespaces/managed-upgrade-operator-production.yml")|.ref'
+            docker run --rm -i quay.io/app-sre/yq yq r - "resourceTemplates[*].targets(namespace.\$ref==/services/osd-operators/namespaces/hivep01ue1/cluster-scope.yml).ref"
     )
 
     delete=false


### PR DESCRIPTION
### What type of PR is this?
bug


### What this PR does / why we need it?
Production promotions will break since the yq syntax cannot retrieve the last promoted SHA.
### Which Jira/Github issue(s) this PR fixes?

The image used for yq was change to be the golang version which has a completely different syntax to the original python version. The entry point for the container is also not correct hence needing the extra yq.

The path to discover what version of the operator promoted to production has changed in app-interface, this has been updated.

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

