### PR TITLE
Retry and alert when UpgradeConfig can not be synced

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -39,6 +39,8 @@ type Metrics interface {
 	UpdateMetricClusterVerificationFailed(string)
 	UpdateMetricClusterVerificationSucceeded(string)
 	UpdateMetricUpgradeWindowNotBreached(string)
+	UpdateMetricUpgradeConfigSynced(string)
+	ResetMetricUpgradeConfigSynced(string)
 	UpdateMetricUpgradeWindowBreached(string)
 	UpdateMetricUpgradeControlPlaneTimeout(string, string)
 	ResetMetricUpgradeControlPlaneTimeout(string, string)
@@ -148,6 +150,11 @@ var (
 		Name:      "upgrade_window_breached",
 		Help:      "Failed to commence upgrade during the upgrade window",
 	}, []string{nameLabel})
+	metricUpgradeConfigSynced = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: metricsTag,
+		Name:      "upgradeconfig_synced",
+		Help:      "UpgradeConfig has not been synced in time",
+	}, []string{nameLabel})
 	metricUpgradeControlPlaneTimeout = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: metricsTag,
 		Name:      "controlplane_timeout",
@@ -178,6 +185,7 @@ var (
 		metricNodeUpgradeEndTime,
 		metricClusterVerificationFailed,
 		metricUpgradeWindowBreached,
+		metricUpgradeConfigSynced,
 		metricUpgradeControlPlaneTimeout,
 		metricUpgradeWorkerTimeout,
 		metricNodeDrainFailed,
@@ -225,6 +233,14 @@ func (c *Counter) UpdateMetricScalingSucceeded(upgradeConfigName string) {
 	metricScalingFailed.With(prometheus.Labels{
 		nameLabel: upgradeConfigName}).Set(
 		float64(0))
+}
+
+func (c *Counter) UpdateMetricUpgradeConfigSynced(name string) {
+	metricUpgradeConfigSynced.With(prometheus.Labels{nameLabel: name}).Set(float64(1))
+}
+
+func (c *Counter) ResetMetricUpgradeConfigSynced(name string) {
+	metricUpgradeConfigSynced.With(prometheus.Labels{nameLabel: name}).Set(float64(0))
 }
 
 func (c *Counter) UpdateMetricUpgradeStartTime(time time.Time, upgradeConfigName string, version string) {

--- a/pkg/metrics/mocks/metrics.go
+++ b/pkg/metrics/mocks/metrics.go
@@ -5,37 +5,36 @@
 package mocks
 
 import (
-	reflect "reflect"
-	time "time"
-
 	gomock "github.com/golang/mock/gomock"
 	metrics "github.com/openshift/managed-upgrade-operator/pkg/metrics"
+	reflect "reflect"
+	time "time"
 )
 
-// MockMetrics is a mock of Metrics interface.
+// MockMetrics is a mock of Metrics interface
 type MockMetrics struct {
 	ctrl     *gomock.Controller
 	recorder *MockMetricsMockRecorder
 }
 
-// MockMetricsMockRecorder is the mock recorder for MockMetrics.
+// MockMetricsMockRecorder is the mock recorder for MockMetrics
 type MockMetricsMockRecorder struct {
 	mock *MockMetrics
 }
 
-// NewMockMetrics creates a new mock instance.
+// NewMockMetrics creates a new mock instance
 func NewMockMetrics(ctrl *gomock.Controller) *MockMetrics {
 	mock := &MockMetrics{ctrl: ctrl}
 	mock.recorder = &MockMetricsMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockMetrics) EXPECT() *MockMetricsMockRecorder {
 	return m.recorder
 }
 
-// IsAlertFiring mocks base method.
+// IsAlertFiring mocks base method
 func (m *MockMetrics) IsAlertFiring(arg0 string, arg1, arg2 []string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsAlertFiring", arg0, arg1, arg2)
@@ -44,13 +43,13 @@ func (m *MockMetrics) IsAlertFiring(arg0 string, arg1, arg2 []string) (bool, err
 	return ret0, ret1
 }
 
-// IsAlertFiring indicates an expected call of IsAlertFiring.
+// IsAlertFiring indicates an expected call of IsAlertFiring
 func (mr *MockMetricsMockRecorder) IsAlertFiring(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAlertFiring", reflect.TypeOf((*MockMetrics)(nil).IsAlertFiring), arg0, arg1, arg2)
 }
 
-// IsClusterVersionAtVersion mocks base method.
+// IsClusterVersionAtVersion mocks base method
 func (m *MockMetrics) IsClusterVersionAtVersion(arg0 string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsClusterVersionAtVersion", arg0)
@@ -59,13 +58,13 @@ func (m *MockMetrics) IsClusterVersionAtVersion(arg0 string) (bool, error) {
 	return ret0, ret1
 }
 
-// IsClusterVersionAtVersion indicates an expected call of IsClusterVersionAtVersion.
+// IsClusterVersionAtVersion indicates an expected call of IsClusterVersionAtVersion
 func (mr *MockMetricsMockRecorder) IsClusterVersionAtVersion(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsClusterVersionAtVersion", reflect.TypeOf((*MockMetrics)(nil).IsClusterVersionAtVersion), arg0)
 }
 
-// IsMetricControlPlaneEndTimeSet mocks base method.
+// IsMetricControlPlaneEndTimeSet mocks base method
 func (m *MockMetrics) IsMetricControlPlaneEndTimeSet(arg0, arg1 string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsMetricControlPlaneEndTimeSet", arg0, arg1)
@@ -74,13 +73,13 @@ func (m *MockMetrics) IsMetricControlPlaneEndTimeSet(arg0, arg1 string) (bool, e
 	return ret0, ret1
 }
 
-// IsMetricControlPlaneEndTimeSet indicates an expected call of IsMetricControlPlaneEndTimeSet.
+// IsMetricControlPlaneEndTimeSet indicates an expected call of IsMetricControlPlaneEndTimeSet
 func (mr *MockMetricsMockRecorder) IsMetricControlPlaneEndTimeSet(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsMetricControlPlaneEndTimeSet", reflect.TypeOf((*MockMetrics)(nil).IsMetricControlPlaneEndTimeSet), arg0, arg1)
 }
 
-// IsMetricNodeUpgradeEndTimeSet mocks base method.
+// IsMetricNodeUpgradeEndTimeSet mocks base method
 func (m *MockMetrics) IsMetricNodeUpgradeEndTimeSet(arg0, arg1 string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsMetricNodeUpgradeEndTimeSet", arg0, arg1)
@@ -89,13 +88,13 @@ func (m *MockMetrics) IsMetricNodeUpgradeEndTimeSet(arg0, arg1 string) (bool, er
 	return ret0, ret1
 }
 
-// IsMetricNodeUpgradeEndTimeSet indicates an expected call of IsMetricNodeUpgradeEndTimeSet.
+// IsMetricNodeUpgradeEndTimeSet indicates an expected call of IsMetricNodeUpgradeEndTimeSet
 func (mr *MockMetricsMockRecorder) IsMetricNodeUpgradeEndTimeSet(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsMetricNodeUpgradeEndTimeSet", reflect.TypeOf((*MockMetrics)(nil).IsMetricNodeUpgradeEndTimeSet), arg0, arg1)
 }
 
-// IsMetricNotificationEventSentSet mocks base method.
+// IsMetricNotificationEventSentSet mocks base method
 func (m *MockMetrics) IsMetricNotificationEventSentSet(arg0, arg1, arg2 string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsMetricNotificationEventSentSet", arg0, arg1, arg2)
@@ -104,13 +103,13 @@ func (m *MockMetrics) IsMetricNotificationEventSentSet(arg0, arg1, arg2 string) 
 	return ret0, ret1
 }
 
-// IsMetricNotificationEventSentSet indicates an expected call of IsMetricNotificationEventSentSet.
+// IsMetricNotificationEventSentSet indicates an expected call of IsMetricNotificationEventSentSet
 func (mr *MockMetricsMockRecorder) IsMetricNotificationEventSentSet(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsMetricNotificationEventSentSet", reflect.TypeOf((*MockMetrics)(nil).IsMetricNotificationEventSentSet), arg0, arg1, arg2)
 }
 
-// IsMetricUpgradeStartTimeSet mocks base method.
+// IsMetricUpgradeStartTimeSet mocks base method
 func (m *MockMetrics) IsMetricUpgradeStartTimeSet(arg0, arg1 string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsMetricUpgradeStartTimeSet", arg0, arg1)
@@ -119,13 +118,13 @@ func (m *MockMetrics) IsMetricUpgradeStartTimeSet(arg0, arg1 string) (bool, erro
 	return ret0, ret1
 }
 
-// IsMetricUpgradeStartTimeSet indicates an expected call of IsMetricUpgradeStartTimeSet.
+// IsMetricUpgradeStartTimeSet indicates an expected call of IsMetricUpgradeStartTimeSet
 func (mr *MockMetricsMockRecorder) IsMetricUpgradeStartTimeSet(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsMetricUpgradeStartTimeSet", reflect.TypeOf((*MockMetrics)(nil).IsMetricUpgradeStartTimeSet), arg0, arg1)
 }
 
-// Query mocks base method.
+// Query mocks base method
 func (m *MockMetrics) Query(arg0 string) (*metrics.AlertResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Query", arg0)
@@ -134,271 +133,295 @@ func (m *MockMetrics) Query(arg0 string) (*metrics.AlertResponse, error) {
 	return ret0, ret1
 }
 
-// Query indicates an expected call of Query.
+// Query indicates an expected call of Query
 func (mr *MockMetricsMockRecorder) Query(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Query", reflect.TypeOf((*MockMetrics)(nil).Query), arg0)
 }
 
-// ResetAllMetricNodeDrainFailed mocks base method.
+// ResetAllMetricNodeDrainFailed mocks base method
 func (m *MockMetrics) ResetAllMetricNodeDrainFailed() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ResetAllMetricNodeDrainFailed")
 }
 
-// ResetAllMetricNodeDrainFailed indicates an expected call of ResetAllMetricNodeDrainFailed.
+// ResetAllMetricNodeDrainFailed indicates an expected call of ResetAllMetricNodeDrainFailed
 func (mr *MockMetricsMockRecorder) ResetAllMetricNodeDrainFailed() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetAllMetricNodeDrainFailed", reflect.TypeOf((*MockMetrics)(nil).ResetAllMetricNodeDrainFailed))
 }
 
-// ResetMetricNodeDrainFailed mocks base method.
+// ResetMetricNodeDrainFailed mocks base method
 func (m *MockMetrics) ResetMetricNodeDrainFailed(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ResetMetricNodeDrainFailed", arg0)
 }
 
-// ResetMetricNodeDrainFailed indicates an expected call of ResetMetricNodeDrainFailed.
+// ResetMetricNodeDrainFailed indicates an expected call of ResetMetricNodeDrainFailed
 func (mr *MockMetricsMockRecorder) ResetMetricNodeDrainFailed(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetMetricNodeDrainFailed", reflect.TypeOf((*MockMetrics)(nil).ResetMetricNodeDrainFailed), arg0)
 }
 
-// ResetMetricUpgradeControlPlaneTimeout mocks base method.
+// ResetMetricUpgradeConfigSynced mocks base method
+func (m *MockMetrics) ResetMetricUpgradeConfigSynced(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ResetMetricUpgradeConfigSynced", arg0)
+}
+
+// ResetMetricUpgradeConfigSynced indicates an expected call of ResetMetricUpgradeConfigSynced
+func (mr *MockMetricsMockRecorder) ResetMetricUpgradeConfigSynced(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetMetricUpgradeConfigSynced", reflect.TypeOf((*MockMetrics)(nil).ResetMetricUpgradeConfigSynced), arg0)
+}
+
+// ResetMetricUpgradeControlPlaneTimeout mocks base method
 func (m *MockMetrics) ResetMetricUpgradeControlPlaneTimeout(arg0, arg1 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ResetMetricUpgradeControlPlaneTimeout", arg0, arg1)
 }
 
-// ResetMetricUpgradeControlPlaneTimeout indicates an expected call of ResetMetricUpgradeControlPlaneTimeout.
+// ResetMetricUpgradeControlPlaneTimeout indicates an expected call of ResetMetricUpgradeControlPlaneTimeout
 func (mr *MockMetricsMockRecorder) ResetMetricUpgradeControlPlaneTimeout(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetMetricUpgradeControlPlaneTimeout", reflect.TypeOf((*MockMetrics)(nil).ResetMetricUpgradeControlPlaneTimeout), arg0, arg1)
 }
 
-// ResetMetricUpgradeWorkerTimeout mocks base method.
+// ResetMetricUpgradeWorkerTimeout mocks base method
 func (m *MockMetrics) ResetMetricUpgradeWorkerTimeout(arg0, arg1 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ResetMetricUpgradeWorkerTimeout", arg0, arg1)
 }
 
-// ResetMetricUpgradeWorkerTimeout indicates an expected call of ResetMetricUpgradeWorkerTimeout.
+// ResetMetricUpgradeWorkerTimeout indicates an expected call of ResetMetricUpgradeWorkerTimeout
 func (mr *MockMetricsMockRecorder) ResetMetricUpgradeWorkerTimeout(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetMetricUpgradeWorkerTimeout", reflect.TypeOf((*MockMetrics)(nil).ResetMetricUpgradeWorkerTimeout), arg0, arg1)
 }
 
-// ResetMetrics mocks base method.
+// ResetMetrics mocks base method
 func (m *MockMetrics) ResetMetrics() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ResetMetrics")
 }
 
-// ResetMetrics indicates an expected call of ResetMetrics.
+// ResetMetrics indicates an expected call of ResetMetrics
 func (mr *MockMetricsMockRecorder) ResetMetrics() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetMetrics", reflect.TypeOf((*MockMetrics)(nil).ResetMetrics))
 }
 
-// UpdateMetricClusterCheckFailed mocks base method.
+// UpdateMetricClusterCheckFailed mocks base method
 func (m *MockMetrics) UpdateMetricClusterCheckFailed(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateMetricClusterCheckFailed", arg0)
 }
 
-// UpdateMetricClusterCheckFailed indicates an expected call of UpdateMetricClusterCheckFailed.
+// UpdateMetricClusterCheckFailed indicates an expected call of UpdateMetricClusterCheckFailed
 func (mr *MockMetricsMockRecorder) UpdateMetricClusterCheckFailed(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricClusterCheckFailed", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricClusterCheckFailed), arg0)
 }
 
-// UpdateMetricClusterCheckSucceeded mocks base method.
+// UpdateMetricClusterCheckSucceeded mocks base method
 func (m *MockMetrics) UpdateMetricClusterCheckSucceeded(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateMetricClusterCheckSucceeded", arg0)
 }
 
-// UpdateMetricClusterCheckSucceeded indicates an expected call of UpdateMetricClusterCheckSucceeded.
+// UpdateMetricClusterCheckSucceeded indicates an expected call of UpdateMetricClusterCheckSucceeded
 func (mr *MockMetricsMockRecorder) UpdateMetricClusterCheckSucceeded(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricClusterCheckSucceeded", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricClusterCheckSucceeded), arg0)
 }
 
-// UpdateMetricClusterVerificationFailed mocks base method.
+// UpdateMetricClusterVerificationFailed mocks base method
 func (m *MockMetrics) UpdateMetricClusterVerificationFailed(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateMetricClusterVerificationFailed", arg0)
 }
 
-// UpdateMetricClusterVerificationFailed indicates an expected call of UpdateMetricClusterVerificationFailed.
+// UpdateMetricClusterVerificationFailed indicates an expected call of UpdateMetricClusterVerificationFailed
 func (mr *MockMetricsMockRecorder) UpdateMetricClusterVerificationFailed(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricClusterVerificationFailed", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricClusterVerificationFailed), arg0)
 }
 
-// UpdateMetricClusterVerificationSucceeded mocks base method.
+// UpdateMetricClusterVerificationSucceeded mocks base method
 func (m *MockMetrics) UpdateMetricClusterVerificationSucceeded(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateMetricClusterVerificationSucceeded", arg0)
 }
 
-// UpdateMetricClusterVerificationSucceeded indicates an expected call of UpdateMetricClusterVerificationSucceeded.
+// UpdateMetricClusterVerificationSucceeded indicates an expected call of UpdateMetricClusterVerificationSucceeded
 func (mr *MockMetricsMockRecorder) UpdateMetricClusterVerificationSucceeded(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricClusterVerificationSucceeded", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricClusterVerificationSucceeded), arg0)
 }
 
-// UpdateMetricControlPlaneEndTime mocks base method.
+// UpdateMetricControlPlaneEndTime mocks base method
 func (m *MockMetrics) UpdateMetricControlPlaneEndTime(arg0 time.Time, arg1, arg2 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateMetricControlPlaneEndTime", arg0, arg1, arg2)
 }
 
-// UpdateMetricControlPlaneEndTime indicates an expected call of UpdateMetricControlPlaneEndTime.
+// UpdateMetricControlPlaneEndTime indicates an expected call of UpdateMetricControlPlaneEndTime
 func (mr *MockMetricsMockRecorder) UpdateMetricControlPlaneEndTime(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricControlPlaneEndTime", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricControlPlaneEndTime), arg0, arg1, arg2)
 }
 
-// UpdateMetricNodeDrainFailed mocks base method.
+// UpdateMetricNodeDrainFailed mocks base method
 func (m *MockMetrics) UpdateMetricNodeDrainFailed(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateMetricNodeDrainFailed", arg0)
 }
 
-// UpdateMetricNodeDrainFailed indicates an expected call of UpdateMetricNodeDrainFailed.
+// UpdateMetricNodeDrainFailed indicates an expected call of UpdateMetricNodeDrainFailed
 func (mr *MockMetricsMockRecorder) UpdateMetricNodeDrainFailed(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricNodeDrainFailed", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricNodeDrainFailed), arg0)
 }
 
-// UpdateMetricNodeUpgradeEndTime mocks base method.
+// UpdateMetricNodeUpgradeEndTime mocks base method
 func (m *MockMetrics) UpdateMetricNodeUpgradeEndTime(arg0 time.Time, arg1, arg2 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateMetricNodeUpgradeEndTime", arg0, arg1, arg2)
 }
 
-// UpdateMetricNodeUpgradeEndTime indicates an expected call of UpdateMetricNodeUpgradeEndTime.
+// UpdateMetricNodeUpgradeEndTime indicates an expected call of UpdateMetricNodeUpgradeEndTime
 func (mr *MockMetricsMockRecorder) UpdateMetricNodeUpgradeEndTime(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricNodeUpgradeEndTime", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricNodeUpgradeEndTime), arg0, arg1, arg2)
 }
 
-// UpdateMetricNotificationEventSent mocks base method.
+// UpdateMetricNotificationEventSent mocks base method
 func (m *MockMetrics) UpdateMetricNotificationEventSent(arg0, arg1, arg2 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateMetricNotificationEventSent", arg0, arg1, arg2)
 }
 
-// UpdateMetricNotificationEventSent indicates an expected call of UpdateMetricNotificationEventSent.
+// UpdateMetricNotificationEventSent indicates an expected call of UpdateMetricNotificationEventSent
 func (mr *MockMetricsMockRecorder) UpdateMetricNotificationEventSent(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricNotificationEventSent", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricNotificationEventSent), arg0, arg1, arg2)
 }
 
-// UpdateMetricScalingFailed mocks base method.
+// UpdateMetricScalingFailed mocks base method
 func (m *MockMetrics) UpdateMetricScalingFailed(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateMetricScalingFailed", arg0)
 }
 
-// UpdateMetricScalingFailed indicates an expected call of UpdateMetricScalingFailed.
+// UpdateMetricScalingFailed indicates an expected call of UpdateMetricScalingFailed
 func (mr *MockMetricsMockRecorder) UpdateMetricScalingFailed(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricScalingFailed", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricScalingFailed), arg0)
 }
 
-// UpdateMetricScalingSucceeded mocks base method.
+// UpdateMetricScalingSucceeded mocks base method
 func (m *MockMetrics) UpdateMetricScalingSucceeded(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateMetricScalingSucceeded", arg0)
 }
 
-// UpdateMetricScalingSucceeded indicates an expected call of UpdateMetricScalingSucceeded.
+// UpdateMetricScalingSucceeded indicates an expected call of UpdateMetricScalingSucceeded
 func (mr *MockMetricsMockRecorder) UpdateMetricScalingSucceeded(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricScalingSucceeded", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricScalingSucceeded), arg0)
 }
 
-// UpdateMetricUpgradeControlPlaneTimeout mocks base method.
+// UpdateMetricUpgradeConfigSynced mocks base method
+func (m *MockMetrics) UpdateMetricUpgradeConfigSynced(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateMetricUpgradeConfigSynced", arg0)
+}
+
+// UpdateMetricUpgradeConfigSynced indicates an expected call of UpdateMetricUpgradeConfigSynced
+func (mr *MockMetricsMockRecorder) UpdateMetricUpgradeConfigSynced(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricUpgradeConfigSynced", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricUpgradeConfigSynced), arg0)
+}
+
+// UpdateMetricUpgradeControlPlaneTimeout mocks base method
 func (m *MockMetrics) UpdateMetricUpgradeControlPlaneTimeout(arg0, arg1 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateMetricUpgradeControlPlaneTimeout", arg0, arg1)
 }
 
-// UpdateMetricUpgradeControlPlaneTimeout indicates an expected call of UpdateMetricUpgradeControlPlaneTimeout.
+// UpdateMetricUpgradeControlPlaneTimeout indicates an expected call of UpdateMetricUpgradeControlPlaneTimeout
 func (mr *MockMetricsMockRecorder) UpdateMetricUpgradeControlPlaneTimeout(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricUpgradeControlPlaneTimeout", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricUpgradeControlPlaneTimeout), arg0, arg1)
 }
 
-// UpdateMetricUpgradeStartTime mocks base method.
+// UpdateMetricUpgradeStartTime mocks base method
 func (m *MockMetrics) UpdateMetricUpgradeStartTime(arg0 time.Time, arg1, arg2 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateMetricUpgradeStartTime", arg0, arg1, arg2)
 }
 
-// UpdateMetricUpgradeStartTime indicates an expected call of UpdateMetricUpgradeStartTime.
+// UpdateMetricUpgradeStartTime indicates an expected call of UpdateMetricUpgradeStartTime
 func (mr *MockMetricsMockRecorder) UpdateMetricUpgradeStartTime(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricUpgradeStartTime", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricUpgradeStartTime), arg0, arg1, arg2)
 }
 
-// UpdateMetricUpgradeWindowBreached mocks base method.
+// UpdateMetricUpgradeWindowBreached mocks base method
 func (m *MockMetrics) UpdateMetricUpgradeWindowBreached(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateMetricUpgradeWindowBreached", arg0)
 }
 
-// UpdateMetricUpgradeWindowBreached indicates an expected call of UpdateMetricUpgradeWindowBreached.
+// UpdateMetricUpgradeWindowBreached indicates an expected call of UpdateMetricUpgradeWindowBreached
 func (mr *MockMetricsMockRecorder) UpdateMetricUpgradeWindowBreached(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricUpgradeWindowBreached", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricUpgradeWindowBreached), arg0)
 }
 
-// UpdateMetricUpgradeWindowNotBreached mocks base method.
+// UpdateMetricUpgradeWindowNotBreached mocks base method
 func (m *MockMetrics) UpdateMetricUpgradeWindowNotBreached(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateMetricUpgradeWindowNotBreached", arg0)
 }
 
-// UpdateMetricUpgradeWindowNotBreached indicates an expected call of UpdateMetricUpgradeWindowNotBreached.
+// UpdateMetricUpgradeWindowNotBreached indicates an expected call of UpdateMetricUpgradeWindowNotBreached
 func (mr *MockMetricsMockRecorder) UpdateMetricUpgradeWindowNotBreached(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricUpgradeWindowNotBreached", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricUpgradeWindowNotBreached), arg0)
 }
 
-// UpdateMetricUpgradeWorkerTimeout mocks base method.
+// UpdateMetricUpgradeWorkerTimeout mocks base method
 func (m *MockMetrics) UpdateMetricUpgradeWorkerTimeout(arg0, arg1 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateMetricUpgradeWorkerTimeout", arg0, arg1)
 }
 
-// UpdateMetricUpgradeWorkerTimeout indicates an expected call of UpdateMetricUpgradeWorkerTimeout.
+// UpdateMetricUpgradeWorkerTimeout indicates an expected call of UpdateMetricUpgradeWorkerTimeout
 func (mr *MockMetricsMockRecorder) UpdateMetricUpgradeWorkerTimeout(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricUpgradeWorkerTimeout", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricUpgradeWorkerTimeout), arg0, arg1)
 }
 
-// UpdateMetricValidationFailed mocks base method.
+// UpdateMetricValidationFailed mocks base method
 func (m *MockMetrics) UpdateMetricValidationFailed(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateMetricValidationFailed", arg0)
 }
 
-// UpdateMetricValidationFailed indicates an expected call of UpdateMetricValidationFailed.
+// UpdateMetricValidationFailed indicates an expected call of UpdateMetricValidationFailed
 func (mr *MockMetricsMockRecorder) UpdateMetricValidationFailed(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricValidationFailed", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricValidationFailed), arg0)
 }
 
-// UpdateMetricValidationSucceeded mocks base method.
+// UpdateMetricValidationSucceeded mocks base method
 func (m *MockMetrics) UpdateMetricValidationSucceeded(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateMetricValidationSucceeded", arg0)
 }
 
-// UpdateMetricValidationSucceeded indicates an expected call of UpdateMetricValidationSucceeded.
+// UpdateMetricValidationSucceeded indicates an expected call of UpdateMetricValidationSucceeded
 func (mr *MockMetricsMockRecorder) UpdateMetricValidationSucceeded(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricValidationSucceeded", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricValidationSucceeded), arg0)

--- a/pkg/metrics/mocks/metrics_builder.go
+++ b/pkg/metrics/mocks/metrics_builder.go
@@ -5,37 +5,36 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	metrics "github.com/openshift/managed-upgrade-operator/pkg/metrics"
+	reflect "reflect"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// MockMetricsBuilder is a mock of MetricsBuilder interface.
+// MockMetricsBuilder is a mock of MetricsBuilder interface
 type MockMetricsBuilder struct {
 	ctrl     *gomock.Controller
 	recorder *MockMetricsBuilderMockRecorder
 }
 
-// MockMetricsBuilderMockRecorder is the mock recorder for MockMetricsBuilder.
+// MockMetricsBuilderMockRecorder is the mock recorder for MockMetricsBuilder
 type MockMetricsBuilderMockRecorder struct {
 	mock *MockMetricsBuilder
 }
 
-// NewMockMetricsBuilder creates a new mock instance.
+// NewMockMetricsBuilder creates a new mock instance
 func NewMockMetricsBuilder(ctrl *gomock.Controller) *MockMetricsBuilder {
 	mock := &MockMetricsBuilder{ctrl: ctrl}
 	mock.recorder = &MockMetricsBuilderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockMetricsBuilder) EXPECT() *MockMetricsBuilderMockRecorder {
 	return m.recorder
 }
 
-// NewClient mocks base method.
+// NewClient mocks base method
 func (m *MockMetricsBuilder) NewClient(arg0 client.Client) (metrics.Metrics, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewClient", arg0)
@@ -44,7 +43,7 @@ func (m *MockMetricsBuilder) NewClient(arg0 client.Client) (metrics.Metrics, err
 	return ret0, ret1
 }
 
-// NewClient indicates an expected call of NewClient.
+// NewClient indicates an expected call of NewClient
 func (mr *MockMetricsBuilderMockRecorder) NewClient(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewClient", reflect.TypeOf((*MockMetricsBuilder)(nil).NewClient), arg0)


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
We need to know if a cluster is possibly missing upgrade schedules
### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://issues.redhat.com/browse/OSD-5414
https://issues.redhat.com/browse/OSD-5413

### Special notes for your reviewer:
This would be combined with a new prom rule to alert after 30 mins of failed syncing
```.yaml
- alert: UpgradeConfigSyncTimeOutSRE
  expr: upgradeoperator_upgradeconfig_synced > 0
  for: 30m
  labels:
    severity: critical
    namespace: openshift-monitoring
  annotations:
    summary: "UpgradeConfig has not been synced in Time"
    description: "This clusters UpgradeConfig has not been synced in time and may be out of date"
```

