### PR TITLE
Log the error when the OCM cluster ID fetch fails

### DIFF
--- a/pkg/notifier/ocmnotifier.go
+++ b/pkg/notifier/ocmnotifier.go
@@ -291,7 +291,7 @@ func getClusterFromOCMApi(kc client.Client, client *http.Client, ocmApi *url.URL
 func (s *ocmNotifier) getInternalClusterId() (*string, error) {
 	cluster, err := getClusterFromOCMApi(s.client, s.httpClient, s.ocmBaseUrl)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to retrieve internal ocm cluster ID")
+		return nil, fmt.Errorf("Failed to retrieve internal ocm cluster ID: %v", err)
 	}
 	return &cluster.Id, nil
 }


### PR DESCRIPTION
### What type of PR is this?

Bug

### What this PR does / why we need it?

I want to see what error occurs when the OCM Cluster ID fetch fails.

### Which Jira/Github issue(s) this PR fixes?

na
### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

