### PR TITLE
Delete and re-create UpgradeConfig on spec change OSD-5970

### DIFF
--- a/pkg/upgradeconfigmanager/upgradeconfigmanager.go
+++ b/pkg/upgradeconfigmanager/upgradeconfigmanager.go
@@ -269,7 +269,7 @@ func (s *upgradeConfigManager) Refresh() (bool, error) {
 
 			// Confirm object is deleted prior to creating
 			if !confirmDeletedUpgrade {
-				wait.PollImmediate(5*time.Second, 60*time.Second, func() (bool, error) {
+				err = wait.PollImmediate(5*time.Second, 60*time.Second, func() (bool, error) {
 					_, err := s.Get()
 					if err != nil {
 						if err == ErrUpgradeConfigNotFound {
@@ -281,6 +281,9 @@ func (s *upgradeConfigManager) Refresh() (bool, error) {
 					}
 					return false, nil
 				})
+				if err != nil {
+					return false, fmt.Errorf("Unable to confirm deletion of current UpgradeConfig")
+				}
 			}
 		}
 

--- a/pkg/upgradeconfigmanager/upgradeconfigmanager.go
+++ b/pkg/upgradeconfigmanager/upgradeconfigmanager.go
@@ -259,7 +259,7 @@ func (s *upgradeConfigManager) Refresh() (bool, error) {
 			err = s.client.Delete(context.TODO(), currentUpgradeConfig, deleteOptions)
 			if err != nil {
 				if err == ErrUpgradeConfigNotFound {
-					log.Info("UpgradeConfig already delete")
+					log.Info("UpgradeConfig already deleted")
 					confirmDeletedUpgrade = true
 				} else {
 					log.Error(err, "can't remove UpgradeConfig during re-create")
@@ -282,7 +282,7 @@ func (s *upgradeConfigManager) Refresh() (bool, error) {
 					return false, nil
 				})
 				if err != nil {
-					return false, fmt.Errorf("Unable to confirm deletion of current UpgradeConfig")
+					return false, fmt.Errorf("Unable to confirm deletion of current UpgradeConfig: %v", err)
 				}
 			}
 		}

--- a/pkg/upgradeconfigmanager/upgradeconfigmanager_test.go
+++ b/pkg/upgradeconfigmanager/upgradeconfigmanager_test.go
@@ -337,7 +337,10 @@ var _ = Describe("UpgradeConfigManager", func() {
 					Type:                 "old type",
 				},
 			}
-			ErrUpgradeConfigNotFound := fmt.Errorf("upgrade config not found")
+			notFound := errors.NewNotFound(schema.GroupResource{
+				Group:    "test",
+				Resource: "test",
+			}, "test")
 
 			gomock.InOrder(
 				mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, *oldUpgradeConfig).Return(nil),
@@ -345,8 +348,8 @@ var _ = Describe("UpgradeConfigManager", func() {
 				mockCVClient.EXPECT().GetClusterVersion().Return(cv, nil),
 				mockSPClientBuilder.EXPECT().New(gomock.Any(), gomock.Any()).Return(mockSPClient, nil),
 				mockSPClient.EXPECT().Get().Return(upgradeConfigSpecs, nil),
-				mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()),
-				mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, *oldUpgradeConfig).Return(ErrUpgradeConfigNotFound),
+				mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
+				mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(notFound),
 				mockKubeClient.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
 					func(ctx context.Context, uc *upgradev1alpha1.UpgradeConfig) error {
 						Expect(uc.Name).To(Equal(TEST_UPGRADECONFIG_CR))

--- a/pkg/upgradeconfigmanager/upgradeconfigmanager_test.go
+++ b/pkg/upgradeconfigmanager/upgradeconfigmanager_test.go
@@ -301,7 +301,6 @@ var _ = Describe("UpgradeConfigManager", func() {
 				mockCVClient.EXPECT().GetClusterVersion().Return(cv, nil),
 				mockSPClientBuilder.EXPECT().New(gomock.Any(), gomock.Any()).Return(mockSPClient, nil),
 				mockSPClient.EXPECT().Get().Return(upgradeConfigSpecs, nil),
-				mockKubeClient.EXPECT().Update(gomock.Any(), gomock.Any()).Return(notFound),
 				mockKubeClient.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
 					func(ctx context.Context, uc *upgradev1alpha1.UpgradeConfig) error {
 						Expect(uc.Name).To(Equal(UPGRADECONFIG_CR_NAME))
@@ -345,7 +344,8 @@ var _ = Describe("UpgradeConfigManager", func() {
 				mockCVClient.EXPECT().GetClusterVersion().Return(cv, nil),
 				mockSPClientBuilder.EXPECT().New(gomock.Any(), gomock.Any()).Return(mockSPClient, nil),
 				mockSPClient.EXPECT().Get().Return(upgradeConfigSpecs, nil),
-				mockKubeClient.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(
+				mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any()),
+				mockKubeClient.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
 					func(ctx context.Context, uc *upgradev1alpha1.UpgradeConfig) error {
 						Expect(uc.Name).To(Equal(TEST_UPGRADECONFIG_CR))
 						Expect(uc.Namespace).To(Equal(TEST_OPERATOR_NAMESPACE))

--- a/pkg/upgradeconfigmanager/upgradeconfigmanager_test.go
+++ b/pkg/upgradeconfigmanager/upgradeconfigmanager_test.go
@@ -337,6 +337,7 @@ var _ = Describe("UpgradeConfigManager", func() {
 					Type:                 "old type",
 				},
 			}
+			ErrUpgradeConfigNotFound := fmt.Errorf("upgrade config not found")
 
 			gomock.InOrder(
 				mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, *oldUpgradeConfig).Return(nil),
@@ -344,7 +345,8 @@ var _ = Describe("UpgradeConfigManager", func() {
 				mockCVClient.EXPECT().GetClusterVersion().Return(cv, nil),
 				mockSPClientBuilder.EXPECT().New(gomock.Any(), gomock.Any()).Return(mockSPClient, nil),
 				mockSPClient.EXPECT().Get().Return(upgradeConfigSpecs, nil),
-				mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any()),
+				mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()),
+				mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, *oldUpgradeConfig).Return(ErrUpgradeConfigNotFound),
 				mockKubeClient.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
 					func(ctx context.Context, uc *upgradev1alpha1.UpgradeConfig) error {
 						Expect(uc.Name).To(Equal(TEST_UPGRADECONFIG_CR))
@@ -359,6 +361,5 @@ var _ = Describe("UpgradeConfigManager", func() {
 			Expect(err).To(BeNil())
 			Expect(changed).To(BeTrue())
 		})
-
 	})
 })


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
This resolves a racey condition where a new upgrade_policy was updating the current UpgradeConfig without deleting it. If the UpgradeConfig was in a failed state, the new upgrade_policy inherited that state rendering MUO unable to proceed with the new upgradepolicy specs updated into the current UpgradeConfig CR
### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-5970 

### Special notes for your reviewer:
Tested by deleting and re-creating upgrade policies that only differ in upgrade_start time as that is where the original condition was evident.

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [X] Ran `make generate` command locally to validate code changes