### PR TITLE
Tidy up OCM interaction code and tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,13 @@ require (
 	github.com/go-logr/logr v0.1.0
 	github.com/go-openapi/runtime v0.19.4
 	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-resty/resty/v2 v2.3.0
 	github.com/golang/mock v1.4.4
 	github.com/golang/protobuf v1.4.1 // indirect
 	github.com/golangci/golangci-lint v1.27.0
 	github.com/google/uuid v1.1.1
 	github.com/hashicorp/go-multierror v1.1.0
+	github.com/jarcoal/httpmock v1.0.6
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.10.0
 	github.com/openshift/api v0.0.0-20200522173408-17ada6e4245b
@@ -27,7 +29,6 @@ require (
 	github.com/prometheus/common v0.9.1
 	github.com/spf13/pflag v1.0.5
 	github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50 // indirect
-	golang.org/x/net v0.0.0-20200506145744-7e3656a0809f // indirect
 	golang.org/x/sys v0.0.0-20200509044756-6aff5f38e54f // indirect
 	golang.org/x/tools v0.0.0-20200522201501-cb1345f3a375 // indirect
 	gopkg.in/yaml.v2 v2.2.8

--- a/go.sum
+++ b/go.sum
@@ -404,6 +404,9 @@ github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2K
 github.com/go-openapi/validate v0.19.5 h1:QhCBKRYqZR+SKo4gl1lPhPahope8/RLt6EVgY8X80w0=
 github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
 github.com/go-ozzo/ozzo-validation v3.5.0+incompatible/go.mod h1:gsEKFIVnabGBt6mXmxK0MoFy+cZoTJY6mu5Ll3LVLBU=
+github.com/go-resty/resty v1.12.0 h1:L1P5qymrXL5H/doXe2pKUr1wxovAI5ilm2LdVLbwThc=
+github.com/go-resty/resty/v2 v2.3.0 h1:JOOeAvjSlapTT92p8xiS19Zxev1neGikoHsXJeOq8So=
+github.com/go-resty/resty/v2 v2.3.0/go.mod h1:UpN9CgLZNsv4e9XG50UU8xdI0F43UQ4HmxLBDwaroHU=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
@@ -661,6 +664,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/influxdata/influxdb v1.7.7/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80sQsxDoMokWK1W5TQtxBFNpzWTD84ibQ=
 github.com/jackc/pgx v3.2.0+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGkVEFm4TeybAXq+I=
+github.com/jarcoal/httpmock v1.0.6 h1:e81vOSexXU3mJuJ4l//geOmKIt+Vkxerk1feQBC8D0g=
+github.com/jarcoal/httpmock v1.0.6/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
 github.com/jessevdk/go-flags v0.0.0-20180331124232-1c38ed7ad0cc/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
@@ -1318,6 +1323,8 @@ golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200506145744-7e3656a0809f h1:QBjCr1Fz5kw158VqdE9JfI9cJnl/ymnJWAdMuinqL7Y=
 golang.org/x/net v0.0.0-20200506145744-7e3656a0809f/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200513185701-a91f0712d120 h1:EZ3cVSzKOlJxAd8e8YAJ7no8nNypTxexh/YE/xW3ZEY=
+golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/pkg/notifier/ocmnotifier_test.go
+++ b/pkg/notifier/ocmnotifier_test.go
@@ -1,16 +1,14 @@
 package notifier
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"os"
 	"path"
-	"strings"
 
+	"github.com/go-resty/resty/v2"
 	"github.com/golang/mock/gomock"
+	"github.com/jarcoal/httpmock"
 	configv1 "github.com/openshift/api/config/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -26,9 +24,6 @@ import (
 const (
 	TEST_CLUSTER_ID                  = "111111-2222222-3333333-4444444"
 	TEST_POLICY_ID                   = "aaaaaa-bbbbbb-cccccc-dddddd"
-	TEST_CLUSTER_ID_WITH_NO_POLICIES = "555555-666666-777777-888888"
-	TEST_CLUSTER_ID_FOR_BAD_REPLY    = "999999-aaaaaa-bbbbbb-cccccc"
-	TEST_CLUSTER_ID_FOR_SAME_STATE   = "000000-000000-000000-000000"
 
 	// Upgrade policy constants
 	TEST_OPERATOR_NAMESPACE        = "openshift-managed-upgrade-operator"
@@ -42,6 +37,9 @@ const (
 	// State constants
 	TEST_STATE_VALUE       = "test-value"
 	TEST_STATE_DESCRIPTION = "test-description"
+
+	// OCM test constants
+	TEST_OCM_SERVER_URL = "https://fakeapi.openshift.com"
 )
 
 var _ = Describe("OCM Notifier", func() {
@@ -49,39 +47,86 @@ var _ = Describe("OCM Notifier", func() {
 		mockCtrl                 *gomock.Controller
 		mockKubeClient           *mocks.MockClient
 		mockUpgradeConfigManager *mockUCMgr.MockUpgradeConfigManager
+		httpClient				 *resty.Client
 		notifier                 *ocmNotifier
-		ocmServer                *httptest.Server
 		upgradeConfigName        types.NamespacedName
 	)
 
+	BeforeSuite(func() {
+		httpClient = resty.New()
+		httpmock.ActivateNonDefault(httpClient.GetClient())
+	})
+
 	BeforeEach(func() {
-		ocmServer = ocmServerMock()
 		mockCtrl = gomock.NewController(GinkgoT())
 		mockKubeClient = mocks.NewMockClient(mockCtrl)
 		mockUpgradeConfigManager = mockUCMgr.NewMockUpgradeConfigManager(mockCtrl)
-
-		ocmServerUrl, _ := url.Parse(ocmServer.URL)
-
+		ocmServerUrl, _ := url.Parse(TEST_OCM_SERVER_URL)
 		notifier = &ocmNotifier{
 			client:               mockKubeClient,
 			ocmBaseUrl:           ocmServerUrl,
-			httpClient:           &http.Client{},
+			httpClient:           httpClient,
 			upgradeConfigManager: mockUpgradeConfigManager,
 		}
 	})
 
 	AfterEach(func() {
 		mockCtrl.Finish()
-		ocmServer.Close()
+		httpmock.Reset()
 	})
 
 	Context("Notify state", func() {
+
+		var (
+			clusterListResponse clusterList
+			upgradePolicyListResponse upgradePolicyList
+		)
+
 		BeforeEach(func() {
 			ns := TEST_OPERATOR_NAMESPACE
 			upgradeConfigName = types.NamespacedName{
 				Name:      "test-upgradeconfig",
 				Namespace: ns,
 			}
+			clusterListResponse = clusterList{
+				Kind:  "ClusterList",
+				Page:  1,
+				Size:  1,
+				Total: 1,
+				Items: []clusterInfo{
+					{
+						Id: TEST_CLUSTER_ID,
+						Version: clusterVersion{
+							Id:           "4.4.4",
+							ChannelGroup: TEST_UPGRADEPOLICY_CHANNELGROUP,
+						},
+					},
+				},
+			}
+			upgradePolicyListResponse = upgradePolicyList{
+				Kind:  "UpgradePolicyList",
+				Page:  1,
+				Size:  1,
+				Total: 1,
+				Items: []upgradePolicy{
+					{
+						Id:           TEST_POLICY_ID,
+						Kind:         "UpgradePolicy",
+						Href:         "test",
+						Schedule:     "test",
+						ScheduleType: "manual",
+						UpgradeType:  TEST_UPGRADEPOLICY_UPGRADETYPE,
+						Version:      TEST_UPGRADEPOLICY_VERSION,
+						NextRun:      TEST_UPGRADEPOLICY_TIME,
+						NodeDrainGracePeriod: nodeDrainGracePeriod{
+							Value: TEST_UPGRADEPOLICY_PDB_TIME,
+							Unit:  "minutes",
+						},
+						ClusterId: TEST_CLUSTER_ID,
+					},
+				},
+			}
+
 			_ = os.Setenv("OPERATOR_NAMESPACE", ns)
 		})
 
@@ -93,8 +138,23 @@ var _ = Describe("OCM Notifier", func() {
 				uc.Spec.UpgradeAt = TEST_UPGRADEPOLICY_TIME
 			})
 			It("returns an error", func() {
+				clResponder, _ := httpmock.NewJsonResponder(http.StatusOK, clusterListResponse)
+				clUrl := path.Join(CLUSTERS_V1_PATH)
+				httpmock.RegisterResponder(http.MethodGet, clUrl, clResponder)
+
+				upResponse := upgradePolicyList{
+					Kind:  "UpgradePolicyList",
+					Page:  1,
+					Size:  0,
+					Total: 0,
+					Items: []upgradePolicy{},
+				}
+				upResponder, _ := httpmock.NewJsonResponder(http.StatusOK, upResponse)
+				upUrl := path.Join(CLUSTERS_V1_PATH, TEST_CLUSTER_ID, UPGRADEPOLICIES_V1_PATH)
+				httpmock.RegisterResponder(http.MethodGet, upUrl, upResponder)
+
 				gomock.InOrder(
-					mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, configv1.ClusterVersion{Spec: configv1.ClusterVersionSpec{ClusterID: TEST_CLUSTER_ID_WITH_NO_POLICIES}}),
+					mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, configv1.ClusterVersion{Spec: configv1.ClusterVersionSpec{ClusterID: TEST_CLUSTER_ID}}),
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 				)
 				err := notifier.NotifyState(TEST_STATE_VALUE, TEST_STATE_DESCRIPTION)
@@ -111,6 +171,14 @@ var _ = Describe("OCM Notifier", func() {
 				uc.Spec.UpgradeAt = TEST_UPGRADEPOLICY_TIME
 			})
 			It("returns an error", func() {
+				clResponder, _ := httpmock.NewJsonResponder(http.StatusOK, clusterListResponse)
+				clUrl := path.Join(CLUSTERS_V1_PATH)
+				httpmock.RegisterResponder(http.MethodGet, clUrl, clResponder)
+
+				upResponder, _ := httpmock.NewJsonResponder(http.StatusOK, upgradePolicyListResponse)
+				upUrl := path.Join(CLUSTERS_V1_PATH, TEST_CLUSTER_ID, UPGRADEPOLICIES_V1_PATH)
+				httpmock.RegisterResponder(http.MethodGet, upUrl, upResponder)
+
 				gomock.InOrder(
 					mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, configv1.ClusterVersion{Spec: configv1.ClusterVersionSpec{ClusterID: TEST_CLUSTER_ID}}),
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
@@ -121,6 +189,7 @@ var _ = Describe("OCM Notifier", func() {
 			})
 		})
 
+
 		Context("When a policy exists but doesn't match upgrade time", func() {
 			var uc upgradev1alpha1.UpgradeConfig
 			BeforeEach(func() {
@@ -129,6 +198,14 @@ var _ = Describe("OCM Notifier", func() {
 				uc.Spec.UpgradeAt = "not the same time"
 			})
 			It("returns an error", func() {
+				clResponder, _ := httpmock.NewJsonResponder(http.StatusOK, clusterListResponse)
+				clUrl := path.Join(CLUSTERS_V1_PATH)
+				httpmock.RegisterResponder(http.MethodGet, clUrl, clResponder)
+
+				upResponder, _ := httpmock.NewJsonResponder(http.StatusOK, upgradePolicyListResponse)
+				upUrl := path.Join(CLUSTERS_V1_PATH, TEST_CLUSTER_ID, UPGRADEPOLICIES_V1_PATH)
+				httpmock.RegisterResponder(http.MethodGet, upUrl, upResponder)
+
 				gomock.InOrder(
 					mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, configv1.ClusterVersion{Spec: configv1.ClusterVersionSpec{ClusterID: TEST_CLUSTER_ID}}),
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
@@ -149,14 +226,31 @@ var _ = Describe("OCM Notifier", func() {
 					uc.Spec.UpgradeAt = TEST_UPGRADEPOLICY_TIME
 				})
 				It("does not send a notification", func() {
+					clResponder, _ := httpmock.NewJsonResponder(http.StatusOK, clusterListResponse)
+					clUrl := path.Join(CLUSTERS_V1_PATH)
+					httpmock.RegisterResponder(http.MethodGet, clUrl, clResponder)
+
+					upResponder, _ := httpmock.NewJsonResponder(http.StatusOK, upgradePolicyListResponse)
+					upUrl := path.Join(CLUSTERS_V1_PATH, TEST_CLUSTER_ID, UPGRADEPOLICIES_V1_PATH)
+					httpmock.RegisterResponder(http.MethodGet, upUrl, upResponder)
+
+					stateResponse := upgradePolicyState{
+						Kind:        "UpgradePolicyState",
+						Href:        "test",
+						Value:       TEST_STATE_VALUE,
+						Description: TEST_STATE_DESCRIPTION,
+					}
+					stateResponder, _ := httpmock.NewJsonResponder(http.StatusOK, stateResponse)
+					stateUrl := path.Join(CLUSTERS_V1_PATH, TEST_CLUSTER_ID, UPGRADEPOLICIES_V1_PATH, TEST_POLICY_ID, STATE_V1_PATH)
+					httpmock.RegisterResponder(http.MethodGet, stateUrl, stateResponder)
+
 					gomock.InOrder(
-						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, configv1.ClusterVersion{Spec: configv1.ClusterVersionSpec{ClusterID: TEST_CLUSTER_ID_FOR_SAME_STATE}}),
+						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, configv1.ClusterVersion{Spec: configv1.ClusterVersionSpec{ClusterID: TEST_CLUSTER_ID}}),
 						mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 					)
 					err := notifier.NotifyState(TEST_STATE_VALUE, TEST_STATE_DESCRIPTION)
 					Expect(err).To(BeNil())
 				})
-
 			})
 
 			Context("When the policy state does not match the notifying state", func() {
@@ -167,6 +261,27 @@ var _ = Describe("OCM Notifier", func() {
 					uc.Spec.UpgradeAt = TEST_UPGRADEPOLICY_TIME
 				})
 				It("sends a notification", func() {
+
+					clResponder, _ := httpmock.NewJsonResponder(http.StatusOK, clusterListResponse)
+					clUrl := path.Join(CLUSTERS_V1_PATH)
+					httpmock.RegisterResponder(http.MethodGet, clUrl, clResponder)
+
+					upResponder, _ := httpmock.NewJsonResponder(http.StatusOK, upgradePolicyListResponse)
+					upUrl := path.Join(CLUSTERS_V1_PATH, TEST_CLUSTER_ID, UPGRADEPOLICIES_V1_PATH)
+					httpmock.RegisterResponder(http.MethodGet, upUrl, upResponder)
+
+					stateResponse := upgradePolicyState{
+						Kind:        "UpgradePolicyState",
+						Href:        "test",
+						Value:       "different value",
+						Description: "different desc",
+					}
+					stateResponder, _ := httpmock.NewJsonResponder(http.StatusOK, stateResponse)
+					stateUrl := path.Join(CLUSTERS_V1_PATH, TEST_CLUSTER_ID, UPGRADEPOLICIES_V1_PATH, TEST_POLICY_ID, STATE_V1_PATH)
+					httpmock.RegisterResponder(http.MethodGet, stateUrl, stateResponder)
+					statePatchResponder, _ := httpmock.NewJsonResponder(http.StatusOK, stateResponse)
+					httpmock.RegisterResponder(http.MethodPatch,stateUrl, statePatchResponder)
+
 					gomock.InOrder(
 						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, configv1.ClusterVersion{Spec: configv1.ClusterVersionSpec{ClusterID: TEST_CLUSTER_ID}}),
 						mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
@@ -177,165 +292,5 @@ var _ = Describe("OCM Notifier", func() {
 			})
 
 		})
-
 	})
 })
-
-func ocmServerMock() *httptest.Server {
-	handler := http.NewServeMux()
-	handler.HandleFunc(CLUSTERS_V1_PATH, clustersMock)
-
-	upPolicyPath := path.Join(CLUSTERS_V1_PATH, TEST_CLUSTER_ID, UPGRADEPOLICIES_V1_PATH)
-	handler.HandleFunc(upPolicyPath, policyMock)
-
-	noPolicyPath := path.Join(CLUSTERS_V1_PATH, TEST_CLUSTER_ID_WITH_NO_POLICIES, UPGRADEPOLICIES_V1_PATH)
-	handler.HandleFunc(noPolicyPath, noPolicyMock)
-
-	statePath := path.Join(CLUSTERS_V1_PATH, TEST_CLUSTER_ID, UPGRADEPOLICIES_V1_PATH, TEST_POLICY_ID, STATE_V1_PATH)
-	handler.HandleFunc(statePath, stateMock)
-
-	upPolicyPathSameState := path.Join(CLUSTERS_V1_PATH, TEST_CLUSTER_ID_FOR_SAME_STATE, UPGRADEPOLICIES_V1_PATH)
-	handler.HandleFunc(upPolicyPathSameState, policyMockSameState)
-	statePathSameState := path.Join(CLUSTERS_V1_PATH, TEST_CLUSTER_ID_FOR_SAME_STATE, UPGRADEPOLICIES_V1_PATH, TEST_POLICY_ID, STATE_V1_PATH)
-	handler.HandleFunc(statePathSameState, stateMockSameValue)
-
-	srv := httptest.NewServer(handler)
-	return srv
-}
-
-func clustersMock(w http.ResponseWriter, r *http.Request) {
-	response := clusterList{
-		Kind:  "ClusterList",
-		Page:  1,
-		Size:  1,
-		Total: 1,
-		Items: []clusterInfo{
-			{
-				Id: "",
-				Version: clusterVersion{
-					Id:           "4.4.4",
-					ChannelGroup: TEST_UPGRADEPOLICY_CHANNELGROUP,
-				},
-			},
-		},
-	}
-
-	// Return different responses based on the cluster ID searched for
-	clusterSearch := r.URL.Query().Get("search")
-
-	// Return a cluster ID that'll have some upgrade policies
-	if strings.Contains(clusterSearch, TEST_CLUSTER_ID) {
-		response.Items[0].Id = TEST_CLUSTER_ID
-	}
-	// Return a cluster ID that'll have no upgrade policies
-	if strings.Contains(clusterSearch, TEST_CLUSTER_ID_WITH_NO_POLICIES) {
-		response.Items[0].Id = TEST_CLUSTER_ID_WITH_NO_POLICIES
-	}
-	// Return a cluster ID that'll have no upgrade policies
-	if strings.Contains(clusterSearch, TEST_CLUSTER_ID_FOR_BAD_REPLY) {
-		response.Items[0].Id = TEST_CLUSTER_ID_FOR_BAD_REPLY
-	}
-	// Return a cluster ID that'll have same state in the policy
-	if strings.Contains(clusterSearch, TEST_CLUSTER_ID_FOR_SAME_STATE) {
-		response.Items[0].Id = TEST_CLUSTER_ID_FOR_SAME_STATE
-	}
-
-	responseJson, _ := json.Marshal(response)
-	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprintln(w, string(responseJson))
-}
-
-func policyMock(w http.ResponseWriter, r *http.Request) {
-	response := upgradePolicyList{
-		Kind:  "UpgradePolicyList",
-		Page:  1,
-		Size:  1,
-		Total: 1,
-		Items: []upgradePolicy{
-			{
-				Id:           TEST_POLICY_ID,
-				Kind:         "UpgradePolicy",
-				Href:         "test",
-				Schedule:     "test",
-				ScheduleType: "manual",
-				UpgradeType:  TEST_UPGRADEPOLICY_UPGRADETYPE,
-				Version:      TEST_UPGRADEPOLICY_VERSION,
-				NextRun:      TEST_UPGRADEPOLICY_TIME,
-				NodeDrainGracePeriod: nodeDrainGracePeriod{
-					Value: TEST_UPGRADEPOLICY_PDB_TIME,
-					Unit:  "minutes",
-				},
-				ClusterId: TEST_CLUSTER_ID,
-			},
-		},
-	}
-	responseJson, _ := json.Marshal(response)
-	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprintln(w, string(responseJson))
-}
-
-func noPolicyMock(w http.ResponseWriter, r *http.Request) {
-	response := upgradePolicyList{
-		Kind:  "UpgradePolicyList",
-		Page:  1,
-		Size:  0,
-		Total: 0,
-		Items: []upgradePolicy{},
-	}
-	responseJson, _ := json.Marshal(response)
-	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprintln(w, string(responseJson))
-}
-
-func policyMockSameState(w http.ResponseWriter, r *http.Request) {
-	response := upgradePolicyList{
-		Kind:  "UpgradePolicyList",
-		Page:  1,
-		Size:  1,
-		Total: 1,
-		Items: []upgradePolicy{
-			{
-				Id:           TEST_POLICY_ID,
-				Kind:         "UpgradePolicy",
-				Href:         "test",
-				Schedule:     "test",
-				ScheduleType: "manual",
-				UpgradeType:  TEST_UPGRADEPOLICY_UPGRADETYPE,
-				Version:      TEST_UPGRADEPOLICY_VERSION,
-				NextRun:      TEST_UPGRADEPOLICY_TIME,
-				NodeDrainGracePeriod: nodeDrainGracePeriod{
-					Value: TEST_UPGRADEPOLICY_PDB_TIME,
-					Unit:  "minutes",
-				},
-				ClusterId: TEST_CLUSTER_ID_FOR_SAME_STATE,
-			},
-		},
-	}
-	responseJson, _ := json.Marshal(response)
-	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprintln(w, string(responseJson))
-}
-
-func stateMockSameValue(w http.ResponseWriter, r *http.Request) {
-	response := upgradePolicyState{
-		Kind:        "UpgradePolicyState",
-		Href:        "test",
-		Value:       "test",
-		Description: "test",
-	}
-	responseJson, _ := json.Marshal(response)
-	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprintln(w, string(responseJson))
-}
-
-func stateMock(w http.ResponseWriter, r *http.Request) {
-	response := upgradePolicyState{
-		Kind:        "UpgradePolicyState",
-		Href:        "test",
-		Value:       TEST_STATE_VALUE,
-		Description: TEST_STATE_DESCRIPTION,
-	}
-	responseJson, _ := json.Marshal(response)
-	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprintln(w, string(responseJson))
-}

--- a/pkg/ocmprovider/ocmprovider.go
+++ b/pkg/ocmprovider/ocmprovider.go
@@ -2,7 +2,6 @@ package ocmprovider
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -10,6 +9,7 @@ import (
 	"time"
 
 	"github.com/blang/semver"
+	"github.com/go-resty/resty/v2"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -46,12 +46,9 @@ func New(client client.Client, ocmBaseUrl *url.URL) (*ocmProvider, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve cluster access token")
 	}
+
 	// Set up the HTTP client using the token
-	httpClient := &http.Client{
-		Transport: &ocmRoundTripper{
-			authorization: *accessToken,
-		},
-	}
+	httpClient := resty.New().SetTransport(&ocmRoundTripper{authorization:*accessToken})
 
 	return &ocmProvider{
 		client:     client,
@@ -66,7 +63,7 @@ type ocmProvider struct {
 	// Base OCM API Url
 	ocmBaseUrl *url.URL
 	// HTTP client used for API queries (TODO: remove in favour of OCM SDK)
-	httpClient *http.Client
+	httpClient *resty.Client
 }
 
 // Represents an unmarshalled Upgrade Policy response from Cluster Services
@@ -140,8 +137,13 @@ func (s *ocmProvider) Get() ([]upgradev1alpha1.UpgradeConfigSpec, error) {
 	cluster, err := getClusterFromOCMApi(s.client, s.httpClient, s.ocmBaseUrl)
 	if err != nil {
 		log.Error(err, "cannot obtain internal cluster ID")
+		// Pass the error up the chain if the cluster ID couldn't be found
+		if err == ErrClusterIdNotFound {
+			return nil, err
+		}
 		return nil, ErrProviderUnavailable
 	}
+	// In case a response was returned that has no cluster ID
 	if cluster.Id == "" {
 		return nil, ErrClusterIdNotFound
 	}
@@ -179,7 +181,7 @@ func (s *ocmProvider) Get() ([]upgradev1alpha1.UpgradeConfigSpec, error) {
 }
 
 // Queries and returns the Upgrade Policy from Cluster Services
-func getClusterUpgradePolicies(cluster *clusterInfo, client *http.Client, ocmBaseUrl *url.URL) (*upgradePolicyList, error) {
+func getClusterUpgradePolicies(cluster *clusterInfo, client *resty.Client, ocmBaseUrl *url.URL) (*upgradePolicyList, error) {
 
 	upUrl, err := url.Parse(ocmBaseUrl.String())
 	if err != nil {
@@ -187,33 +189,22 @@ func getClusterUpgradePolicies(cluster *clusterInfo, client *http.Client, ocmBas
 	}
 	upUrl.Path = path.Join(upUrl.Path, CLUSTERS_V1_PATH, cluster.Id, UPGRADEPOLICIES_V1_PATH)
 
-	request := &http.Request{
-		Method: "GET",
-		URL:    upUrl,
-	}
-	response, err := client.Do(request)
+	response, err := client.R().
+		SetResult(&upgradePolicyList{}).
+		ExpectContentType("application/json").
+		Get(upUrl.String())
+
 	if err != nil {
 		return nil, fmt.Errorf("can't query upgrade service: %v", err)
 	}
-	operationId := response.Header[OPERATION_ID_HEADER]
-
-	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("received error code '%v' from OCM upgrade policy service, operation id '%v'", response.StatusCode, operationId)
+	operationId := response.Header().Get(OPERATION_ID_HEADER)
+	if response.IsError() {
+		return nil, fmt.Errorf("received error code %v, operation id '%v'", response.StatusCode(), operationId)
 	}
 
-	if response.Body != nil {
-		defer response.Body.Close()
-	}
+	upgradeResponses := response.Result().(*upgradePolicyList)
 
-	var upgradeResponses upgradePolicyList
-	decoder := json.NewDecoder(response.Body)
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&upgradeResponses)
-	if err != nil {
-		return nil, fmt.Errorf("unable to decode OCM upgrade policy response, operation id '%v'", operationId)
-	}
-
-	return &upgradeResponses, nil
+	return upgradeResponses, nil
 }
 
 // getNextOccurringUpgradePolicy returns the next occurring upgradepolicy from a list of upgrade
@@ -279,7 +270,7 @@ func inferUpgradeChannelFromChannelGroup(channelGroup string, toVersion string) 
 }
 
 // Read cluster info from OCM
-func getClusterFromOCMApi(kc client.Client, client *http.Client, ocmApi *url.URL) (*clusterInfo, error) {
+func getClusterFromOCMApi(kc client.Client, client *resty.Client, ocmApi *url.URL) (*clusterInfo, error) {
 
 	// fetch the clusterversion, which contains the internal ID
 	cv := &configv1.ClusterVersion{}
@@ -289,44 +280,34 @@ func getClusterFromOCMApi(kc client.Client, client *http.Client, ocmApi *url.URL
 	}
 	externalID := cv.Spec.ClusterID
 
-	search := fmt.Sprintf("external_id = '%s'", externalID)
-	query := make(url.Values)
-	query.Add("page", "1")
-	query.Add("size", "1")
-	query.Add("search", search)
-
 	csUrl, err := url.Parse(ocmApi.String())
 	if err != nil {
 		return nil, fmt.Errorf("can't parse OCM API url: %v", err)
 	}
 	csUrl.Path = path.Join(csUrl.Path, CLUSTERS_V1_PATH)
-	csUrl.RawQuery = query.Encode()
-	request := &http.Request{
-		Method: "GET",
-		URL:    csUrl,
-	}
 
-	response, err := client.Do(request)
+	response, err := client.R().
+		SetQueryParams(map[string]string {
+			"page": "1",
+			"size": "1",
+			"search": fmt.Sprintf("external_id = '%s'", externalID),
+		}).
+		SetResult(&clusterList{}).
+		ExpectContentType("application/json").
+		Get(csUrl.String())
+
 	if err != nil {
 		return nil, fmt.Errorf("can't query OCM cluster service: %v", err)
 	}
-	operationId := response.Header[OPERATION_ID_HEADER]
-	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("received error code %v, operation id '%v'", response.StatusCode, operationId)
+
+	operationId := response.Header().Get(OPERATION_ID_HEADER)
+	if response.IsError() {
+		return nil, fmt.Errorf("received error code %v, operation id '%v'", response.StatusCode(), operationId)
 	}
 
-	if response.Body != nil {
-		defer response.Body.Close()
-	}
-
-	var listResponse clusterList
-	decoder := json.NewDecoder(response.Body)
-	err = decoder.Decode(&listResponse)
-	if err != nil {
-		return nil, fmt.Errorf("unable to decode OCM cluster response, operation id '%v'", operationId)
-	}
+	listResponse := response.Result().(*clusterList)
 	if listResponse.Size != 1 || len(listResponse.Items) != 1 {
-		return nil, fmt.Errorf("no items returned from OCM cluster service, operation id '%v'", operationId)
+		return nil, ErrClusterIdNotFound
 	}
 
 	return &listResponse.Items[0], nil

--- a/pkg/ocmprovider/ocmprovider.go
+++ b/pkg/ocmprovider/ocmprovider.go
@@ -3,13 +3,13 @@ package ocmprovider
 import (
 	"context"
 	"fmt"
+	"github.com/go-resty/resty/v2"
 	"net/http"
 	"net/url"
 	"path"
 	"time"
 
 	"github.com/blang/semver"
-	"github.com/go-resty/resty/v2"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -86,13 +86,7 @@ type upgradePolicy struct {
 	Version              string               `json:"version"`
 	NextRun              string               `json:"next_run"`
 	PrevRun              string               `json:"prev_run"`
-	NodeDrainGracePeriod nodeDrainGracePeriod `json:"node_drain_grace_period"`
 	ClusterId            string               `json:"cluster_id"`
-}
-
-type nodeDrainGracePeriod struct {
-	Value int64  `json:"value"`
-	Unit  string `json:"unit"`
 }
 
 // Represents an unmarshalled Cluster List response from Cluster Services
@@ -108,6 +102,12 @@ type clusterList struct {
 type clusterInfo struct {
 	Id      string         `json:"id"`
 	Version clusterVersion `json:"version"`
+	NodeDrainGracePeriod nodeDrainGracePeriod `json:"node_drain_grace_period"`
+}
+
+type nodeDrainGracePeriod struct {
+	Value int64  `json:"value"`
+	Unit  string `json:"unit"`
 }
 
 type clusterVersion struct {
@@ -249,7 +249,7 @@ func buildUpgradeConfigSpecs(upgradePolicy *upgradePolicy, cluster *clusterInfo,
 			Channel: *upgradeChannel,
 		},
 		UpgradeAt:            upgradePolicy.NextRun,
-		PDBForceDrainTimeout: int32(upgradePolicy.NodeDrainGracePeriod.Value),
+		PDBForceDrainTimeout: int32(cluster.NodeDrainGracePeriod.Value),
 		Type:                 upgradev1alpha1.UpgradeType(upgradePolicy.UpgradeType),
 	}
 	upgradeConfigSpecs = append(upgradeConfigSpecs, upgradeConfigSpec)

--- a/pkg/ocmprovider/ocmprovider_test.go
+++ b/pkg/ocmprovider/ocmprovider_test.go
@@ -109,6 +109,10 @@ var _ = Describe("OCM Provider", func() {
 							Id:           "4.4.4",
 							ChannelGroup: TEST_UPGRADEPOLICY_CHANNELGROUP,
 						},
+						NodeDrainGracePeriod: nodeDrainGracePeriod{
+							Value: TEST_UPGRADEPOLICY_PDB_TIME,
+							Unit:  "minutes",
+						},
 					},
 				},
 			}
@@ -127,10 +131,6 @@ var _ = Describe("OCM Provider", func() {
 						UpgradeType:  TEST_UPGRADEPOLICY_UPGRADETYPE,
 						Version:      TEST_UPGRADEPOLICY_VERSION,
 						NextRun:      TEST_UPGRADEPOLICY_TIME,
-						NodeDrainGracePeriod: nodeDrainGracePeriod{
-							Value: TEST_UPGRADEPOLICY_PDB_TIME,
-							Unit:  "minutes",
-						},
 						ClusterId: TEST_CLUSTER_ID,
 					},
 				},
@@ -191,10 +191,6 @@ var _ = Describe("OCM Provider", func() {
 						UpgradeType:  TEST_UPGRADEPOLICY_UPGRADETYPE,
 						Version:      TEST_UPGRADEPOLICY_VERSION,
 						NextRun:      TEST_UPGRADEPOLICY_TIME,
-						NodeDrainGracePeriod: nodeDrainGracePeriod{
-							Value: TEST_UPGRADEPOLICY_PDB_TIME,
-							Unit:  "minutes",
-						},
 						ClusterId: TEST_CLUSTER_ID_MULTI_POLICIES,
 					},
 					{
@@ -206,10 +202,6 @@ var _ = Describe("OCM Provider", func() {
 						UpgradeType:  TEST_UPGRADEPOLICY_UPGRADETYPE,
 						Version:      TEST_UPGRADEPOLICY_VERSION,
 						NextRun:      TEST_UPGRADEPOLICY_TIME_NEXT_OCCURRING,
-						NodeDrainGracePeriod: nodeDrainGracePeriod{
-							Value: TEST_UPGRADEPOLICY_PDB_TIME,
-							Unit:  "minutes",
-						},
 						ClusterId: TEST_CLUSTER_ID_MULTI_POLICIES,
 					},
 				},

--- a/pkg/ocmprovider/ocmprovider_test.go
+++ b/pkg/ocmprovider/ocmprovider_test.go
@@ -1,18 +1,16 @@
 package ocmprovider
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
-	"os"
-	"path"
-	"strings"
-
+	"github.com/go-resty/resty/v2"
+	"github.com/jarcoal/httpmock"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/managed-upgrade-operator/pkg/apis/upgrade/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -25,8 +23,6 @@ const (
 	TEST_CLUSTER_ID_MULTI_POLICIES   = "444444-333333-222222-111111"
 	TEST_POLICY_ID_MANUAL            = "aaaaaa-bbbbbb-cccccc-dddddd"
 	TEST_POLICY_ID_AUTOMATIC         = "aaaaaa-bbbbbb-cccccc-dddddd"
-	TEST_CLUSTER_ID_WITH_NO_POLICIES = "555555-666666-777777-888888"
-	TEST_CLUSTER_ID_FOR_BAD_REPLY    = "999999-aaaaaa-bbbbbb-cccccc"
 
 	// Upgrade policy constants
 	TEST_OPERATOR_NAMESPACE                = "test-managed-upgrade-operator"
@@ -36,6 +32,9 @@ const (
 	TEST_UPGRADEPOLICY_VERSION             = "4.4.5"
 	TEST_UPGRADEPOLICY_CHANNELGROUP        = "fast"
 	TEST_UPGRADEPOLICY_PDB_TIME            = 60
+
+	// OCM test constants
+	TEST_OCM_SERVER_URL = "https://fakeapi.openshift.com"
 )
 
 var _ = Describe("OCM Provider", func() {
@@ -43,26 +42,29 @@ var _ = Describe("OCM Provider", func() {
 		mockCtrl       *gomock.Controller
 		mockKubeClient *mocks.MockClient
 		provider       *ocmProvider
-		ocmServer      *httptest.Server
+		httpClient				 *resty.Client
 	)
 
+	BeforeSuite(func() {
+		httpClient = resty.New()
+		httpmock.ActivateNonDefault(httpClient.GetClient())
+	})
+
 	BeforeEach(func() {
-		ocmServer = ocmServerMock()
 		mockCtrl = gomock.NewController(GinkgoT())
 		mockKubeClient = mocks.NewMockClient(mockCtrl)
-
-		ocmServerUrl, _ := url.Parse(ocmServer.URL)
+		ocmServerUrl, _ := url.Parse(TEST_OCM_SERVER_URL)
 
 		provider = &ocmProvider{
 			client:     mockKubeClient,
 			ocmBaseUrl: ocmServerUrl,
-			httpClient: &http.Client{},
+			httpClient: httpClient,
 		}
 	})
 
 	AfterEach(func() {
 		mockCtrl.Finish()
-		ocmServer.Close()
+		httpmock.Reset()
 	})
 
 	Context("Inferring the upgrade channel", func() {
@@ -83,11 +85,54 @@ var _ = Describe("OCM Provider", func() {
 	})
 
 	Context("Getting upgrade policies", func() {
-		var clusterVersion *configv1.ClusterVersion
+		var (
+			cv                        *configv1.ClusterVersion
+			clusterListResponse       clusterList
+			upgradePolicyListResponse upgradePolicyList
+		)
+
 		BeforeEach(func() {
-			clusterVersion = &configv1.ClusterVersion{
+			cv = &configv1.ClusterVersion{
 				Spec: configv1.ClusterVersionSpec{
 					ClusterID: TEST_CLUSTER_ID,
+				},
+			}
+			clusterListResponse = clusterList{
+				Kind:  "ClusterList",
+				Page:  1,
+				Size:  1,
+				Total: 1,
+				Items: []clusterInfo{
+					{
+						Id: TEST_CLUSTER_ID,
+						Version: clusterVersion{
+							Id:           "4.4.4",
+							ChannelGroup: TEST_UPGRADEPOLICY_CHANNELGROUP,
+						},
+					},
+				},
+			}
+			upgradePolicyListResponse = upgradePolicyList{
+				Kind:  "UpgradePolicyList",
+				Page:  1,
+				Size:  1,
+				Total: 1,
+				Items: []upgradePolicy{
+					{
+						Id:           TEST_POLICY_ID_MANUAL,
+						Kind:         "UpgradePolicy",
+						Href:         "test",
+						Schedule:     "test",
+						ScheduleType: "manual",
+						UpgradeType:  TEST_UPGRADEPOLICY_UPGRADETYPE,
+						Version:      TEST_UPGRADEPOLICY_VERSION,
+						NextRun:      TEST_UPGRADEPOLICY_TIME,
+						NodeDrainGracePeriod: nodeDrainGracePeriod{
+							Value: TEST_UPGRADEPOLICY_PDB_TIME,
+							Unit:  "minutes",
+						},
+						ClusterId: TEST_CLUSTER_ID,
+					},
 				},
 			}
 			_ = os.Setenv("OPERATOR_NAMESPACE", TEST_OPERATOR_NAMESPACE)
@@ -104,8 +149,16 @@ var _ = Describe("OCM Provider", func() {
 				Type:                 TEST_UPGRADEPOLICY_UPGRADETYPE,
 			}
 
+			clResponder, _ := httpmock.NewJsonResponder(http.StatusOK, clusterListResponse)
+			clUrl := path.Join(CLUSTERS_V1_PATH)
+			httpmock.RegisterResponder(http.MethodGet, clUrl, clResponder)
+
+			upResponder, _ := httpmock.NewJsonResponder(http.StatusOK, upgradePolicyListResponse)
+			upUrl := path.Join(CLUSTERS_V1_PATH, TEST_CLUSTER_ID, UPGRADEPOLICIES_V1_PATH)
+			httpmock.RegisterResponder(http.MethodGet, upUrl, upResponder)
+
 			gomock.InOrder(
-				mockKubeClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "version"}, gomock.Any()).SetArg(2, *clusterVersion).Return(nil),
+				mockKubeClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "version"}, gomock.Any()).SetArg(2, *cv).Return(nil),
 			)
 			specs, err := provider.Get()
 			Expect(err).To(BeNil())
@@ -113,11 +166,6 @@ var _ = Describe("OCM Provider", func() {
 		})
 
 		It("Returns next occurring spec if multiple exist", func() {
-			multiPolicyClusterVersion := &configv1.ClusterVersion{
-				Spec: configv1.ClusterVersionSpec{
-					ClusterID: TEST_CLUSTER_ID_MULTI_POLICIES,
-				},
-			}
 			expectedSpec := v1alpha1.UpgradeConfigSpec{
 				Desired: v1alpha1.Update{
 					Version: TEST_UPGRADEPOLICY_VERSION,
@@ -128,8 +176,55 @@ var _ = Describe("OCM Provider", func() {
 				Type:                 TEST_UPGRADEPOLICY_UPGRADETYPE,
 			}
 
+			multiPolicyResponse := upgradePolicyList{
+				Kind:  "UpgradePolicyList",
+				Page:  1,
+				Size:  2,
+				Total: 2,
+				Items: []upgradePolicy{
+					{
+						Id:           TEST_POLICY_ID_MANUAL,
+						Kind:         "UpgradePolicy",
+						Href:         "test",
+						Schedule:     "test",
+						ScheduleType: "manual",
+						UpgradeType:  TEST_UPGRADEPOLICY_UPGRADETYPE,
+						Version:      TEST_UPGRADEPOLICY_VERSION,
+						NextRun:      TEST_UPGRADEPOLICY_TIME,
+						NodeDrainGracePeriod: nodeDrainGracePeriod{
+							Value: TEST_UPGRADEPOLICY_PDB_TIME,
+							Unit:  "minutes",
+						},
+						ClusterId: TEST_CLUSTER_ID_MULTI_POLICIES,
+					},
+					{
+						Id:           TEST_POLICY_ID_AUTOMATIC,
+						Kind:         "UpgradePolicy",
+						Href:         "test",
+						Schedule:     "3 5 5 * *",
+						ScheduleType: "automatic",
+						UpgradeType:  TEST_UPGRADEPOLICY_UPGRADETYPE,
+						Version:      TEST_UPGRADEPOLICY_VERSION,
+						NextRun:      TEST_UPGRADEPOLICY_TIME_NEXT_OCCURRING,
+						NodeDrainGracePeriod: nodeDrainGracePeriod{
+							Value: TEST_UPGRADEPOLICY_PDB_TIME,
+							Unit:  "minutes",
+						},
+						ClusterId: TEST_CLUSTER_ID_MULTI_POLICIES,
+					},
+				},
+			}
+
+			clResponder, _ := httpmock.NewJsonResponder(http.StatusOK, clusterListResponse)
+			clUrl := path.Join(CLUSTERS_V1_PATH)
+			httpmock.RegisterResponder(http.MethodGet, clUrl, clResponder)
+
+			upResponder, _ := httpmock.NewJsonResponder(http.StatusOK, multiPolicyResponse)
+			upUrl := path.Join(CLUSTERS_V1_PATH, TEST_CLUSTER_ID, UPGRADEPOLICIES_V1_PATH)
+			httpmock.RegisterResponder(http.MethodGet, upUrl, upResponder)
+
 			gomock.InOrder(
-				mockKubeClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "version"}, gomock.Any()).SetArg(2, *multiPolicyClusterVersion).Return(nil),
+				mockKubeClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "version"}, gomock.Any()).SetArg(2, *cv).Return(nil),
 			)
 			specs, err := provider.Get()
 			Expect(err).To(BeNil())
@@ -137,13 +232,23 @@ var _ = Describe("OCM Provider", func() {
 		})
 
 		It("Returns no specs if there are no policies", func() {
-			noPolicyClusterVersion := &configv1.ClusterVersion{
-				Spec: configv1.ClusterVersionSpec{
-					ClusterID: TEST_CLUSTER_ID_WITH_NO_POLICIES,
-				},
+			clResponder, _ := httpmock.NewJsonResponder(http.StatusOK, clusterListResponse)
+			clUrl := path.Join(CLUSTERS_V1_PATH)
+			httpmock.RegisterResponder(http.MethodGet, clUrl, clResponder)
+
+			upResponse := upgradePolicyList{
+				Kind:  "UpgradePolicyList",
+				Page:  1,
+				Size:  0,
+				Total: 0,
+				Items: []upgradePolicy{},
 			}
+			upResponder, _ := httpmock.NewJsonResponder(http.StatusOK, upResponse)
+			upUrl := path.Join(CLUSTERS_V1_PATH, TEST_CLUSTER_ID, UPGRADEPOLICIES_V1_PATH)
+			httpmock.RegisterResponder(http.MethodGet, upUrl, upResponder)
+
 			gomock.InOrder(
-				mockKubeClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "version"}, gomock.Any()).SetArg(2, *noPolicyClusterVersion).Return(nil),
+				mockKubeClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "version"}, gomock.Any()).SetArg(2, *cv).Return(nil),
 			)
 			specs, err := provider.Get()
 			Expect(err).To(BeNil())
@@ -151,10 +256,13 @@ var _ = Describe("OCM Provider", func() {
 		})
 
 		It("Errors if the provider is unavailable", func() {
-			u, _ := url.Parse("http://doesnotexist.example.com")
-			provider.ocmBaseUrl = u
+
+			clResponder := httpmock.NewErrorResponder(fmt.Errorf("fake error"))
+			clUrl := path.Join(CLUSTERS_V1_PATH)
+			httpmock.RegisterResponder(http.MethodGet, clUrl, clResponder)
+
 			gomock.InOrder(
-				mockKubeClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "version"}, gomock.Any()).SetArg(2, *clusterVersion).Return(nil),
+				mockKubeClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "version"}, gomock.Any()).SetArg(2, *cv).Return(nil),
 			)
 			specs, err := provider.Get()
 			Expect(err).To(Equal(ErrProviderUnavailable))
@@ -162,41 +270,39 @@ var _ = Describe("OCM Provider", func() {
 		})
 
 		It("Errors if the internal cluster ID can't be retrieved", func() {
-			clusterVersion = &configv1.ClusterVersion{
-				Spec: configv1.ClusterVersionSpec{
-					ClusterID: "not a cluster ID we know",
-				},
+
+			noClustersResponse := clusterList{
+				Kind:  "ClusterList",
+				Page:  1,
+				Size:  0,
+				Total: 0,
+				Items: []clusterInfo{},
 			}
+			clResponder, _ := httpmock.NewJsonResponder(http.StatusOK, noClustersResponse)
+			clUrl := path.Join(CLUSTERS_V1_PATH)
+			httpmock.RegisterResponder(http.MethodGet, clUrl, clResponder)
+
 			gomock.InOrder(
-				mockKubeClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "version"}, gomock.Any()).SetArg(2, *clusterVersion).Return(nil),
+				mockKubeClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "version"}, gomock.Any()).SetArg(2, *cv).Return(nil),
 			)
 			specs, err := provider.Get()
 			Expect(err).To(Equal(ErrClusterIdNotFound))
 			Expect(specs).To(BeNil())
 		})
 
-		It("Errors if the internal cluster ID can't be retrieved", func() {
-			clusterVersion = &configv1.ClusterVersion{
-				Spec: configv1.ClusterVersionSpec{
-					ClusterID: "not a cluster ID we know",
-				},
-			}
-			gomock.InOrder(
-				mockKubeClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "version"}, gomock.Any()).SetArg(2, *clusterVersion).Return(nil),
-			)
-			specs, err := provider.Get()
-			Expect(err).To(Equal(ErrClusterIdNotFound))
-			Expect(specs).To(BeNil())
-		})
 
 		It("Errors if the policy response can't be parsed", func() {
-			noPolicyClusterVersion := &configv1.ClusterVersion{
-				Spec: configv1.ClusterVersionSpec{
-					ClusterID: TEST_CLUSTER_ID_FOR_BAD_REPLY,
-				},
-			}
+
+			clResponder, _ := httpmock.NewJsonResponder(http.StatusOK, clusterListResponse)
+			clUrl := path.Join(CLUSTERS_V1_PATH)
+			httpmock.RegisterResponder(http.MethodGet, clUrl, clResponder)
+
+			upResponder := httpmock.NewStringResponder(http.StatusOK, "this isnt a policy response")
+			upUrl := path.Join(CLUSTERS_V1_PATH, TEST_CLUSTER_ID, UPGRADEPOLICIES_V1_PATH)
+			httpmock.RegisterResponder(http.MethodGet, upUrl, upResponder)
+
 			gomock.InOrder(
-				mockKubeClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "version"}, gomock.Any()).SetArg(2, *noPolicyClusterVersion).Return(nil),
+				mockKubeClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "version"}, gomock.Any()).SetArg(2, *cv).Return(nil),
 			)
 			specs, err := provider.Get()
 			Expect(err).To(Equal(ErrRetrievingPolicies))
@@ -205,156 +311,3 @@ var _ = Describe("OCM Provider", func() {
 
 	})
 })
-
-func ocmServerMock() *httptest.Server {
-	handler := http.NewServeMux()
-	handler.HandleFunc(CLUSTERS_V1_PATH, clustersMock)
-
-	upPolicyPath := path.Join(CLUSTERS_V1_PATH, TEST_CLUSTER_ID, UPGRADEPOLICIES_V1_PATH)
-	handler.HandleFunc(upPolicyPath, policyMock)
-
-	multiUpPolicyPath := path.Join(CLUSTERS_V1_PATH, TEST_CLUSTER_ID_MULTI_POLICIES, UPGRADEPOLICIES_V1_PATH)
-	handler.HandleFunc(multiUpPolicyPath, multiPolicyMock)
-
-	noPolicyPath := path.Join(CLUSTERS_V1_PATH, TEST_CLUSTER_ID_WITH_NO_POLICIES, UPGRADEPOLICIES_V1_PATH)
-	handler.HandleFunc(noPolicyPath, noPolicyMock)
-
-	garbagePath := path.Join(CLUSTERS_V1_PATH, TEST_CLUSTER_ID_FOR_BAD_REPLY, UPGRADEPOLICIES_V1_PATH)
-	handler.HandleFunc(garbagePath, garbageMock)
-
-	srv := httptest.NewServer(handler)
-	return srv
-}
-
-func clustersMock(w http.ResponseWriter, r *http.Request) {
-	response := clusterList{
-		Kind:  "ClusterList",
-		Page:  1,
-		Size:  1,
-		Total: 1,
-		Items: []clusterInfo{
-			{
-				Id: "",
-				Version: clusterVersion{
-					Id:           "4.4.4",
-					ChannelGroup: TEST_UPGRADEPOLICY_CHANNELGROUP,
-				},
-			},
-		},
-	}
-
-	// Return different responses based on the cluster ID searched for
-	clusterSearch := r.URL.Query().Get("search")
-
-	// Return a cluster ID that'll have one upgrade policy
-	if strings.Contains(clusterSearch, TEST_CLUSTER_ID) {
-		response.Items[0].Id = TEST_CLUSTER_ID
-	}
-	// Return a cluster ID that'll have multiple upgrade policies
-	if strings.Contains(clusterSearch, TEST_CLUSTER_ID_MULTI_POLICIES) {
-		response.Items[0].Id = TEST_CLUSTER_ID_MULTI_POLICIES
-	}
-	// Return a cluster ID that'll have no upgrade policies
-	if strings.Contains(clusterSearch, TEST_CLUSTER_ID_WITH_NO_POLICIES) {
-		response.Items[0].Id = TEST_CLUSTER_ID_WITH_NO_POLICIES
-	}
-	// Return a cluster ID that'll have no upgrade policies
-	if strings.Contains(clusterSearch, TEST_CLUSTER_ID_FOR_BAD_REPLY) {
-		response.Items[0].Id = TEST_CLUSTER_ID_FOR_BAD_REPLY
-	}
-
-	responseJson, _ := json.Marshal(response)
-	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprintln(w, string(responseJson))
-}
-
-func policyMock(w http.ResponseWriter, r *http.Request) {
-	response := upgradePolicyList{
-		Kind:  "UpgradePolicyList",
-		Page:  1,
-		Size:  1,
-		Total: 1,
-		Items: []upgradePolicy{
-			{
-				Id:           TEST_POLICY_ID_MANUAL,
-				Kind:         "UpgradePolicy",
-				Href:         "test",
-				Schedule:     "test",
-				ScheduleType: "manual",
-				UpgradeType:  TEST_UPGRADEPOLICY_UPGRADETYPE,
-				Version:      TEST_UPGRADEPOLICY_VERSION,
-				NextRun:      TEST_UPGRADEPOLICY_TIME,
-				NodeDrainGracePeriod: nodeDrainGracePeriod{
-					Value: TEST_UPGRADEPOLICY_PDB_TIME,
-					Unit:  "minutes",
-				},
-				ClusterId: TEST_CLUSTER_ID,
-			},
-		},
-	}
-	responseJson, _ := json.Marshal(response)
-	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprintln(w, string(responseJson))
-}
-
-func multiPolicyMock(w http.ResponseWriter, r *http.Request) {
-	response := upgradePolicyList{
-		Kind:  "UpgradePolicyList",
-		Page:  1,
-		Size:  2,
-		Total: 2,
-		Items: []upgradePolicy{
-			{
-				Id:           TEST_POLICY_ID_MANUAL,
-				Kind:         "UpgradePolicy",
-				Href:         "test",
-				Schedule:     "test",
-				ScheduleType: "manual",
-				UpgradeType:  TEST_UPGRADEPOLICY_UPGRADETYPE,
-				Version:      TEST_UPGRADEPOLICY_VERSION,
-				NextRun:      TEST_UPGRADEPOLICY_TIME,
-				NodeDrainGracePeriod: nodeDrainGracePeriod{
-					Value: TEST_UPGRADEPOLICY_PDB_TIME,
-					Unit:  "minutes",
-				},
-				ClusterId: TEST_CLUSTER_ID_MULTI_POLICIES,
-			},
-			{
-				Id:           TEST_POLICY_ID_AUTOMATIC,
-				Kind:         "UpgradePolicy",
-				Href:         "test",
-				Schedule:     "3 5 5 * *",
-				ScheduleType: "automatic",
-				UpgradeType:  TEST_UPGRADEPOLICY_UPGRADETYPE,
-				Version:      TEST_UPGRADEPOLICY_VERSION,
-				NextRun:      TEST_UPGRADEPOLICY_TIME_NEXT_OCCURRING,
-				NodeDrainGracePeriod: nodeDrainGracePeriod{
-					Value: TEST_UPGRADEPOLICY_PDB_TIME,
-					Unit:  "minutes",
-				},
-				ClusterId: TEST_CLUSTER_ID_MULTI_POLICIES,
-			},
-		},
-	}
-	responseJson, _ := json.Marshal(response)
-	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprintln(w, string(responseJson))
-}
-
-func noPolicyMock(w http.ResponseWriter, r *http.Request) {
-	response := upgradePolicyList{
-		Kind:  "UpgradePolicyList",
-		Page:  1,
-		Size:  0,
-		Total: 0,
-		Items: []upgradePolicy{},
-	}
-	responseJson, _ := json.Marshal(response)
-	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprintln(w, string(responseJson))
-}
-
-func garbageMock(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprintln(w, "this is not json at all {")
-}


### PR DESCRIPTION
### What type of PR is this?
Cleanup/Refactor

### What this PR does / why we need it?
As we're not going to be able to use the OCM SDK in MUO for a while (if ever), I'm tidying up all our OCM interaction code and test cases so that it can serve a more long-term and maintainable purpose.

- Removing all `httpclient` interaction and manual JSON marshalling/unmarshalling, replaced with `resty` to do it all for us
- Removing all HTTP server mocking from the test cases and replaced with the much nicer `httpmock`
- A slight tweak to the `ocmProvider` so that it returns an `ErrProviderUnavailable` in all cases of a bad response from OCM when querying for the clusterID, _except_ for the case where we get a valid response but no `cluster` in the list. This will make it easier to catch/handle the occasional situation where a cluster no longer has permissions to query for its own clusterf ID.

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
