### PR TITLE
Fix tests after closing the controllers

### DIFF
--- a/pkg/clusterversion/clusterversion_test.go
+++ b/pkg/clusterversion/clusterversion_test.go
@@ -35,6 +35,10 @@ var _ = Describe("ClusterVersion client and utils", func() {
 		upgradeConfig = testStructs.NewUpgradeConfigBuilder().WithNamespacedName(upgradeConfigName).GetUpgradeConfig()
 	})
 
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+	
 	Context("ClusterVersion client", func() {
 		It("should get the ClusterVersion resource", func() {
 			gomock.InOrder(

--- a/pkg/machinery/machinery_test.go
+++ b/pkg/machinery/machinery_test.go
@@ -30,6 +30,10 @@ var _ = Describe("Machinery client and utils", func() {
 		machineryClient = &machinery{}
 	})
 
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
 	Context("When assessing whether all machines are upgraded", func() {
 		var configPool *machineconfigapi.MachineConfigPool
 		var nodeType = "worker"


### PR DESCRIPTION
Adding
```.go
	AfterEach(func() {
		mockCtrl.Finish()
	})
```
to some tests. Then the associated fixes.

