### PR TITLE
Reset metrics when upgrade failed OSD-6094

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -31,8 +31,10 @@ type Metrics interface {
 	UpdateMetricValidationSucceeded(string)
 	UpdateMetricClusterCheckFailed(string)
 	UpdateMetricClusterCheckSucceeded(string)
+	ResetMetricClusterCheck(string)
 	UpdateMetricScalingFailed(string)
 	UpdateMetricScalingSucceeded(string)
+	ResetMetricScaling(string)
 	UpdateMetricClusterVerificationFailed(string)
 	UpdateMetricClusterVerificationSucceeded(string)
 	UpdateMetricUpgradeWindowNotBreached(string)
@@ -199,6 +201,12 @@ func (c *Counter) UpdateMetricClusterCheckSucceeded(upgradeConfigName string) {
 		float64(0))
 }
 
+func (c *Counter) ResetMetricClusterCheck(upgradeConfigName string) {
+	metricClusterCheckFailed.With(prometheus.Labels{
+		nameLabel: upgradeConfigName}).Set(
+		float64(0))
+}
+
 func (c *Counter) UpdateMetricScalingFailed(upgradeConfigName string) {
 	metricScalingFailed.With(prometheus.Labels{
 		nameLabel: upgradeConfigName}).Set(
@@ -206,6 +214,12 @@ func (c *Counter) UpdateMetricScalingFailed(upgradeConfigName string) {
 }
 
 func (c *Counter) UpdateMetricScalingSucceeded(upgradeConfigName string) {
+	metricScalingFailed.With(prometheus.Labels{
+		nameLabel: upgradeConfigName}).Set(
+		float64(0))
+}
+
+func (c *Counter) ResetMetricScaling(upgradeConfigName string) {
 	metricScalingFailed.With(prometheus.Labels{
 		nameLabel: upgradeConfigName}).Set(
 		float64(0))

--- a/pkg/metrics/mocks/metrics.go
+++ b/pkg/metrics/mocks/metrics.go
@@ -105,6 +105,18 @@ func (mr *MockMetricsMockRecorder) ResetAllMetricNodeDrainFailed() *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetAllMetricNodeDrainFailed", reflect.TypeOf((*MockMetrics)(nil).ResetAllMetricNodeDrainFailed))
 }
 
+// ResetMetricClusterCheck mocks base method
+func (m *MockMetrics) ResetMetricClusterCheck(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ResetMetricClusterCheck", arg0)
+}
+
+// ResetMetricClusterCheck indicates an expected call of ResetMetricClusterCheck
+func (mr *MockMetricsMockRecorder) ResetMetricClusterCheck(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetMetricClusterCheck", reflect.TypeOf((*MockMetrics)(nil).ResetMetricClusterCheck), arg0)
+}
+
 // ResetMetricNodeDrainFailed mocks base method
 func (m *MockMetrics) ResetMetricNodeDrainFailed(arg0 string) {
 	m.ctrl.T.Helper()
@@ -115,6 +127,18 @@ func (m *MockMetrics) ResetMetricNodeDrainFailed(arg0 string) {
 func (mr *MockMetricsMockRecorder) ResetMetricNodeDrainFailed(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetMetricNodeDrainFailed", reflect.TypeOf((*MockMetrics)(nil).ResetMetricNodeDrainFailed), arg0)
+}
+
+// ResetMetricScaling mocks base method
+func (m *MockMetrics) ResetMetricScaling(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ResetMetricScaling", arg0)
+}
+
+// ResetMetricScaling indicates an expected call of ResetMetricScaling
+func (mr *MockMetricsMockRecorder) ResetMetricScaling(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetMetricScaling", reflect.TypeOf((*MockMetrics)(nil).ResetMetricScaling), arg0)
 }
 
 // ResetMetricUpgradeConfigSynced mocks base method

--- a/pkg/osd_cluster_upgrader/upgrader.go
+++ b/pkg/osd_cluster_upgrader/upgrader.go
@@ -635,6 +635,10 @@ func performUpgradeFailure(metricsClient metrics.Metrics, nc eventmanager.EventM
 	// flag window breached metric
 	metricsClient.UpdateMetricUpgradeWindowBreached(upgradeConfig.Name)
 
+	// cancel previously triggered metrics
+	metricsClient.ResetMetricScaling(upgradeConfig.Name)
+	metricsClient.ResetMetricClusterCheck(upgradeConfig.Name)
+
 	return nil
 }
 

--- a/pkg/osd_cluster_upgrader/upgrader_test.go
+++ b/pkg/osd_cluster_upgrader/upgrader_test.go
@@ -560,6 +560,8 @@ var _ = Describe("ClusterUpgrader", func() {
 						mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(false, nil),
 						mockEMClient.EXPECT().Notify(notifier.StateFailed),
 						mockMetricsClient.EXPECT().UpdateMetricUpgradeWindowBreached(upgradeConfig.Name),
+						mockMetricsClient.EXPECT().ResetMetricScaling(upgradeConfig.Name),
+						mockMetricsClient.EXPECT().ResetMetricClusterCheck(upgradeConfig.Name),
 					)
 					phase, condition, err := cu.UpgradeCluster(upgradeConfig, logger)
 					Expect(phase).To(Equal(upgradev1alpha1.UpgradePhaseFailed))


### PR DESCRIPTION
Created reset functions for metrics that are triggered prior to an
upgrade being cancelled due to upgrade window timeout

### What type of PR is this?
bug

### What this PR does / why we need it?
Correctly resets metrics after a failed upgrade

### Which Jira/Github issue(s) this PR fixes?
[OSD-6094](https://issues.redhat.com/browse/OSD-6094)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [x] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

