### PR TITLE
Reconcile at upgrade start time

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -15,7 +15,6 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -27,6 +26,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	machineapi "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	machineconfigapi "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	muocfg "github.com/openshift/managed-upgrade-operator/config"
 	"github.com/openshift/managed-upgrade-operator/pkg/apis"
 	"github.com/openshift/managed-upgrade-operator/pkg/controller"
 	upgrademetrics "github.com/openshift/managed-upgrade-operator/pkg/metrics"
@@ -102,7 +102,7 @@ func main() {
 	}
 
 	// This set the sync period to 5m
-	syncPeriod := time.Duration(5 * time.Minute)
+	syncPeriod := time.Duration(muocfg.SyncPeriodDefault)
 
 	// Set default manager options
 	options := manager.Options{

--- a/config/config.go
+++ b/config/config.go
@@ -1,5 +1,9 @@
 package config
 
+import "time"
+
 const (
 	OperatorName string = "managed-upgrade-operator"
+	// Default reconcile sync period for each controller
+	SyncPeriodDefault = 5 * time.Minute
 )

--- a/pkg/controller/upgradeconfig/upgradeconfig_controller_test.go
+++ b/pkg/controller/upgradeconfig/upgradeconfig_controller_test.go
@@ -610,9 +610,9 @@ var _ = Describe("UpgradeConfigController", func() {
 						mockConfigManagerBuilder.EXPECT().New(gomock.Any(), gomock.Any()).Return(mockConfigManager),
 						mockConfigManager.EXPECT().Into(gomock.Any()).SetArg(0, cfg),
 						mockScheduler.EXPECT().IsReadyToUpgrade(gomock.Any(), gomock.Any()).Return(scheduler.SchedulerResult{IsReady: false, IsBreached: true}),
-						mockMetricsClient.EXPECT().UpdateMetricUpgradeWindowBreached(upgradeConfig.Name),
 						mockKubeClient.EXPECT().Status().Return(mockUpdater),
 						mockUpdater.EXPECT().Update(gomock.Any(), gomock.Any()),
+						mockMetricsClient.EXPECT().UpdateMetricUpgradeWindowBreached(upgradeConfig.Name),
 					)
 					result, err := reconciler.Reconcile(reconcile.Request{NamespacedName: upgradeConfigName})
 					Expect(err).NotTo(HaveOccurred())

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -19,29 +19,29 @@ func NewScheduler() Scheduler {
 }
 
 type SchedulerResult struct {
-	IsReady    bool
-	IsBreached bool
+	IsReady          bool
+	IsBreached       bool
+	TimeUntilUpgrade time.Duration
 }
 
 func (s *scheduler) IsReadyToUpgrade(upgradeConfig *upgradev1alpha1.UpgradeConfig, timeOut time.Duration) SchedulerResult {
 	upgradeTime, err := time.Parse(time.RFC3339, upgradeConfig.Spec.UpgradeAt)
 	if err != nil {
 		log.Error(err, "failed to parse spec.upgradeAt", upgradeConfig.Spec.UpgradeAt)
-		return SchedulerResult{IsReady: false, IsBreached: false}
+		return SchedulerResult{IsReady: false, IsBreached: false, TimeUntilUpgrade: 0}
 	}
 	now := time.Now()
 	if now.After(upgradeTime) {
 		// Is the current time within the allowable upgrade window
 		if upgradeTime.Add(timeOut).After(now) {
-			return SchedulerResult{IsReady: true, IsBreached: false}
+			return SchedulerResult{IsReady: true, IsBreached: false, TimeUntilUpgrade: 0}
 		}
 
-		return SchedulerResult{IsReady: false, IsBreached: true}
-	} else {
-		// It hasn't reached the upgrade window yet
-		pendingTime := upgradeTime.Sub(now)
-		log.Infof("Upgrade is scheduled in %d hours %d mins", int(pendingTime.Hours()), int(pendingTime.Minutes())-(int(pendingTime.Hours())*60))
+		return SchedulerResult{IsReady: false, IsBreached: true, TimeUntilUpgrade: 0}
 	}
 
-	return SchedulerResult{IsReady: false, IsBreached: false}
+	// It hasn't reached the upgrade window yet
+	pendingTime := upgradeTime.Sub(now)
+	log.Infof("Upgrade is scheduled in %d hours %d mins", int(pendingTime.Hours()), int(pendingTime.Minutes())-(int(pendingTime.Hours())*60))
+	return SchedulerResult{IsReady: false, IsBreached: false, TimeUntilUpgrade: pendingTime}
 }


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
This PR alters the behaviour of the UpgradeConfig controller such that, if it detects an impending upgrade to occur before its next reconcile, it will reconcile at the time of the upgrade rather than wait for the next regular reconcile period.

This results in the operator initiating an upgrade as close to the desired 'upgradeAt' time as can be achieved.

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [X] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

