### PR TITLE
OSD-6851: Pull operator image by digest

### DIFF
--- a/hack/app_sre_build_deploy.sh
+++ b/hack/app_sre_build_deploy.sh
@@ -10,6 +10,7 @@ CURRENT_DIR=$(dirname "$0")
 
 BASE_IMG="${_OPERATOR_NAME}"
 QUAY_IMAGE="quay.io/app-sre/${BASE_IMG}"
+# FIXME: Don't override this. The default (set in standard.mk) is fine.
 IMG="${BASE_IMG}:latest"
 
 GIT_HASH=$(git rev-parse --short=7 HEAD)


### PR DESCRIPTION
...rather than by tag.

### What type of PR is this?
feature

### What this PR does / why we need it?
ICSP policy requires pulling by digest. This sets us up to be able to use ICSP if needed.

### Which Jira/Github issue(s) this PR fixes?
[OSD-6851](https://issues.redhat.com/browse/OSD-6851)

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

