### PR TITLE
OSD-6474 Don't use the channel in version comparisons

### DIFF
--- a/pkg/clusterversion/cv.go
+++ b/pkg/clusterversion/cv.go
@@ -146,8 +146,7 @@ func (c *clusterVersionClient) HasUpgradeCompleted(cv *configv1.ClusterVersion, 
 // isEqualVersion compare the upgrade version state for cv and uc
 func isEqualVersion(cv *configv1.ClusterVersion, uc *upgradev1alpha1.UpgradeConfig) bool {
 	if cv.Spec.DesiredUpdate != nil &&
-		cv.Spec.DesiredUpdate.Version == uc.Spec.Desired.Version &&
-		cv.Spec.Channel == uc.Spec.Desired.Channel {
+		cv.Spec.DesiredUpdate.Version == uc.Spec.Desired.Version {
 		return true
 	}
 


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
Stop MUO considering the `channel` when checking if the `clusterversion` version is equal to the version in `UpgradeConfig`.

This is currently causing issues when:
- MUO upgrades clusters using a version+channel which differs from the channel in the `clusterdeployment`'s `api.openshift/com/channel-group` label.
- Any y-stream upgrades. 

This is because the [MCC channel patching](https://github.com/openshift/managed-cluster-config/tree/master/deploy/osd-channel-patch) ends up changing the cluster's `clusterversion` channel to something different to that in the `UpgradeConfig`, causing the `isEqualVersion` check to fail.

This change does not impact MUO's logic when changing the cluster's channel, as it does not use the `isEqualVersion` function. (see: `EnsureDesiredVersion`)

### Which Jira/Github issue(s) this PR fixes?

[OSD-6474](https://issues.redhat.com/browse/OSD-6474)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

