### PR TITLE
OSD-5571 report completed based on full upgrade completion

### DIFF
--- a/pkg/eventmanager/eventmanager.go
+++ b/pkg/eventmanager/eventmanager.go
@@ -164,20 +164,10 @@ func checkUpgradeEnd(mc metrics.Metrics, nc notifier.Notifier, uc *upgradev1alph
 
 	upgradeEnded := false
 
-	// Check metrics if the node upgrade end time metric has been set
-	isSet, err := mc.IsMetricNodeUpgradeEndTimeSet(uc.Name, uc.Spec.Desired.Version)
-	if err != nil {
-		log.Error(err, "could not check metrics for upgrade end time")
-	} else {
-	   upgradeEnded = isSet
-	}
-
-	// As a backup, check if upgradeConfig indicates the upgrade has completed
-	if !upgradeEnded {
-		upgradePhase, err := getUpgradePhase(uc)
-		if err == nil && *upgradePhase == upgradev1alpha1.UpgradePhaseUpgraded {
-			upgradeEnded = true
-		}
+	// Check if upgradeConfig indicates the upgrade has completed
+	upgradePhase, err := getUpgradePhase(uc)
+	if err == nil && *upgradePhase == upgradev1alpha1.UpgradePhaseUpgraded {
+		upgradeEnded = true
 	}
 
 	// If the upgrade hasn't ended, do nothing

--- a/pkg/eventmanager/eventmanager_test.go
+++ b/pkg/eventmanager/eventmanager_test.go
@@ -82,6 +82,7 @@ var _ = Describe("OCM Notifier", func() {
 			}
 			uc = *testStructs.NewUpgradeConfigBuilder().WithNamespacedName(upgradeConfigName).WithPhase(upgradev1alpha1.UpgradePhasePending).GetUpgradeConfig()
 			uc.Spec.Desired.Version = TEST_UPGRADE_VERSION
+			uc.Status.History[0].Version = TEST_UPGRADE_VERSION
 			uc.Spec.UpgradeAt = TEST_UPGRADE_TIME
 		})
 
@@ -91,8 +92,6 @@ var _ = Describe("OCM Notifier", func() {
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 					mockMetricsClient.EXPECT().IsClusterVersionAtVersion(TEST_UPGRADE_VERSION).Return(true, nil),
 					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(notifier.StateStarted), TEST_UPGRADE_VERSION).Return(true, nil),
-					mockMetricsClient.EXPECT().IsMetricNodeUpgradeEndTimeSet(TEST_UPGRADECONFIG_CR, TEST_UPGRADE_VERSION).Return(true, nil),
-					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(notifier.StateCompleted), TEST_UPGRADE_VERSION).Return(true, nil),
 				)
 				err := manager.notificationRefresh()
 				Expect(err).To(BeNil())
@@ -106,8 +105,6 @@ var _ = Describe("OCM Notifier", func() {
 					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(notifier.StateStarted), TEST_UPGRADE_VERSION).Return(false, nil),
 					mockNotifier.EXPECT().NotifyState(notifier.StateStarted, gomock.Any()),
 					mockMetricsClient.EXPECT().UpdateMetricNotificationEventSent(TEST_UPGRADECONFIG_CR, string(notifier.StateStarted), TEST_UPGRADE_VERSION),
-					mockMetricsClient.EXPECT().IsMetricNodeUpgradeEndTimeSet(TEST_UPGRADECONFIG_CR, TEST_UPGRADE_VERSION).Return(true, nil),
-					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(notifier.StateCompleted), TEST_UPGRADE_VERSION).Return(true, nil),
 				)
 				err := manager.notificationRefresh()
 				Expect(err).To(BeNil())
@@ -122,8 +119,9 @@ var _ = Describe("OCM Notifier", func() {
 				Name:      TEST_UPGRADECONFIG_CR,
 				Namespace: TEST_OPERATOR_NAMESPACE,
 			}
-			uc = *testStructs.NewUpgradeConfigBuilder().WithNamespacedName(upgradeConfigName).WithPhase(upgradev1alpha1.UpgradePhasePending).GetUpgradeConfig()
+			uc = *testStructs.NewUpgradeConfigBuilder().WithNamespacedName(upgradeConfigName).WithPhase(upgradev1alpha1.UpgradePhaseUpgraded).GetUpgradeConfig()
 			uc.Spec.Desired.Version = TEST_UPGRADE_VERSION
+			uc.Status.History[0].Version = TEST_UPGRADE_VERSION
 			uc.Spec.UpgradeAt = TEST_UPGRADE_TIME
 		})
 
@@ -133,7 +131,6 @@ var _ = Describe("OCM Notifier", func() {
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 					mockMetricsClient.EXPECT().IsClusterVersionAtVersion(TEST_UPGRADE_VERSION).Return(true, nil),
 					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(notifier.StateStarted), TEST_UPGRADE_VERSION).Return(true, nil),
-					mockMetricsClient.EXPECT().IsMetricNodeUpgradeEndTimeSet(TEST_UPGRADECONFIG_CR, TEST_UPGRADE_VERSION).Return(true, nil),
 					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(notifier.StateCompleted), TEST_UPGRADE_VERSION).Return(true, nil),
 				)
 				err := manager.notificationRefresh()
@@ -146,7 +143,6 @@ var _ = Describe("OCM Notifier", func() {
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 					mockMetricsClient.EXPECT().IsClusterVersionAtVersion(TEST_UPGRADE_VERSION).Return(true, nil),
 					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(notifier.StateStarted), TEST_UPGRADE_VERSION).Return(true, nil),
-					mockMetricsClient.EXPECT().IsMetricNodeUpgradeEndTimeSet(TEST_UPGRADECONFIG_CR, TEST_UPGRADE_VERSION).Return(true, nil),
 					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(notifier.StateCompleted), TEST_UPGRADE_VERSION).Return(false, nil),
 					mockNotifier.EXPECT().NotifyState(notifier.StateCompleted, gomock.Any()),
 					mockMetricsClient.EXPECT().UpdateMetricNotificationEventSent(TEST_UPGRADECONFIG_CR, string(notifier.StateCompleted), TEST_UPGRADE_VERSION),
@@ -156,5 +152,4 @@ var _ = Describe("OCM Notifier", func() {
 			})
 		})
 	})
-
 })


### PR DESCRIPTION
### What type of PR is this?

Bug

### What this PR does / why we need it?

Only send a "completed" notification if the upgrade has fully finished all upgrade steps. The only way we can know this right now is through checking the UpgradeConfig phase, so I have removed the metrics check in the meantime which was considering the cluster upgraded when the worker nodes were upgraded.

### Which Jira/Github issue(s) this PR fixes?

[OSD-5571](https://issues.redhat.com/browse/OSD-5571)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

