### PR TITLE
OSD-5714 send delayed notifications

### DIFF
--- a/deploy/managed-upgrade-operator-config.yaml
+++ b/deploy/managed-upgrade-operator-config.yaml
@@ -16,7 +16,8 @@ data:
     scale:
       timeOut: 30
     upgradeWindow:
-      timeOut: 60
+      delayTrigger: 30
+      timeOut: 120
     nodeDrain:
       timeOut: 45
       expectedNodeDrainTime: 8

--- a/pkg/apis/upgrade/v1alpha1/upgradeconfig_types.go
+++ b/pkg/apis/upgrade/v1alpha1/upgradeconfig_types.go
@@ -96,6 +96,7 @@ type UpgradeCondition struct {
 
 const (
 	SendStartedNotification       UpgradeConditionType = "SendStartedNotification"
+	SendDelayedNotification       UpgradeConditionType = "SendDelayedNotification"
 	UpgradeValidated              UpgradeConditionType = "Validation"
 	UpgradePreHealthCheck         UpgradeConditionType = "PreHealthCheck"
 	UpgradeScaleUpExtraNodes      UpgradeConditionType = "ScaleUpExtraNodes"

--- a/pkg/apis/upgrade/v1alpha1/upgradeconfig_types.go
+++ b/pkg/apis/upgrade/v1alpha1/upgradeconfig_types.go
@@ -96,7 +96,7 @@ type UpgradeCondition struct {
 
 const (
 	SendStartedNotification       UpgradeConditionType = "SendStartedNotification"
-	SendDelayedNotification       UpgradeConditionType = "SendDelayedNotification"
+	UpgradeDelayedCheck           UpgradeConditionType = "UpgradeDelayedCheck"
 	UpgradeValidated              UpgradeConditionType = "Validation"
 	UpgradePreHealthCheck         UpgradeConditionType = "PreHealthCheck"
 	UpgradeScaleUpExtraNodes      UpgradeConditionType = "ScaleUpExtraNodes"

--- a/pkg/controller/upgradeconfig/config.go
+++ b/pkg/controller/upgradeconfig/config.go
@@ -15,10 +15,10 @@ type upgradeWindow struct {
 }
 
 func (cfg *config) IsValid() error {
-	if cfg.UpgradeWindow.TimeOut <= 0 {
+	if cfg.UpgradeWindow.TimeOut < 0 {
 		return fmt.Errorf("Config upgrade window time out is invalid")
 	}
-	if cfg.UpgradeWindow.DelayTrigger <= 0 {
+	if cfg.UpgradeWindow.DelayTrigger < 0 {
 		return fmt.Errorf("Config upgrade window delay trigger is invalid")
 	}
 	return nil

--- a/pkg/controller/upgradeconfig/config.go
+++ b/pkg/controller/upgradeconfig/config.go
@@ -10,17 +10,24 @@ type config struct {
 }
 
 type upgradeWindow struct {
-	TimeOut int `yaml:"timeOut" default:"60"`
+	TimeOut int `yaml:"timeOut" default:"120"`
+	DelayTrigger int `yaml:"delayTrigger" default:"30"`
 }
 
 func (cfg *config) IsValid() error {
 	if cfg.UpgradeWindow.TimeOut <= 0 {
 		return fmt.Errorf("Config upgrade window time out is invalid")
 	}
-
+	if cfg.UpgradeWindow.DelayTrigger <= 0 {
+		return fmt.Errorf("Config upgrade window delay trigger is invalid")
+	}
 	return nil
 }
 
 func (cfg *config) GetUpgradeWindowTimeOutDuration() time.Duration {
 	return time.Duration(cfg.UpgradeWindow.TimeOut) * time.Minute
+}
+
+func (cfg *config) GetUpgradeWindowDelayTriggerDuration() time.Duration {
+	return time.Duration(cfg.UpgradeWindow.DelayTrigger) * time.Minute
 }

--- a/pkg/eventmanager/eventmanager.go
+++ b/pkg/eventmanager/eventmanager.go
@@ -93,6 +93,8 @@ func (s *eventManager) Notify(state notifier.NotifyState) error {
 		description = fmt.Sprintf("Cluster upgrade to version %s is currently delayed", uc.Spec.Desired.Version)
 	case notifier.StateCompleted:
 		description = fmt.Sprintf("Cluster has been successfully upgraded to version %s", uc.Spec.Desired.Version)
+	case notifier.StateFailed:
+		description = "Cluster did not pass its pre-upgrade verification checks"
 	default:
 		return fmt.Errorf("state %v not yet implemented", state)
 	}

--- a/pkg/notifier/notifier.go
+++ b/pkg/notifier/notifier.go
@@ -27,6 +27,7 @@ const (
 	StateCompleted NotifyState = "completed"
 	StateDelayed   NotifyState = "delayed"
 	StateFailed    NotifyState = "failed"
+	StateCancelled NotifyState = "cancelled"
 )
 
 type NotifyState string

--- a/pkg/notifier/ocmnotifier.go
+++ b/pkg/notifier/ocmnotifier.go
@@ -79,7 +79,9 @@ func (s *ocmNotifier) NotifyState(value NotifyState, description string) error {
 	}
 
 	// Don't notify if the state is already at the same value
-	if currentState.Value == string(value) {
+	// Only notify if it's a valid transition
+	shouldNotify := validateStateTransition(NotifyState(currentState.Value), value)
+	if !shouldNotify {
 		return nil
 	}
 
@@ -156,6 +158,50 @@ func (s *ocmNotifier) sendNotification(value NotifyState, description string, po
 	}
 
 	return nil
+}
+
+// Validates that a state transition can be made from the supplied from/to states
+func validateStateTransition(from NotifyState, to NotifyState) bool {
+
+	switch from {
+	case StatePending:
+		// Can only go to a started state
+		switch to {
+		case StateStarted:
+			return true
+		default:
+			return false
+		}
+	case StateStarted:
+		// Can go to a delayed, completed or failed state
+		switch to {
+		case StateDelayed:
+			return true
+		case StateCompleted:
+			return true
+		case StateFailed:
+			return true
+		default: return false
+		}
+	case StateDelayed:
+		// can go to completed or failed state
+		switch to {
+		case StateCompleted:
+			return true
+		case StateFailed:
+			return true
+		default:
+			return false
+		}
+	case StateCompleted:
+		// can't go anywhere
+		return false
+	case StateFailed:
+		// can't go anywhere
+		return false
+	default:
+		return false
+	}
 }
 
 // Queries and returns the Upgrade Policy from Cluster Services

--- a/pkg/osd_cluster_upgrader/config.go
+++ b/pkg/osd_cluster_upgrader/config.go
@@ -41,7 +41,12 @@ func (cfg *maintenanceConfig) GetControlPlaneDuration() time.Duration {
 }
 
 type upgradeWindow struct {
+	TimeOut int `yaml:"timeOut" default:"120"`
 	DelayTrigger int `yaml:"delayTrigger" default:"30"`
+}
+
+func (cfg *upgradeWindow) GetUpgradeWindowTimeOutDuration() time.Duration {
+	return time.Duration(cfg.TimeOut) * time.Minute
 }
 
 func (cfg *upgradeWindow) GetUpgradeDelayedTriggerDuration() time.Duration {
@@ -74,8 +79,11 @@ func (cfg *osdUpgradeConfig) IsValid() error {
 	if cfg.NodeDrain.ExpectedNodeDrainTime <= 0 {
 		return fmt.Errorf("Config nodeDrain expectedNodeDrainTime is invalid")
 	}
-	if cfg.UpgradeWindow.DelayTrigger <= 0 {
+	if cfg.UpgradeWindow.DelayTrigger < 0 {
 		return fmt.Errorf("Config upgrade window delay trigger is invalid")
+	}
+	if cfg.UpgradeWindow.TimeOut < 0 {
+		return fmt.Errorf("Config upgrade window time out is invalid")
 	}
 	return nil
 }

--- a/pkg/osd_cluster_upgrader/config.go
+++ b/pkg/osd_cluster_upgrader/config.go
@@ -8,11 +8,12 @@ import (
 )
 
 type osdUpgradeConfig struct {
-	Maintenance  maintenanceConfig `yaml:"maintenance"`
-	Scale        scaleConfig       `yaml:"scale"`
-	NodeDrain    drain.NodeDrain   `yaml:"nodeDrain"`
-	HealthCheck  healthCheck       `yaml:"healthCheck"`
-	Verification verification      `yaml:"verification"`
+	Maintenance   maintenanceConfig `yaml:"maintenance"`
+	Scale         scaleConfig       `yaml:"scale"`
+	NodeDrain     drain.NodeDrain   `yaml:"nodeDrain"`
+	HealthCheck   healthCheck       `yaml:"healthCheck"`
+	Verification  verification      `yaml:"verification"`
+	UpgradeWindow upgradeWindow     `yaml:"upgradeWindow"`
 }
 
 type maintenanceConfig struct {
@@ -37,6 +38,14 @@ func (cfg *maintenanceConfig) IsValid() error {
 
 func (cfg *maintenanceConfig) GetControlPlaneDuration() time.Duration {
 	return time.Duration(cfg.ControlPlaneTime) * time.Minute
+}
+
+type upgradeWindow struct {
+	DelayTrigger int `yaml:"delayTrigger" default:"30"`
+}
+
+func (cfg *upgradeWindow) GetUpgradeDelayedTriggerDuration() time.Duration {
+	return time.Duration(cfg.DelayTrigger) * time.Minute
 }
 
 type scaleConfig struct {
@@ -65,7 +74,9 @@ func (cfg *osdUpgradeConfig) IsValid() error {
 	if cfg.NodeDrain.ExpectedNodeDrainTime <= 0 {
 		return fmt.Errorf("Config nodeDrain expectedNodeDrainTime is invalid")
 	}
-
+	if cfg.UpgradeWindow.DelayTrigger <= 0 {
+		return fmt.Errorf("Config upgrade window delay trigger is invalid")
+	}
 	return nil
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -37,7 +37,7 @@ func (s *scheduler) IsReadyToUpgrade(upgradeConfig *upgradev1alpha1.UpgradeConfi
 			return SchedulerResult{IsReady: true, IsBreached: false, TimeUntilUpgrade: 0}
 		}
 
-		return SchedulerResult{IsReady: false, IsBreached: true, TimeUntilUpgrade: 0}
+		return SchedulerResult{IsReady: true, IsBreached: true, TimeUntilUpgrade: 0}
 	}
 
 	// It hasn't reached the upgrade window yet

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Scheduler", func() {
 		s := &scheduler{}
 		upgradeConfig = testUpgradeConfig(true, time.Now().Add(-10*time.Minute).Format(time.RFC3339))
 		result := s.IsReadyToUpgrade(upgradeConfig, 5 * time.Minute)
-		Expect(result.IsReady).To(BeFalse())
+		Expect(result.IsReady).To(BeTrue())
 		Expect(result.IsBreached).To(BeTrue())
 	})
 })


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
This feature allows the `managed-upgrade-operator`'s `OSD` upgrader to submit a `delayed` notification if the control plane has not commenced within a configurable time window.

This PR introduces a `delayTrigger` configuration item to the `UpgradeWindow` configuration block which measures the time in minutes before we consider the upgrade to be delayed.

This feature also introduces the ability to 'fail' an upgrade during the pre-Control Plane upgrade phases. This will result in a 'failed' notification sent to OCM, the `UpgradeConfig` phase marked as Failed, and no further execution of the upgrade.

I have also moved all logic of 'window breach' handling outside of the controller and into the OSD upgrader, where it rightfully belongs, and forms the bulk of the 'failure' check. This is OSD-specific logic that has no business being in the controller. In doing this change, the controller now always attempts an upgrade if the current time is after the 'upgradeAt' time, and leaves the upgrader (in this case, OSD's) to decide whether it should upgrade or not. This is all in keeping with trying to keep the controller as generic and business-logic-agnostic as possible, and shifting that to the upgraders.

Note that handling any initialization cleanup (scaling down nodes, tearing down maintenance windows) is covered separately by [OSD-5723](https://issues.redhat.com/browse/OSD-5723). This PR is big enough as it is.

### Which Jira/Github issue(s) this PR fixes?

OHSS-5714
OHSS-5715

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

