### PR TITLE
Add report status from OSD operators to OCM

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -14,11 +14,18 @@ parameters:
   - name: REPO_NAME
     value: managed-upgrade-operator
     required: true
+  - name: OPERATOR_NAME
+    value: managed-upgrade-operator
+    required: true
 
 objects:
   - apiVersion: hive.openshift.io/v1
     kind: SelectorSyncSet
     metadata:
+    annotations:
+      component-display-name: Managed Upgrade Operator
+      component-name: ${OPERATOR_NAME}
+      telemeter-query: csv_succeeded{_id="$CLUSTER_ID",name=~"${OPERATOR_NAME}.*",exported_namespace=~"openshift-.*",namespace="openshift-operator-lifecycle-manager"} == 1
       labels:
         managed.openshift.io/gitHash: ${IMAGE_TAG}
         managed.openshift.io/gitRepoName: ${REPO_NAME}


### PR DESCRIPTION
### What type of PR is this?
_feature_


### What this PR does / why we need it?

Part of https://issues.redhat.com/browse/SDE-591

parsing the template using `oc process --local -f` looks like this:

```
"telemeter-query": "csv_succeeded{_id=\"$CLUSTER_ID\",name=~\"managed-upgrade-operator.*\",exported_namespace=~\"openshift-.*\",namespace=\"openshift-operator-lifecycle-manager\"} == 1"
```

The `CLUSTER_ID` parameter is not going to be replaced via this template, but from OCM.

### Which Jira/Github issue(s) this PR fixes?

Fixes https://issues.redhat.com/browse/SDE-591 (part of it)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

