### PR TITLE
handle the metrics and the extra machine set when upgrade failed

### DIFF
--- a/pkg/controller/nodekeeper/nodekeeper_controller.go
+++ b/pkg/controller/nodekeeper/nodekeeper_controller.go
@@ -3,13 +3,14 @@ package nodekeeper
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/managed-upgrade-operator/util"
 	"time"
+
+	"github.com/openshift/managed-upgrade-operator/util"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime"
+	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"

--- a/pkg/controller/upgradeconfig/upgradeconfig_controller.go
+++ b/pkg/controller/upgradeconfig/upgradeconfig_controller.go
@@ -21,14 +21,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	muocfg "github.com/openshift/managed-upgrade-operator/config"
 	upgradev1alpha1 "github.com/openshift/managed-upgrade-operator/pkg/apis/upgrade/v1alpha1"
 	cub "github.com/openshift/managed-upgrade-operator/pkg/cluster_upgrader_builder"
 	cv "github.com/openshift/managed-upgrade-operator/pkg/clusterversion"
 	"github.com/openshift/managed-upgrade-operator/pkg/configmanager"
+	"github.com/openshift/managed-upgrade-operator/pkg/eventmanager"
 	"github.com/openshift/managed-upgrade-operator/pkg/metrics"
 	"github.com/openshift/managed-upgrade-operator/pkg/scheduler"
-	muocfg "github.com/openshift/managed-upgrade-operator/config"
-	"github.com/openshift/managed-upgrade-operator/pkg/eventmanager"
 	ucmgr "github.com/openshift/managed-upgrade-operator/pkg/upgradeconfigmanager"
 	"github.com/openshift/managed-upgrade-operator/pkg/validation"
 )
@@ -129,7 +129,7 @@ func (r *ReconcileUpgradeConfig) Reconcile(request reconcile.Request) (reconcile
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue
-			metricsClient.ResetMetrics()
+			metricsClient.ResetAllMetrics()
 			reqLogger.Info("Reset all the metrics due to no upgrade config present.")
 			return reconcile.Result{}, nil
 		}

--- a/pkg/controller/upgradeconfig/upgradeconfig_controller_test.go
+++ b/pkg/controller/upgradeconfig/upgradeconfig_controller_test.go
@@ -126,7 +126,7 @@ var _ = Describe("UpgradeConfigController", func() {
 				gomock.InOrder(
 					mockEMBuilder.EXPECT().NewManager(gomock.Any()).Return(mockEMClient, nil),
 					mockKubeClient.EXPECT().Get(gomock.Any(), upgradeConfigName, gomock.Any()).SetArg(2, *upgradeConfig).Return(notFound),
-					mockMetricsClient.EXPECT().ResetMetrics(),
+					mockMetricsClient.EXPECT().ResetAllMetrics(),
 				)
 				result, err := reconciler.Reconcile(reconcile.Request{NamespacedName: upgradeConfigName})
 				Expect(err).NotTo(HaveOccurred())

--- a/pkg/metrics/mocks/metrics.go
+++ b/pkg/metrics/mocks/metrics.go
@@ -105,16 +105,28 @@ func (mr *MockMetricsMockRecorder) ResetAllMetricNodeDrainFailed() *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetAllMetricNodeDrainFailed", reflect.TypeOf((*MockMetrics)(nil).ResetAllMetricNodeDrainFailed))
 }
 
-// ResetMetricClusterCheck mocks base method
-func (m *MockMetrics) ResetMetricClusterCheck(arg0 string) {
+// ResetAllMetrics mocks base method
+func (m *MockMetrics) ResetAllMetrics() {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ResetMetricClusterCheck", arg0)
+	m.ctrl.Call(m, "ResetAllMetrics")
 }
 
-// ResetMetricClusterCheck indicates an expected call of ResetMetricClusterCheck
-func (mr *MockMetricsMockRecorder) ResetMetricClusterCheck(arg0 interface{}) *gomock.Call {
+// ResetAllMetrics indicates an expected call of ResetAllMetrics
+func (mr *MockMetricsMockRecorder) ResetAllMetrics() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetMetricClusterCheck", reflect.TypeOf((*MockMetrics)(nil).ResetMetricClusterCheck), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetAllMetrics", reflect.TypeOf((*MockMetrics)(nil).ResetAllMetrics))
+}
+
+// ResetFailureMetrics mocks base method
+func (m *MockMetrics) ResetFailureMetrics() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ResetFailureMetrics")
+}
+
+// ResetFailureMetrics indicates an expected call of ResetFailureMetrics
+func (mr *MockMetricsMockRecorder) ResetFailureMetrics() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetFailureMetrics", reflect.TypeOf((*MockMetrics)(nil).ResetFailureMetrics))
 }
 
 // ResetMetricNodeDrainFailed mocks base method
@@ -127,18 +139,6 @@ func (m *MockMetrics) ResetMetricNodeDrainFailed(arg0 string) {
 func (mr *MockMetricsMockRecorder) ResetMetricNodeDrainFailed(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetMetricNodeDrainFailed", reflect.TypeOf((*MockMetrics)(nil).ResetMetricNodeDrainFailed), arg0)
-}
-
-// ResetMetricScaling mocks base method
-func (m *MockMetrics) ResetMetricScaling(arg0 string) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ResetMetricScaling", arg0)
-}
-
-// ResetMetricScaling indicates an expected call of ResetMetricScaling
-func (mr *MockMetricsMockRecorder) ResetMetricScaling(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetMetricScaling", reflect.TypeOf((*MockMetrics)(nil).ResetMetricScaling), arg0)
 }
 
 // ResetMetricUpgradeConfigSynced mocks base method
@@ -175,18 +175,6 @@ func (m *MockMetrics) ResetMetricUpgradeWorkerTimeout(arg0, arg1 string) {
 func (mr *MockMetricsMockRecorder) ResetMetricUpgradeWorkerTimeout(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetMetricUpgradeWorkerTimeout", reflect.TypeOf((*MockMetrics)(nil).ResetMetricUpgradeWorkerTimeout), arg0, arg1)
-}
-
-// ResetMetrics mocks base method
-func (m *MockMetrics) ResetMetrics() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ResetMetrics")
-}
-
-// ResetMetrics indicates an expected call of ResetMetrics
-func (mr *MockMetricsMockRecorder) ResetMetrics() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetMetrics", reflect.TypeOf((*MockMetrics)(nil).ResetMetrics))
 }
 
 // UpdateMetricClusterCheckFailed mocks base method


### PR DESCRIPTION
### What type of PR is this?
bug/enhancement

### What this PR does / why we need it?
force scale down the extra machine when upgrade failed
reset metric when node scale failed

### Which Jira/Github issue(s) this PR fixes?

_Fixes [OSD-5723](https://issues.redhat.com/browse/OSD-5723) OSD-6094_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [x] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

