### PR TITLE
Revert "OSD-6179 Use upgrade_channel_group for channel data"

### DIFF
--- a/pkg/notifier/ocmnotifier_test.go
+++ b/pkg/notifier/ocmnotifier_test.go
@@ -78,9 +78,9 @@ var _ = Describe("OCM Notifier", func() {
 			}
 			cluster = ocm.ClusterInfo{
 				Id: TEST_CLUSTER_ID,
-				UpgradeChannelGroup: TEST_UPGRADEPOLICY_CHANNELGROUP,
 				Version: ocm.ClusterVersion{
 					Id:           "4.4.4",
+					ChannelGroup: TEST_UPGRADEPOLICY_CHANNELGROUP,
 				},
 			}
 			upgradePolicyListResponse = ocm.UpgradePolicyList{

--- a/pkg/ocm/client_test.go
+++ b/pkg/ocm/client_test.go
@@ -70,9 +70,9 @@ var _ = Describe("OCM Client", func() {
 			Items: []ClusterInfo{
 				{
 					Id: TEST_CLUSTER_ID,
-					UpgradeChannelGroup: TEST_UPGRADEPOLICY_CHANNELGROUP,
 					Version: ClusterVersion{
 						Id:           "4.4.4",
+						ChannelGroup: TEST_UPGRADEPOLICY_CHANNELGROUP,
 					},
 					NodeDrainGracePeriod: NodeDrainGracePeriod{
 						Value: TEST_UPGRADEPOLICY_PDB_TIME,

--- a/pkg/ocm/model.go
+++ b/pkg/ocm/model.go
@@ -11,16 +11,16 @@ type UpgradePolicyList struct {
 
 // Represents an unmarshalled individual Upgrade Policy response from Cluster Services
 type UpgradePolicy struct {
-	Id           string `json:"id"`
-	Kind         string `json:"kind"`
-	Href         string `json:"href"`
-	Schedule     string `json:"schedule"`
-	ScheduleType string `json:"schedule_type"`
-	UpgradeType  string `json:"upgrade_type"`
-	Version      string `json:"version"`
-	NextRun      string `json:"next_run"`
-	PrevRun      string `json:"prev_run"`
-	ClusterId    string `json:"cluster_id"`
+	Id                   string               `json:"id"`
+	Kind                 string               `json:"kind"`
+	Href                 string               `json:"href"`
+	Schedule             string               `json:"schedule"`
+	ScheduleType         string               `json:"schedule_type"`
+	UpgradeType          string               `json:"upgrade_type"`
+	Version              string               `json:"version"`
+	NextRun              string               `json:"next_run"`
+	PrevRun              string               `json:"prev_run"`
+	ClusterId            string               `json:"cluster_id"`
 }
 
 // Represents an unmarshalled Cluster List response from Cluster Services
@@ -34,9 +34,8 @@ type ClusterList struct {
 
 // Represents a partial unmarshalled Cluster response from Cluster Services
 type ClusterInfo struct {
-	Id                   string               `json:"id"`
-	UpgradeChannelGroup  string               `json:"upgrade_channel_group"`
-	Version              ClusterVersion       `json:"version"`
+	Id      string         `json:"id"`
+	Version ClusterVersion `json:"version"`
 	NodeDrainGracePeriod NodeDrainGracePeriod `json:"node_drain_grace_period"`
 }
 
@@ -63,3 +62,5 @@ type UpgradePolicyState struct {
 	Value       string `json:"value"`
 	Description string `json:"description"`
 }
+
+

--- a/pkg/ocmprovider/ocmprovider.go
+++ b/pkg/ocmprovider/ocmprovider.go
@@ -63,7 +63,7 @@ func (s *ocmProvider) Get() ([]upgradev1alpha1.UpgradeConfigSpec, error) {
 	if cluster.Id == "" {
 		return nil, ErrClusterIdNotFound
 	}
-	if cluster.UpgradeChannelGroup == "" {
+	if cluster.Version.ChannelGroup == "" {
 		return nil, ErrMissingChannelGroup
 	}
 
@@ -156,9 +156,9 @@ func buildUpgradeConfigSpecs(upgradePolicy *ocm.UpgradePolicy, cluster *ocm.Clus
 
 	upgradeConfigSpecs := make([]upgradev1alpha1.UpgradeConfigSpec, 0)
 
-	upgradeChannel, err := inferUpgradeChannelFromChannelGroup(cluster.UpgradeChannelGroup, upgradePolicy.Version)
+	upgradeChannel, err := inferUpgradeChannelFromChannelGroup(cluster.Version.ChannelGroup, upgradePolicy.Version)
 	if err != nil {
-		return nil, fmt.Errorf("unable to determine channel from channel group '%v' and version '%v' for policy ID '%v'", cluster.UpgradeChannelGroup, upgradePolicy.Version, upgradePolicy.Id)
+		return nil, fmt.Errorf("unable to determine channel from channel group '%v' and version '%v' for policy ID '%v'", cluster.Version.ChannelGroup, upgradePolicy.Version, upgradePolicy.Id)
 	}
 	upgradeConfigSpec := upgradev1alpha1.UpgradeConfigSpec{
 		Desired: upgradev1alpha1.Update{

--- a/pkg/ocmprovider/ocmprovider_test.go
+++ b/pkg/ocmprovider/ocmprovider_test.go
@@ -104,10 +104,11 @@ var _ = Describe("OCM Provider", func() {
 
 		BeforeEach(func() {
 			cluster = ocm.ClusterInfo{
+
 				Id: TEST_CLUSTER_ID,
-				UpgradeChannelGroup: TEST_UPGRADEPOLICY_CHANNELGROUP,
 				Version: ocm.ClusterVersion{
 					Id:           "4.4.4",
+					ChannelGroup: TEST_UPGRADEPOLICY_CHANNELGROUP,
 				},
 				NodeDrainGracePeriod: ocm.NodeDrainGracePeriod{
 					Value: TEST_UPGRADEPOLICY_PDB_TIME,


### PR DESCRIPTION
### What type of PR is this?

This reverts commit b2ff002414c076660486771c7699b499c66b41cd. ([OSD-6179](https://issues.redhat.com/browse/OSD-6179))

### What this PR does / why we need it?

As part of [SDA-3675](https://issues.redhat.com/browse/SDA-3675) it has been decided that we're going to revert back to using `version.channel_group` rather than `upgrade_channel_group` for determining the upgrade channel.

### Which Jira/Github issue(s) this PR fixes?

[OSD-6479](https://issues.redhat.com/browse/OSD-6479)
[SDA-3675](https://issues.redhat.com/browse/SDA-3675)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR
