### PR TITLE
OSD-5867 read PDB timeout from cluster config

### DIFF
--- a/pkg/ocmprovider/ocmprovider.go
+++ b/pkg/ocmprovider/ocmprovider.go
@@ -89,13 +89,7 @@ type upgradePolicy struct {
 	Version              string               `json:"version"`
 	NextRun              string               `json:"next_run"`
 	PrevRun              string               `json:"prev_run"`
-	NodeDrainGracePeriod nodeDrainGracePeriod `json:"node_drain_grace_period"`
 	ClusterId            string               `json:"cluster_id"`
-}
-
-type nodeDrainGracePeriod struct {
-	Value int64  `json:"value"`
-	Unit  string `json:"unit"`
 }
 
 // Represents an unmarshalled Cluster List response from Cluster Services
@@ -111,6 +105,12 @@ type clusterList struct {
 type clusterInfo struct {
 	Id      string         `json:"id"`
 	Version clusterVersion `json:"version"`
+	NodeDrainGracePeriod nodeDrainGracePeriod `json:"node_drain_grace_period"`
+}
+
+type nodeDrainGracePeriod struct {
+	Value int64  `json:"value"`
+	Unit  string `json:"unit"`
 }
 
 type clusterVersion struct {
@@ -258,7 +258,7 @@ func buildUpgradeConfigSpecs(upgradePolicy *upgradePolicy, cluster *clusterInfo,
 			Channel: *upgradeChannel,
 		},
 		UpgradeAt:            upgradePolicy.NextRun,
-		PDBForceDrainTimeout: int32(upgradePolicy.NodeDrainGracePeriod.Value),
+		PDBForceDrainTimeout: int32(cluster.NodeDrainGracePeriod.Value),
 		Type:                 upgradev1alpha1.UpgradeType(upgradePolicy.UpgradeType),
 	}
 	upgradeConfigSpecs = append(upgradeConfigSpecs, upgradeConfigSpec)

--- a/pkg/ocmprovider/ocmprovider_test.go
+++ b/pkg/ocmprovider/ocmprovider_test.go
@@ -239,6 +239,10 @@ func clustersMock(w http.ResponseWriter, r *http.Request) {
 					Id:           "4.4.4",
 					ChannelGroup: TEST_UPGRADEPOLICY_CHANNELGROUP,
 				},
+				NodeDrainGracePeriod: nodeDrainGracePeriod{
+					Value: TEST_UPGRADEPOLICY_PDB_TIME,
+					Unit:  "minutes",
+				},
 			},
 		},
 	}
@@ -284,10 +288,6 @@ func policyMock(w http.ResponseWriter, r *http.Request) {
 				UpgradeType:  TEST_UPGRADEPOLICY_UPGRADETYPE,
 				Version:      TEST_UPGRADEPOLICY_VERSION,
 				NextRun:      TEST_UPGRADEPOLICY_TIME,
-				NodeDrainGracePeriod: nodeDrainGracePeriod{
-					Value: TEST_UPGRADEPOLICY_PDB_TIME,
-					Unit:  "minutes",
-				},
 				ClusterId: TEST_CLUSTER_ID,
 			},
 		},
@@ -313,10 +313,6 @@ func multiPolicyMock(w http.ResponseWriter, r *http.Request) {
 				UpgradeType:  TEST_UPGRADEPOLICY_UPGRADETYPE,
 				Version:      TEST_UPGRADEPOLICY_VERSION,
 				NextRun:      TEST_UPGRADEPOLICY_TIME,
-				NodeDrainGracePeriod: nodeDrainGracePeriod{
-					Value: TEST_UPGRADEPOLICY_PDB_TIME,
-					Unit:  "minutes",
-				},
 				ClusterId: TEST_CLUSTER_ID_MULTI_POLICIES,
 			},
 			{
@@ -328,10 +324,6 @@ func multiPolicyMock(w http.ResponseWriter, r *http.Request) {
 				UpgradeType:  TEST_UPGRADEPOLICY_UPGRADETYPE,
 				Version:      TEST_UPGRADEPOLICY_VERSION,
 				NextRun:      TEST_UPGRADEPOLICY_TIME_NEXT_OCCURRING,
-				NodeDrainGracePeriod: nodeDrainGracePeriod{
-					Value: TEST_UPGRADEPOLICY_PDB_TIME,
-					Unit:  "minutes",
-				},
 				ClusterId: TEST_CLUSTER_ID_MULTI_POLICIES,
 			},
 		},


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
Changes MUO to read the `nodeDrainGracePeriod` from the `clusters` service rather than `upgrade_policies`, which is its new home.

### Which Jira/Github issue(s) this PR fixes?

[OSD-5867](https://issues.redhat.com/browse/OSD-5867)

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

