### PR TITLE
Return next occuring of multiple upgrade policies

### DIFF
--- a/pkg/ocmprovider/ocmprovider.go
+++ b/pkg/ocmprovider/ocmprovider.go
@@ -33,12 +33,11 @@ var log = logf.Log.WithName("ocm-config-getter")
 // Errors
 var (
 	ErrProviderUnavailable = fmt.Errorf("OCM Provider unavailable")
-	ErrClusterIdNotFound = fmt.Errorf("cluster ID can't be found")
+	ErrClusterIdNotFound   = fmt.Errorf("cluster ID can't be found")
 	ErrMissingChannelGroup = fmt.Errorf("channel group not returned or empty")
-	ErrRetrievingPolicies = fmt.Errorf("could not retrieve provider upgrade policies")
-	ErrProcessingPolicies = fmt.Errorf("could not process provider upgrade policies")
+	ErrRetrievingPolicies  = fmt.Errorf("could not retrieve provider upgrade policies")
+	ErrProcessingPolicies  = fmt.Errorf("could not process provider upgrade policies")
 )
-
 
 func New(client client.Client, ocmBaseUrl *url.URL) (*ocmProvider, error) {
 
@@ -150,21 +149,33 @@ func (s *ocmProvider) Get() ([]upgradev1alpha1.UpgradeConfigSpec, error) {
 		return nil, ErrMissingChannelGroup
 	}
 
-	// Retrieve the cluster's upgrade policy from Cluster Services
+	// Retrieve the cluster's available upgrade policies from Cluster Services
 	upgradePolicies, err := getClusterUpgradePolicies(cluster, s.httpClient, s.ocmBaseUrl)
 	if err != nil {
 		log.Error(err, "error retrieving upgrade policies")
 		return nil, ErrRetrievingPolicies
 	}
 
-	// Apply the Upgrade Policies to the cluster
-	specs, err := buildUpgradeConfigSpecs(upgradePolicies, cluster, s.client)
-	if err != nil {
-		log.Error(err, "cannot build UpgradeConfigs from policy")
-		return nil, ErrProcessingPolicies
-	}
+	// Get the next occurring policy from the available policies
+	if len(upgradePolicies.Items) > 0 {
+		nextOccurringUpgradePolicy, err := getNextOccurringUpgradePolicy(upgradePolicies)
+		if err != nil {
+			log.Error(err, "error getting next upgrade policy from upgrade policies")
+			return nil, err
+		}
+		log.Info(fmt.Sprintf("Detected upgrade policy %s as next occurring.", nextOccurringUpgradePolicy.Id))
 
-	return specs, nil
+		// Apply the next occurring Upgrade policy to the clusters UpgradeConfig CR.
+		specs, err := buildUpgradeConfigSpecs(nextOccurringUpgradePolicy, cluster, s.client)
+		if err != nil {
+			log.Error(err, "cannot build UpgradeConfigs from policy")
+			return nil, ErrProcessingPolicies
+		}
+
+		return specs, nil
+	}
+	log.Info("No upgrade policies available")
+	return nil, nil
 }
 
 // Queries and returns the Upgrade Policy from Cluster Services
@@ -194,40 +205,63 @@ func getClusterUpgradePolicies(cluster *clusterInfo, client *http.Client, ocmBas
 		defer response.Body.Close()
 	}
 
-	var upgradeResponse upgradePolicyList
+	var upgradeResponses upgradePolicyList
 	decoder := json.NewDecoder(response.Body)
 	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&upgradeResponse)
+	err = decoder.Decode(&upgradeResponses)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode OCM upgrade policy response, operation id '%v'", operationId)
 	}
 
-	return &upgradeResponse, nil
+	return &upgradeResponses, nil
+}
+
+// getNextOccurringUpgradePolicy returns the next occurring upgradepolicy from a list of upgrade
+// policies, regardless of the schedule_type.
+func getNextOccurringUpgradePolicy(uPs *upgradePolicyList) (*upgradePolicy, error) {
+	var nextOccurringUpgradePolicy upgradePolicy
+
+	nextOccurringUpgradePolicy = uPs.Items[0]
+
+	for _, uP := range uPs.Items {
+		currentNext, err := time.Parse(time.RFC3339, nextOccurringUpgradePolicy.NextRun)
+		if err != nil {
+			return &nextOccurringUpgradePolicy, err
+		}
+		evalNext, err := time.Parse(time.RFC3339, uP.NextRun)
+		if err != nil {
+			return &nextOccurringUpgradePolicy, err
+		}
+
+		if evalNext.Before(currentNext) {
+			nextOccurringUpgradePolicy = uP
+		}
+	}
+
+	return &nextOccurringUpgradePolicy, nil
 }
 
 // Applies the supplied Upgrade Policy to the cluster in the form of an UpgradeConfig
 // Returns an indication of if the policy being applied differs to the existing UpgradeConfig,
 // and indication of error if one occurs.
-func buildUpgradeConfigSpecs(upgradePolicies *upgradePolicyList, cluster *clusterInfo, c client.Client) ([]upgradev1alpha1.UpgradeConfigSpec, error) {
+func buildUpgradeConfigSpecs(upgradePolicy *upgradePolicy, cluster *clusterInfo, c client.Client) ([]upgradev1alpha1.UpgradeConfigSpec, error) {
 
 	upgradeConfigSpecs := make([]upgradev1alpha1.UpgradeConfigSpec, 0)
 
-	for _, upgradePolicy := range upgradePolicies.Items {
-		upgradeChannel, err := inferUpgradeChannelFromChannelGroup(cluster.Version.ChannelGroup, upgradePolicy.Version)
-		if err != nil {
-			return nil, fmt.Errorf("unable to determine channel from channel group '%v' and version '%v' for policy ID '%v'", cluster.Version.ChannelGroup, upgradePolicy.Version, upgradePolicy.Id)
-		}
-		upgradeConfigSpec := upgradev1alpha1.UpgradeConfigSpec{
-			Desired: upgradev1alpha1.Update{
-				Version: upgradePolicy.Version,
-				Channel: *upgradeChannel,
-			},
-			UpgradeAt:            upgradePolicy.NextRun,
-			PDBForceDrainTimeout: int32(upgradePolicy.NodeDrainGracePeriod.Value),
-			Type:                 upgradev1alpha1.UpgradeType(upgradePolicy.UpgradeType),
-		}
-		upgradeConfigSpecs = append(upgradeConfigSpecs, upgradeConfigSpec)
+	upgradeChannel, err := inferUpgradeChannelFromChannelGroup(cluster.Version.ChannelGroup, upgradePolicy.Version)
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine channel from channel group '%v' and version '%v' for policy ID '%v'", cluster.Version.ChannelGroup, upgradePolicy.Version, upgradePolicy.Id)
 	}
+	upgradeConfigSpec := upgradev1alpha1.UpgradeConfigSpec{
+		Desired: upgradev1alpha1.Update{
+			Version: upgradePolicy.Version,
+			Channel: *upgradeChannel,
+		},
+		UpgradeAt:            upgradePolicy.NextRun,
+		PDBForceDrainTimeout: int32(upgradePolicy.NodeDrainGracePeriod.Value),
+		Type:                 upgradev1alpha1.UpgradeType(upgradePolicy.UpgradeType),
+	}
+	upgradeConfigSpecs = append(upgradeConfigSpecs, upgradeConfigSpec)
 
 	return upgradeConfigSpecs, nil
 }

--- a/pkg/upgradeconfigmanager/upgradeconfigmanager_test.go
+++ b/pkg/upgradeconfigmanager/upgradeconfigmanager_test.go
@@ -219,7 +219,7 @@ var _ = Describe("UpgradeConfigManager", func() {
 			Expect(err).To(Equal(ErrRetrievingUpgradeConfigs))
 		})
 
-		It("should not proceed if an upgrade is occuring", func() {
+		It("should not proceed if an upgrade is occurring", func() {
 			upgradeConfig.Status.History = []upgradev1alpha1.UpgradeHistory{
 				{
 					Version: TEST_UPGRADE_VERSION,


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
This enables the operator to iterate through all available upgrade_policies and process the next occuring. 

### Which Jira/Github issue(s) this PR fixes?
[OSD-5564](https://issues.redhat.com/browse/OSD-5564)

### Further notes
This is vulnerable https://github.com/openshift/managed-upgrade-operator/blob/master/pkg/notifier/ocmnotifier.go#L107-L115. Its possible to create an upgrade policy of `schedule_type` = "automatic" or "manual" that have both the same `version` and `next_run`. Will need protection from this upstream. 

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster (validates correct policy is used and cleared with notifications)
- [x] Ran `make generate` command locally to validate code changes

