### PR TITLE
OSD-6746 use CVO availableUpdates for validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,14 +13,12 @@ require (
 	github.com/golang/mock v1.4.4
 	github.com/golang/protobuf v1.4.1 // indirect
 	github.com/golangci/golangci-lint v1.27.0
-	github.com/google/uuid v1.1.1
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/jarcoal/httpmock v1.0.6
 	github.com/jpillora/backoff v1.0.0
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.10.0
 	github.com/openshift/api v0.0.0-20200522173408-17ada6e4245b
-	github.com/openshift/cluster-version-operator v3.11.1-0.20190629164025-08cac1c02538+incompatible
 	github.com/openshift/machine-api-operator v0.2.1-0.20200226185612-9b0170a1ba07
 	github.com/openshift/machine-config-operator v4.2.0-alpha.0.0.20190917115525-033375cbe820+incompatible
 	github.com/operator-framework/api v0.3.6

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -3,16 +3,11 @@ package validation
 
 import (
 	"fmt"
-	"net/url"
-	"runtime"
 	"time"
 
 	"github.com/blang/semver"
 	"github.com/go-logr/logr"
-	"github.com/google/uuid"
 	configv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/cluster-version-operator/pkg/cincinnati"
-
 	upgradev1alpha1 "github.com/openshift/managed-upgrade-operator/pkg/apis/upgrade/v1alpha1"
 	cv "github.com/openshift/managed-upgrade-operator/pkg/clusterversion"
 )
@@ -121,52 +116,18 @@ func (v *validator) IsValidUpgradeConfig(uC *upgradev1alpha1.UpgradeConfig, cV *
 		logger.Info(fmt.Sprintf("Desired version %s validated as greater then current version %s", desiredVersion, currentVersion))
 	}
 
-	// Validate available version is in Cincinnati.
-	desiredChannel := uC.Spec.Desired.Channel
-	clusterId, err := uuid.Parse(string(cV.Spec.ClusterID))
-	if err != nil {
-		return ValidatorResult{
-			IsValid:           false,
-			IsAvailableUpdate: false,
-			Message:           "",
-		}, nil
-	}
-	upstreamURI, err := url.Parse(string(cV.Spec.Upstream))
-	if err != nil {
-		return ValidatorResult{
-			IsValid:           false,
-			IsAvailableUpdate: false,
-			Message:           "",
-		}, nil
-	}
-
-	updates, err := cincinnati.NewClient(clusterId, nil, nil).GetUpdates(upstreamURI, runtime.GOARCH, desiredChannel, currentVersion)
-	if err != nil {
-		return ValidatorResult{
-			IsValid:           false,
-			IsAvailableUpdate: false,
-			Message:           "",
-		}, err
-	}
-
-	var cvoUpdates []configv1.Update
-	for _, update := range updates {
-		cvoUpdates = append(cvoUpdates, configv1.Update{
-			Version: update.Version.String(),
-			Image:   update.Image,
-		})
-	}
-
-	// Check whether the desired version exists in availableUpdates
-	found := false
-	for _, v := range cvoUpdates {
-		if v.Version == dv && !v.Force {
-			found = true
+	// Validate available version is in CVO's availableUpdates
+	foundAvailableUpdate := false
+	for _, update := range cV.Status.AvailableUpdates {
+		// Ensure version exists
+		if update.Version == dv {
+			foundAvailableUpdate = true
 		}
+		// We can't check channel here yet, it's not present in OCP 4.5
 	}
 
-	if !found {
-		logger.Info(fmt.Sprintf("Failed to find the desired version %s in channel %s", desiredVersion, desiredChannel))
+	if !foundAvailableUpdate {
+		logger.Info(fmt.Sprintf("Failed to find the desired version %s in clusterversion's availableUpdates", desiredVersion))
 		return ValidatorResult{
 			IsValid:           false,
 			IsAvailableUpdate: false,


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
This PR removes Cincinnati validation from the version validator and replaces it with a check of CVO's `availableUpdates`. There are a couple of motivations for this:
- The `upstream` URL is not guaranteed to be present in `clusterversion` and in 4.7 clusters it has been observed as missing. This breaks the validator which currently has a hard dependency on `upstream` being present in order to discern the Cincinnati URL.
- As channel group change during upgrade is no longer possible for OCM-driven upgrades, the cluster's `availableUpdates` should be a true representation of what Cincinnati would tell MUO anyway.

### Which Jira/Github issue(s) this PR fixes?
[OSD-6746](https://issues.redhat.com/browse/OSD-6746)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster (tested both 4.6 and 4.7 clusters)
