### PR TITLE
OSD-6688 Add a drain strategy for pods stuck terminating

### DIFF
--- a/pkg/drain/nodeDrainStrategy.go
+++ b/pkg/drain/nodeDrainStrategy.go
@@ -18,6 +18,7 @@ var (
 	pdbPodDeleteName               = "PDB-DELETE"
 	defaultPodFinalizerRemovalName = "DEFAULT-FINALIZER"
 	pdbPodFinalizerRemovalName     = "PDB-FINALIZER"
+	stuckTerminatingPodName        = "POD-STUCK-TERMINATING"
 )
 
 func NewNodeDrainStrategy(c client.Client, cfg *NodeDrain, ts []TimedDrainStrategy) (NodeDrainStrategy, error) {

--- a/pkg/drain/osd_drain_strategy_test.go
+++ b/pkg/drain/osd_drain_strategy_test.go
@@ -422,5 +422,28 @@ var _ = Describe("OSD Drain Strategy", func() {
 				Expect(len(filteredPods.Items)).To(Equal(0))
 			})
 		})
+		Context("Pods terminating", func() {
+			It("should return pods that are terminating", func() {
+				podList = &corev1.PodList{
+					Items: []corev1.Pod{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								DeletionTimestamp: &metav1.Time{Time: time.Now()},
+							},
+						},
+					},
+				}
+				filteredPods := pod.FilterPods(podList, isTerminating)
+				Expect(len(filteredPods.Items)).To(Equal(1))
+			})
+			It("should not return pods that are not terminating", func() {
+				podList = &corev1.PodList{
+					Items: []corev1.Pod{{}},
+				}
+				filteredPods := pod.FilterPods(podList, isTerminating)
+				Expect(len(filteredPods.Items)).To(Equal(0))
+			})
+		})
+
 	})
 })

--- a/pkg/drain/podDeleteStrategy.go
+++ b/pkg/drain/podDeleteStrategy.go
@@ -21,7 +21,7 @@ func (pds *podDeletionStrategy) Execute(node *corev1.Node) (*DrainStrategyResult
 	}
 
 	gp := int64(0)
-	res, err := pod.DeletePods(pds.client, podsToDelete, &client.DeleteOptions{GracePeriodSeconds: &gp})
+	res, err := pod.DeletePods(pds.client, podsToDelete, true, &client.DeleteOptions{GracePeriodSeconds: &gp})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/drain/pod_predicates.go
+++ b/pkg/drain/pod_predicates.go
@@ -60,3 +60,12 @@ func containsMatchLabel(p corev1.Pod, pdbList *policyv1beta1.PodDisruptionBudget
 func hasFinalizers(p corev1.Pod) bool {
 	return len(p.ObjectMeta.GetFinalizers()) > 0
 }
+
+func hasNoFinalizers(p corev1.Pod) bool {
+	return len(p.ObjectMeta.GetFinalizers()) == 0
+}
+
+func isTerminating(p corev1.Pod) bool {
+	return p.DeletionTimestamp != nil
+}
+

--- a/pkg/drain/strategy.go
+++ b/pkg/drain/strategy.go
@@ -79,6 +79,10 @@ func (dsb *drainStrategyBuilder) NewNodeDrainStrategy(c client.Client, uc *upgra
 			client:  c,
 			filters: append(defaultOsdPodPredicates, isNotPdbPod),
 		}),
+		newTimedStrategy(stuckTerminatingPodName, "Pod stuck terminating removal", defaultDuration, &stuckTerminatingStrategy{
+			client:  c,
+			filters: append(defaultOsdPodPredicates, isNotPdbPod),
+		}),
 		newTimedStrategy(pdbPodDeleteName, "PDB pod deletion", pdbDuration, &podDeletionStrategy{
 			client:  c,
 			filters: append(defaultOsdPodPredicates, isPdbPod),

--- a/pkg/drain/stuckTerminatingStrategy.go
+++ b/pkg/drain/stuckTerminatingStrategy.go
@@ -1,0 +1,52 @@
+package drain
+
+import (
+	"context"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/managed-upgrade-operator/pkg/pod"
+)
+
+type stuckTerminatingStrategy struct {
+	client  client.Client
+	filters []pod.PodPredicate
+}
+
+func (sts *stuckTerminatingStrategy) Execute(node *corev1.Node) (*DrainStrategyResult, error) {
+	podsStuckTerminating, err := sts.getPodList(node)
+	if err != nil {
+		return nil, err
+	}
+
+	gp := int64(0)
+	res, err := pod.DeletePods(sts.client, podsStuckTerminating, false, &client.DeleteOptions{GracePeriodSeconds: &gp})
+	if err != nil {
+		return nil, err
+	}
+
+	return &DrainStrategyResult{
+		Message:     res.Message,
+		HasExecuted: res.NumMarkedForDeletion > 0,
+	}, nil
+}
+
+func (sts *stuckTerminatingStrategy) IsValid(node *corev1.Node) (bool, error) {
+	targetPods, err := sts.getPodList(node)
+	if err != nil {
+		return false, err
+	}
+
+	return len(targetPods.Items) > 0, nil
+}
+
+func (sts *stuckTerminatingStrategy) getPodList(node *corev1.Node) (*corev1.PodList, error) {
+	allPods := &corev1.PodList{}
+	err := sts.client.List(context.TODO(), allPods)
+	if err != nil {
+		return nil, err
+	}
+
+	filters := append([]pod.PodPredicate{isOnNode(node), hasNoFinalizers, isTerminating}, sts.filters...)
+	return pod.FilterPods(allPods, filters...), nil
+}

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -35,11 +35,11 @@ type DeleteResult struct {
 	NumMarkedForDeletion int
 }
 
-func DeletePods(c client.Client, pl *corev1.PodList, options ...client.DeleteOption) (*DeleteResult, error) {
+func DeletePods(c client.Client, pl *corev1.PodList, ignoreAlreadyDeleting bool, options ...client.DeleteOption) (*DeleteResult, error) {
 	me := &multierror.Error{}
 	var podsMarkedForDeletion []string
 	for _, p := range pl.Items {
-		if p.DeletionTimestamp == nil {
+		if !ignoreAlreadyDeleting || p.DeletionTimestamp == nil {
 			err := c.Delete(context.TODO(), &p, options...)
 			if err != nil {
 				me = multierror.Append(err, me)

--- a/pkg/pod/pod_suite_test.go
+++ b/pkg/pod/pod_suite_test.go
@@ -1,0 +1,13 @@
+package pod
+
+import (
+"testing"
+
+. "github.com/onsi/ginkgo"
+. "github.com/onsi/gomega"
+)
+
+func TestPod(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Pod Suite")
+}

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -1,16 +1,24 @@
 package pod
 
 import (
-	corev1 "k8s.io/api/core/v1"
+	"time"
 
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/managed-upgrade-operator/util/mocks"
 )
 
 var _ = Describe("Pod Filter", func() {
 
 	var (
 		podList       *corev1.PodList
+		mockKubeClient           *mocks.MockClient
+		mockCtrl                 *gomock.Controller
 		passPredicate PodPredicate = func(p corev1.Pod) bool {
 			return true
 		}
@@ -20,6 +28,8 @@ var _ = Describe("Pod Filter", func() {
 	)
 
 	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockKubeClient = mocks.NewMockClient(mockCtrl)
 		podList = &corev1.PodList{
 			Items: []corev1.Pod{
 				{}, {}, {},
@@ -41,4 +51,95 @@ var _ = Describe("Pod Filter", func() {
 			Expect(len(filteredPods.Items)).To(Equal(0))
 		})
 	})
+
+	Context("Removing Finalizers", func() {
+		var (
+			podList *corev1.PodList
+		)
+
+		BeforeEach(func() {
+			podList = &corev1.PodList{
+				Items: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testpod",
+							Finalizers: []string {
+								"deleteThisFinalizer",
+								"deleteThisFinalizerAlso",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testpod3",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testpod",
+							Finalizers: []string {
+								"deleteThisFinalizer",
+							},
+						},
+					},
+				},
+			}
+		})
+
+		It("Should remove finalizers if they exist", func() {
+			mockKubeClient.EXPECT().Update(gomock.Any(), gomock.Any()).Times(2)
+			result, err := RemoveFinalizersFromPod(mockKubeClient, podList)
+			Expect(err).To(BeNil())
+			Expect(result.NumRemoved).To(Equal(2))
+		})
+	})
+
+	Context("Deleting Pods", func() {
+		var (
+			podList *corev1.PodList
+		)
+
+		BeforeEach(func() {
+			podList = &corev1.PodList{
+				Items: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testpodBeingDeleted",
+							DeletionTimestamp: &metav1.Time{Time: time.Now()},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testpodBeingDeletedToo",
+							DeletionTimestamp: &metav1.Time{Time: time.Now()},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testpod3",
+						},
+					},
+				},
+			}
+		})
+
+		Context("When deleting pods that aren't already deleting", func() {
+			It("Should not attempt to re-delete deleting pods", func() {
+				gp := int64(0)
+				mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
+				result, err := DeletePods(mockKubeClient, podList, true, &client.DeleteOptions{GracePeriodSeconds: &gp})
+				Expect(err).To(BeNil())
+				Expect(result.NumMarkedForDeletion).To(Equal(1))
+			})
+			It("Should attempt to re-delete deleting pods if asked", func() {
+				gp := int64(0)
+				mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Times(3)
+				result, err := DeletePods(mockKubeClient, podList, false, &client.DeleteOptions{GracePeriodSeconds: &gp})
+				Expect(err).To(BeNil())
+				Expect(result.NumMarkedForDeletion).To(Equal(3))
+			})
+
+		})
+	})
+
 })


### PR DESCRIPTION
### What type of PR is this?

Feature

### What this PR does / why we need it?

This PR introduces a new node drain strategy to deal with pods that are stuck in a Terminating phase and yet which are not actively being guarded by a PDB or a Finalizer.

This strategy will perform a force deletion (with a grace period of 0) on any pods that:

- are not guarded by a PDB, and
- do not have any finalizers, and
- have been in a Terminating phase for longer than `nodeDrain.timeOut` minutes (from the MUO configmap).

In addition to the above, during development of this PR I noticed that our `pods` tests have not been being included in the overall test suite (they were missing a Ginkgo suite, so they've been skipped the whole time), so that is now fixed.  I also wrote some tests to exercise the `RemoveFinalizers` and `DeletePods` functions in the `pods` package, as well as additional tests for any new functionality added as part of this PR.

### Which Jira/Github issue(s) this PR fixes?

[OSD-6688](https://issues.redhat.com/browse/OSD-6688)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
