### PR TITLE
Retry policy sync on failure

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -29,7 +29,7 @@ import (
 	muocfg "github.com/openshift/managed-upgrade-operator/config"
 	"github.com/openshift/managed-upgrade-operator/pkg/apis"
 	"github.com/openshift/managed-upgrade-operator/pkg/controller"
-	upgrademetrics "github.com/openshift/managed-upgrade-operator/pkg/metrics"
+	"github.com/openshift/managed-upgrade-operator/pkg/metrics/collector"
 	"github.com/openshift/managed-upgrade-operator/pkg/upgradeconfigmanager"
 	"github.com/openshift/managed-upgrade-operator/version"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
@@ -171,7 +171,7 @@ func main() {
 		log.Error(err, "unable to create k8s client for upgrade metrics")
 		os.Exit(1)
 	}
-	uCollector, err := upgrademetrics.NewUpgradeCollector(metricsClient)
+	uCollector, err := collector.NewUpgradeCollector(metricsClient)
 	if err != nil {
 		log.Error(err, "unable to create upgrade metrics collector")
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/golangci/golangci-lint v1.27.0
 	github.com/google/uuid v1.1.1
 	github.com/hashicorp/go-multierror v1.1.0
+	github.com/jpillora/backoff v1.0.0
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.10.0
 	github.com/openshift/api v0.0.0-20200522173408-17ada6e4245b

--- a/go.sum
+++ b/go.sum
@@ -678,6 +678,7 @@ github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52Cu
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9688Y0wesXCyonoVr47MasHilkuLMqGhRZ4Hpak=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/pkg/metrics/collector/collector.go
+++ b/pkg/metrics/collector/collector.go
@@ -1,4 +1,4 @@
-package metrics
+package collector
 
 import (
 	"time"

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -36,6 +36,8 @@ type Metrics interface {
 	UpdateMetricClusterVerificationFailed(string)
 	UpdateMetricClusterVerificationSucceeded(string)
 	UpdateMetricUpgradeWindowNotBreached(string)
+	UpdateMetricUpgradeConfigSynced(string)
+	ResetMetricUpgradeConfigSynced(string)
 	UpdateMetricUpgradeWindowBreached(string)
 	UpdateMetricUpgradeControlPlaneTimeout(string, string)
 	ResetMetricUpgradeControlPlaneTimeout(string, string)
@@ -127,6 +129,11 @@ var (
 		Name:      "upgrade_window_breached",
 		Help:      "Failed to commence upgrade during the upgrade window",
 	}, []string{nameLabel})
+	metricUpgradeConfigSynced = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: metricsTag,
+		Name:      "upgradeconfig_synced",
+		Help:      "UpgradeConfig has not been synced in time",
+	}, []string{nameLabel})
 	metricUpgradeControlPlaneTimeout = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: metricsTag,
 		Name:      "controlplane_timeout",
@@ -154,6 +161,7 @@ var (
 		metricScalingFailed,
 		metricClusterVerificationFailed,
 		metricUpgradeWindowBreached,
+		metricUpgradeConfigSynced,
 		metricUpgradeControlPlaneTimeout,
 		metricUpgradeWorkerTimeout,
 		metricNodeDrainFailed,
@@ -201,6 +209,14 @@ func (c *Counter) UpdateMetricScalingSucceeded(upgradeConfigName string) {
 	metricScalingFailed.With(prometheus.Labels{
 		nameLabel: upgradeConfigName}).Set(
 		float64(0))
+}
+
+func (c *Counter) UpdateMetricUpgradeConfigSynced(name string) {
+	metricUpgradeConfigSynced.With(prometheus.Labels{nameLabel: name}).Set(float64(1))
+}
+
+func (c *Counter) ResetMetricUpgradeConfigSynced(name string) {
+	metricUpgradeConfigSynced.With(prometheus.Labels{nameLabel: name}).Set(float64(0))
 }
 
 func (c *Counter) UpdateMetricUpgradeControlPlaneTimeout(upgradeConfigName, version string) {

--- a/pkg/metrics/mocks/metrics.go
+++ b/pkg/metrics/mocks/metrics.go
@@ -8,7 +8,6 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	metrics "github.com/openshift/managed-upgrade-operator/pkg/metrics"
 	reflect "reflect"
-	time "time"
 )
 
 // MockMetrics is a mock of Metrics interface

--- a/pkg/metrics/mocks/metrics.go
+++ b/pkg/metrics/mocks/metrics.go
@@ -8,6 +8,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	metrics "github.com/openshift/managed-upgrade-operator/pkg/metrics"
 	reflect "reflect"
+	time "time"
 )
 
 // MockMetrics is a mock of Metrics interface
@@ -115,6 +116,18 @@ func (m *MockMetrics) ResetMetricNodeDrainFailed(arg0 string) {
 func (mr *MockMetricsMockRecorder) ResetMetricNodeDrainFailed(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetMetricNodeDrainFailed", reflect.TypeOf((*MockMetrics)(nil).ResetMetricNodeDrainFailed), arg0)
+}
+
+// ResetMetricUpgradeConfigSynced mocks base method
+func (m *MockMetrics) ResetMetricUpgradeConfigSynced(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ResetMetricUpgradeConfigSynced", arg0)
+}
+
+// ResetMetricUpgradeConfigSynced indicates an expected call of ResetMetricUpgradeConfigSynced
+func (mr *MockMetricsMockRecorder) ResetMetricUpgradeConfigSynced(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetMetricUpgradeConfigSynced", reflect.TypeOf((*MockMetrics)(nil).ResetMetricUpgradeConfigSynced), arg0)
 }
 
 // ResetMetricUpgradeControlPlaneTimeout mocks base method
@@ -247,6 +260,18 @@ func (m *MockMetrics) UpdateMetricScalingSucceeded(arg0 string) {
 func (mr *MockMetricsMockRecorder) UpdateMetricScalingSucceeded(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricScalingSucceeded", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricScalingSucceeded), arg0)
+}
+
+// UpdateMetricUpgradeConfigSynced mocks base method
+func (m *MockMetrics) UpdateMetricUpgradeConfigSynced(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateMetricUpgradeConfigSynced", arg0)
+}
+
+// UpdateMetricUpgradeConfigSynced indicates an expected call of UpdateMetricUpgradeConfigSynced
+func (mr *MockMetricsMockRecorder) UpdateMetricUpgradeConfigSynced(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricUpgradeConfigSynced", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricUpgradeConfigSynced), arg0)
 }
 
 // UpdateMetricUpgradeControlPlaneTimeout mocks base method

--- a/pkg/upgradeconfigmanager/upgradeconfigmanager.go
+++ b/pkg/upgradeconfigmanager/upgradeconfigmanager.go
@@ -16,6 +16,7 @@ import (
 	upgradev1alpha1 "github.com/openshift/managed-upgrade-operator/pkg/apis/upgrade/v1alpha1"
 	cv "github.com/openshift/managed-upgrade-operator/pkg/clusterversion"
 	"github.com/openshift/managed-upgrade-operator/pkg/configmanager"
+	"github.com/openshift/managed-upgrade-operator/pkg/metrics"
 	"github.com/openshift/managed-upgrade-operator/pkg/specprovider"
 	"github.com/openshift/managed-upgrade-operator/util"
 )
@@ -28,7 +29,9 @@ const (
 	// Name of the Custom Resource that the provider will manage
 	UPGRADECONFIG_CR_NAME = "osd-upgrade-config"
 	// Jitter factor (percentage / 100) used to alter watch interval
-	JITTER_FACTOR = 0.1
+	JITTER_FACTOR         = 0.1
+	INITIAL_SYNC_DURATION = 1 * time.Minute
+	ERROR_RETRY_DURATION  = 5 * time.Minute
 )
 
 // Errors
@@ -66,6 +69,7 @@ type upgradeConfigManager struct {
 	cvClientBuilder      cv.ClusterVersionBuilder
 	specProviderBuilder  specprovider.SpecProviderBuilder
 	configManagerBuilder configmanager.ConfigManagerBuilder
+	metricsClient        metrics.Metrics
 }
 
 func (ucb *upgradeConfigManagerBuilder) NewManager(client client.Client) (UpgradeConfigManager, error) {
@@ -73,12 +77,18 @@ func (ucb *upgradeConfigManagerBuilder) NewManager(client client.Client) (Upgrad
 	spBuilder := specprovider.NewBuilder()
 	cvBuilder := cv.NewBuilder()
 	cmBuilder := configmanager.NewBuilder()
+	mBuilder := metrics.NewBuilder()
+	mClient, err := mBuilder.NewClient(client)
+	if err != nil {
+		return nil, err
+	}
 
 	return &upgradeConfigManager{
 		client:               client,
 		cvClientBuilder:      cvBuilder,
 		specProviderBuilder:  spBuilder,
 		configManagerBuilder: cmBuilder,
+		metricsClient:        mClient,
 	}, nil
 }
 
@@ -114,21 +124,18 @@ func (s *upgradeConfigManager) StartSync(stopCh <-chan struct{}) {
 		return
 	}
 
-	_, err = s.Refresh()
-	if err != nil {
-		log.Error(err, "unable to refresh upgrade config")
-	}
-
+	duration := durationWithJitter(INITIAL_SYNC_DURATION, JITTER_FACTOR)
 	for {
-
-		// Select a new watch interval with jitter
-		duration := durationWithJitter(cfg.GetWatchInterval(), JITTER_FACTOR)
-
 		select {
 		case <-time.After(duration):
 			_, err := s.Refresh()
 			if err != nil {
 				log.Error(err, "unable to refresh upgrade config")
+				s.metricsClient.UpdateMetricUpgradeConfigSynced(UPGRADECONFIG_CR_NAME)
+				duration = durationWithJitter(ERROR_RETRY_DURATION, JITTER_FACTOR)
+			} else {
+				s.metricsClient.ResetMetricUpgradeConfigSynced(UPGRADECONFIG_CR_NAME)
+				duration = durationWithJitter(cfg.GetWatchInterval(), JITTER_FACTOR)
 			}
 		case <-stopCh:
 			log.Info("Stopping the upgradeConfigManager")


### PR DESCRIPTION
### What type of PR is this?

Feature

### What this PR does / why we need it?

This is a redux of the PR reverted by #154, a feature we can safely promote now that all clusters can talk to OCM.
Things fixed/added since the last PR:
- Fixed a cyclic import error by moving the new metric collector off to its own package.
- Added an exponential backoff (starts at 1min retries and doubles on each failure), up to a max of 1h

### Which Jira/Github issue(s) this PR fixes?

[OSD-5413](https://issues.redhat.com/browse/OSD-5413)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [X] Ran `make generate` command locally to validate code changes

