### PR TITLE
OSD-6268 Add context descriptions to failure events

### DIFF
--- a/pkg/eventmanager/eventmanager.go
+++ b/pkg/eventmanager/eventmanager.go
@@ -11,15 +11,15 @@ import (
 )
 
 const (
-	UPGRADE_PRECHECK_FAILED_DESC       = "Cluster upgrade to version %s failed as the cluster did not pass its pre-upgrade verification checks."
-	UPGRADE_PREHEALTHCHECK_FAILED_DESC = "Cluster upgrade to version %s failed on the Pre-Health Check step. Health alerts are firing in the cluster which could impact the upgrade's operation, so the upgrade did not proceed."
-	UPGRADE_EXTDEPCHECK_FAILED_DESC    = "Cluster upgrade to version %s failed on the External Dependency Availability Check step. A dependency of the upgrade was deemed un-available, so the upgrade did not proceed."
-	UPGRADE_SCALE_FAILED_DESC          = "Cluster upgrade to version %s failed on the Scale-Up Worker Node step. A temporary additional worker node was unable to be created to temporarily house workloads, so the upgrade did not proceed."
+	UPGRADE_PRECHECK_FAILED_DESC       = "Cluster upgrade to version %s was cancelled as the cluster did not pass its pre-upgrade verification checks. Automated upgrades will be retried on their next scheduling cycle. If you have manually scheduled an upgrade instead, it must now be rescheduled."
+	UPGRADE_PREHEALTHCHECK_FAILED_DESC = "Cluster upgrade to version %s was cancelled during the Pre-Health Check step. Health alerts are firing in the cluster which could impact the upgrade's operation, so the upgrade did not proceed. Automated upgrades will be retried on their next scheduling cycle. If you have manually scheduled an upgrade instead, it must now be rescheduled."
+	UPGRADE_EXTDEPCHECK_FAILED_DESC    = "Cluster upgrade to version %s was cancelled during the External Dependency Availability Check step. A required external dependency of the upgrade was unavailable, so the upgrade did not proceed. Automated upgrades will be retried on their next scheduling cycle. If you have manually scheduled an upgrade instead, it must now be rescheduled."
+	UPGRADE_SCALE_FAILED_DESC          = "Cluster upgrade to version %s was cancelled during the Scale-Up Worker Node step. A temporary additional worker node was unable to be created to temporarily house workloads, so the upgrade did not proceed. Automated upgrades will be retried on their next scheduling cycle. If you have manually scheduled an upgrade instead, it must now be rescheduled."
 
-	UPGRADE_DEFAULT_DELAY_DESC        = "Cluster upgrade to version %s is currently delayed"
-	UPGRADE_PREHEALTHCHECK_DELAY_DESC = "Cluster upgrade to version %s is currently delayed as health alerts are firing in the cluster which could impact the upgrade's operation."
-	UPGRADE_EXTDEPCHECK_DELAY_DESC    = "Cluster upgrade to version %s is currently delayed as an external dependency of the upgrade is currently un-available."
-	UPGRADE_SCALE_DELAY_DESC          = "Cluster upgrade to version %s is currently delayed attempting to scale up an additional worker node."
+	UPGRADE_DEFAULT_DELAY_DESC        = "Cluster upgrade to version %s is experiencing a delay whilst it performs necessary pre-upgrade procedures. The upgrade will continue to retry. This is an informational notification and no action is required."
+	UPGRADE_PREHEALTHCHECK_DELAY_DESC = "Cluster upgrade to version %s is experiencing a delay as health alerts are firing in the cluster which could impact the upgrade's operation. The upgrade will continue to retry. This is an informational notification and no action is required by you."
+	UPGRADE_EXTDEPCHECK_DELAY_DESC    = "Cluster upgrade to version %s is experiencing a delay as an external dependency of the upgrade is currently unavailable. The upgrade will continue to retry. This is an informational notification and no action is required by you."
+	UPGRADE_SCALE_DELAY_DESC          = "Cluster upgrade to version %s is experiencing a delay attempting to scale up an additional worker node. The upgrade will continue to retry. This is an informational notification and no action is required by you."
 )
 
 //go:generate mockgen -destination=mocks/eventmanager.go -package=mocks github.com/openshift/managed-upgrade-operator/pkg/eventmanager EventManager

--- a/pkg/eventmanager/eventmanager.go
+++ b/pkg/eventmanager/eventmanager.go
@@ -2,8 +2,7 @@ package eventmanager
 
 import (
 	"fmt"
-	"time"
-
+	"github.com/openshift/managed-upgrade-operator/pkg/apis/upgrade/v1alpha1"
 	"github.com/openshift/managed-upgrade-operator/pkg/configmanager"
 	"github.com/openshift/managed-upgrade-operator/pkg/metrics"
 	"github.com/openshift/managed-upgrade-operator/pkg/notifier"
@@ -12,7 +11,10 @@ import (
 )
 
 const (
-	REFRESH_INTERVAL = 5 * time.Minute
+	UPGRADE_PRECHECK_FAILED_DESC = "Upgrade failed as the cluster did not pass its pre-upgrade verification checks."
+	UPGRADE_PREHEALTHCHECK_FAILED_DESC = "Upgrade failed on the Pre-Health Check step. Health alerts are firing in the cluster which could impact the upgrade's operation, so the upgrade did not proceed."
+	UPGRADE_EXTDEPCHECK_FAILED_DESC = "Upgrade failed on the External Dependency Availability Check step. A dependency of the upgrade was deemed un-available, so the upgrade did not proceed."
+	UPGRADE_SCALE_FAILED_DESC = "Upgrade failed on the Scale-Up Worker Node step. A temporary additional worker node was unable to be created to temporarily house workloads, so the upgrade did not proceed."
 )
 
 //go:generate mockgen -destination=mocks/eventmanager.go -package=mocks github.com/openshift/managed-upgrade-operator/pkg/eventmanager EventManager
@@ -94,7 +96,7 @@ func (s *eventManager) Notify(state notifier.NotifyState) error {
 	case notifier.StateCompleted:
 		description = fmt.Sprintf("Cluster has been successfully upgraded to version %s", uc.Spec.Desired.Version)
 	case notifier.StateFailed:
-		description = "Cluster did not pass its pre-upgrade verification checks"
+		description = createFailureDescription(uc)
 	default:
 		return fmt.Errorf("state %v not yet implemented", state)
 	}
@@ -107,4 +109,48 @@ func (s *eventManager) Notify(state notifier.NotifyState) error {
 	s.metrics.UpdateMetricNotificationEventSent(uc.Name, string(state), uc.Spec.Desired.Version)
 
 	return nil
+}
+
+// Generates a Failure notification description based on the UpgradeConfig's last failed state
+func createFailureDescription(uc *v1alpha1.UpgradeConfig) string {
+	// Default failure message
+	var description = UPGRADE_PRECHECK_FAILED_DESC
+
+	history := uc.Status.History.GetHistory(uc.Spec.Desired.Version)
+	// Handle a missing history
+	if history == nil {
+		return description
+	}
+	// Handle no conditions available
+	if len(history.Conditions) == 0 {
+		return description
+	}
+
+	// Find the condition which will describe what step the upgrade got to
+	var failedCondition v1alpha1.UpgradeCondition
+	foundFailedCondition := false
+	for _, condition := range history.Conditions {
+		// Find the first incomplete condition (should only be one)
+		if condition.IsFalse() {
+			failedCondition = condition
+			foundFailedCondition = true
+			break
+		}
+	}
+
+	// No incomplete condition? Just return default
+	if !foundFailedCondition {
+		return description
+	}
+
+	switch failedCondition.Type {
+	case v1alpha1.UpgradePreHealthCheck:
+		description = UPGRADE_PREHEALTHCHECK_FAILED_DESC
+	case v1alpha1.ExtDepAvailabilityCheck:
+		description = UPGRADE_EXTDEPCHECK_FAILED_DESC
+	case v1alpha1.UpgradeScaleUpExtraNodes:
+		description = UPGRADE_SCALE_FAILED_DESC
+	}
+
+	return description
 }

--- a/pkg/eventmanager/eventmanager_test.go
+++ b/pkg/eventmanager/eventmanager_test.go
@@ -138,10 +138,11 @@ var _ = Describe("OCM Notifier", func() {
 						Message:            "There are 2 critical alerts",
 					},
 				}
+				expectedDescription := fmt.Sprintf(UPGRADE_PREHEALTHCHECK_FAILED_DESC, uc.Spec.Desired.Version)
 				gomock.InOrder(
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION).Return(false, nil),
-					mockNotifier.EXPECT().NotifyState(testState, UPGRADE_PREHEALTHCHECK_FAILED_DESC),
+					mockNotifier.EXPECT().NotifyState(testState, expectedDescription),
 					mockMetricsClient.EXPECT().UpdateMetricNotificationEventSent(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION),
 				)
 				err := manager.Notify(testState)
@@ -159,10 +160,11 @@ var _ = Describe("OCM Notifier", func() {
 						Message:            "An external dependency is down.",
 					},
 				}
+				expectedDescription := fmt.Sprintf(UPGRADE_EXTDEPCHECK_FAILED_DESC, uc.Spec.Desired.Version)
 				gomock.InOrder(
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION).Return(false, nil),
-					mockNotifier.EXPECT().NotifyState(testState, UPGRADE_EXTDEPCHECK_FAILED_DESC),
+					mockNotifier.EXPECT().NotifyState(testState, expectedDescription),
 					mockMetricsClient.EXPECT().UpdateMetricNotificationEventSent(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION),
 				)
 				err := manager.Notify(testState)
@@ -180,10 +182,11 @@ var _ = Describe("OCM Notifier", func() {
 						Message:            "Cannot scale nodes.",
 					},
 				}
+				expectedDescription := fmt.Sprintf(UPGRADE_SCALE_FAILED_DESC, uc.Spec.Desired.Version)
 				gomock.InOrder(
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION).Return(false, nil),
-					mockNotifier.EXPECT().NotifyState(testState, UPGRADE_SCALE_FAILED_DESC),
+					mockNotifier.EXPECT().NotifyState(testState, expectedDescription),
 					mockMetricsClient.EXPECT().UpdateMetricNotificationEventSent(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION),
 				)
 				err := manager.Notify(testState)
@@ -201,10 +204,115 @@ var _ = Describe("OCM Notifier", func() {
 						Message:            "in your neighbourhood",
 					},
 				}
+				expectedDescription := fmt.Sprintf(UPGRADE_PRECHECK_FAILED_DESC, uc.Spec.Desired.Version)
 				gomock.InOrder(
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION).Return(false, nil),
-					mockNotifier.EXPECT().NotifyState(testState, UPGRADE_PRECHECK_FAILED_DESC),
+					mockNotifier.EXPECT().NotifyState(testState, expectedDescription),
+					mockMetricsClient.EXPECT().UpdateMetricNotificationEventSent(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION),
+				)
+				err := manager.Notify(testState)
+				Expect(err).To(BeNil())
+			})
+		})
+
+	})
+
+	Context("When notifying a delayed state", func() {
+		var uc upgradev1alpha1.UpgradeConfig
+		var testState = notifier.StateDelayed
+		BeforeEach(func() {
+			upgradeConfigName = types.NamespacedName{
+				Name:      TEST_UPGRADECONFIG_CR,
+				Namespace: TEST_OPERATOR_NAMESPACE,
+			}
+			uc = *testStructs.NewUpgradeConfigBuilder().WithNamespacedName(upgradeConfigName).WithPhase(upgradev1alpha1.UpgradePhaseUpgrading).GetUpgradeConfig()
+			uc.Spec.Desired.Version = TEST_UPGRADE_VERSION
+			uc.Status.History[0].Version = TEST_UPGRADE_VERSION
+			uc.Spec.UpgradeAt = TEST_UPGRADE_TIME
+		})
+
+		Context("when the pre-health-check failed", func() {
+			It("sends a correct notification and description", func() {
+				uc.Status.History[0].Conditions = []upgradev1alpha1.UpgradeCondition{
+					{
+						Type:               upgradev1alpha1.UpgradePreHealthCheck,
+						Status:             "False",
+						Reason:             "PreHealthCheck not done",
+						Message:            "There are 2 critical alerts",
+					},
+				}
+				expectedDescription := fmt.Sprintf(UPGRADE_PREHEALTHCHECK_DELAY_DESC, uc.Spec.Desired.Version)
+				gomock.InOrder(
+					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
+					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION).Return(false, nil),
+					mockNotifier.EXPECT().NotifyState(testState, expectedDescription),
+					mockMetricsClient.EXPECT().UpdateMetricNotificationEventSent(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION),
+				)
+				err := manager.Notify(testState)
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("when the external dependency check failed", func() {
+			It("sends a correct notification and description", func() {
+				uc.Status.History[0].Conditions = []upgradev1alpha1.UpgradeCondition{
+					{
+						Type:               upgradev1alpha1.ExtDepAvailabilityCheck,
+						Status:             "False",
+						Reason:             "ExtDepAvailabilityCheck not done",
+						Message:            "An external dependency is down.",
+					},
+				}
+				expectedDescription := fmt.Sprintf(UPGRADE_EXTDEPCHECK_DELAY_DESC, uc.Spec.Desired.Version)
+				gomock.InOrder(
+					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
+					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION).Return(false, nil),
+					mockNotifier.EXPECT().NotifyState(testState, expectedDescription),
+					mockMetricsClient.EXPECT().UpdateMetricNotificationEventSent(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION),
+				)
+				err := manager.Notify(testState)
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("when the scale up fails", func() {
+			It("sends a correct notification and description", func() {
+				uc.Status.History[0].Conditions = []upgradev1alpha1.UpgradeCondition{
+					{
+						Type:               upgradev1alpha1.UpgradeScaleUpExtraNodes,
+						Status:             "False",
+						Reason:             "UpgradeScaleUpExtraNodes not done",
+						Message:            "Cannot scale nodes.",
+					},
+				}
+				expectedDescription := fmt.Sprintf(UPGRADE_SCALE_DELAY_DESC, uc.Spec.Desired.Version)
+				gomock.InOrder(
+					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
+					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION).Return(false, nil),
+					mockNotifier.EXPECT().NotifyState(testState, expectedDescription),
+					mockMetricsClient.EXPECT().UpdateMetricNotificationEventSent(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION),
+				)
+				err := manager.Notify(testState)
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("when an indeterminate failure occurs", func() {
+			It("sends a correct default notification and description", func() {
+				uc.Status.History[0].Conditions = []upgradev1alpha1.UpgradeCondition{
+					{
+						Type:               upgradev1alpha1.CommenceUpgrade,
+						Status:             "False",
+						Reason:             "something strange",
+						Message:            "in your neighbourhood",
+					},
+				}
+				expectedDescription := fmt.Sprintf(UPGRADE_DEFAULT_DELAY_DESC, uc.Spec.Desired.Version)
+				gomock.InOrder(
+					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
+					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION).Return(false, nil),
+					mockNotifier.EXPECT().NotifyState(testState, expectedDescription),
 					mockMetricsClient.EXPECT().UpdateMetricNotificationEventSent(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION),
 				)
 				err := manager.Notify(testState)


### PR DESCRIPTION
### What type of PR is this?

Feature

### What this PR does / why we need it?

This PR adds more expressive failure descriptions to the upgrade policy states sent to OCM. The following failure scenarios now have descriptions which convey which step failed:
- Pre-health check
- External dependency check
- Worker node scale up

### Which Jira/Github issue(s) this PR fixes?

[OSD-6268](https://issues.redhat.com/browse/OSD-6268)

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
