### PR TITLE
add resource limit/request for the operator

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -34,6 +34,13 @@ spec:
           command:
           - managed-upgrade-operator
           imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 5m
+              memory: 50Mi
+            limits:
+              cpu: 20m
+              memory: 100Mi
           env:
             - name: WATCH_NAMESPACE
               valueFrom:


### PR DESCRIPTION
set the resource limits/requests for the operator

based on the usage for a running cluster, the cpu usage will be around 2.5m and the memory usage will be around 50M
Set the requests so that the pod will be scheduled only when the node has enough resources
and also the limits in case the operator eating up the resources


### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

