### PR TITLE
[OSD-6919] - Adding skeleton files for ARO Upgrader

### DIFF
--- a/pkg/cluster_upgrader_builder/cluster_upgrader_builder.go
+++ b/pkg/cluster_upgrader_builder/cluster_upgrader_builder.go
@@ -8,6 +8,7 @@ import (
 	upgradev1alpha1 "github.com/openshift/managed-upgrade-operator/pkg/apis/upgrade/v1alpha1"
 	"github.com/openshift/managed-upgrade-operator/pkg/configmanager"
 	"github.com/openshift/managed-upgrade-operator/pkg/metrics"
+	"github.com/openshift/managed-upgrade-operator/pkg/upgraders/aro"
 	"github.com/openshift/managed-upgrade-operator/pkg/upgraders/osd"
 )
 
@@ -32,6 +33,12 @@ func (cub *clusterUpgraderBuilder) NewClient(c client.Client, cfm configmanager.
 	switch upgradeType {
 	case upgradev1alpha1.OSD:
 		cu, err := osd.NewClient(c, cfm, mc, nc)
+		if err != nil {
+			return nil, err
+		}
+		return cu, nil
+	case upgradev1alpha1.ARO:
+		cu, err := aro.NewClient(c, cfm, mc, nc)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/upgraders/aro/aro_upgrader_maintenance_window_test.go
+++ b/pkg/upgraders/aro/aro_upgrader_maintenance_window_test.go
@@ -1,12 +1,16 @@
-package aro_test
+package aro
 
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"github.com/openshift/managed-upgrade-operator/pkg/upgraders/aro"
 )
 
-var _ = Describe("AroUpgraderMaintenanceWindow", func() {
-
+var _ = Describe("ARO Upgrader Maintenance Window", func() {
+	Context("When performing ARO upgrade", func() {
+		It("Checks Upgrade is Successful", func() {
+			status, err := checkUpgrade()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(BeTrue())
+		})
+	})
 })

--- a/pkg/upgraders/aro/aro_upgrader_maintenance_window_test.go
+++ b/pkg/upgraders/aro/aro_upgrader_maintenance_window_test.go
@@ -1,0 +1,12 @@
+package aro_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/managed-upgrade-operator/pkg/upgraders/aro"
+)
+
+var _ = Describe("AroUpgraderMaintenanceWindow", func() {
+
+})

--- a/pkg/upgraders/aro/aro_upgrader_suite_test.go
+++ b/pkg/upgraders/aro/aro_upgrader_suite_test.go
@@ -1,4 +1,4 @@
-package aro_test
+package aro
 
 import (
 	"testing"

--- a/pkg/upgraders/aro/aro_upgrader_suite_test.go
+++ b/pkg/upgraders/aro/aro_upgrader_suite_test.go
@@ -1,0 +1,13 @@
+package aro_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestAro(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ARO Upgrader Suite")
+}

--- a/pkg/upgraders/aro/aro_upgrader_test.go
+++ b/pkg/upgraders/aro/aro_upgrader_test.go
@@ -1,12 +1,23 @@
-package aro_test
+package aro
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"github.com/openshift/managed-upgrade-operator/pkg/upgraders/aro"
 )
 
-var _ = Describe("AroUpgrader", func() {
-
+var _ = Describe("ARO Upgrader", func() {
+	Context("When performing ARO upgrade", func() {
+		It("Checks Upgrade is Successful", func() {
+			status, err := checkUpgrade()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(BeTrue())
+		})
+	})
 })
+
+func checkUpgrade() (bool, error) {
+	fmt.Println("Dummy check to test ARO upgrade")
+	return true, nil
+}

--- a/pkg/upgraders/aro/aro_upgrader_test.go
+++ b/pkg/upgraders/aro/aro_upgrader_test.go
@@ -1,0 +1,12 @@
+package aro_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/managed-upgrade-operator/pkg/upgraders/aro"
+)
+
+var _ = Describe("AroUpgrader", func() {
+
+})

--- a/pkg/upgraders/aro/aro_upgrader_verification_test.go
+++ b/pkg/upgraders/aro/aro_upgrader_verification_test.go
@@ -1,12 +1,23 @@
-package aro_test
+package aro
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"github.com/openshift/managed-upgrade-operator/pkg/upgraders/aro"
 )
 
-var _ = Describe("AroUpgraderVerification", func() {
-
+var _ = Describe("ARO Upgrader Verification", func() {
+	Context("When performing ARO upgrade", func() {
+		It("Checks Upgrade is Successful", func() {
+			status, err := checkUpgradeVerification()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(BeTrue())
+		})
+	})
 })
+
+func checkUpgradeVerification() (bool, error) {
+	fmt.Println("Dummy check to test ARO upgrade verification")
+	return true, nil
+}

--- a/pkg/upgraders/aro/aro_upgrader_verification_test.go
+++ b/pkg/upgraders/aro/aro_upgrader_verification_test.go
@@ -1,0 +1,12 @@
+package aro_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/managed-upgrade-operator/pkg/upgraders/aro"
+)
+
+var _ = Describe("AroUpgraderVerification", func() {
+
+})

--- a/pkg/upgraders/aro/config.go
+++ b/pkg/upgraders/aro/config.go
@@ -1,0 +1,98 @@
+package aro
+
+import (
+	"fmt"
+	"time"
+
+	ac "github.com/openshift/managed-upgrade-operator/pkg/availabilitychecks"
+	"github.com/openshift/managed-upgrade-operator/pkg/drain"
+)
+
+type aroUpgradeConfig struct {
+	Maintenance                    maintenanceConfig                 `yaml:"maintenance"`
+	Scale                          scaleConfig                       `yaml:"scale"`
+	NodeDrain                      drain.NodeDrain                   `yaml:"nodeDrain"`
+	HealthCheck                    healthCheck                       `yaml:"healthCheck"`
+	ExtDependencyAvailabilityCheck ac.ExtDependencyAvailabilityCheck `yaml:"extDependencyAvailabilityChecks"`
+	Verification                   verification                      `yaml:"verification"`
+	UpgradeWindow                  upgradeWindow                     `yaml:"upgradeWindow"`
+}
+
+type maintenanceConfig struct {
+	ControlPlaneTime int           `yaml:"controlPlaneTime" default:"60"`
+	IgnoredAlerts    ignoredAlerts `yaml:"ignoredAlerts"`
+}
+
+type ignoredAlerts struct {
+	// Generally upgrades should not fire critical alerts but there are some critical alerts that will fire.
+	// e.g. 'etcdMembersDown' happens as the masters drain/reboot and a master is offline but this is expected and will resolve.
+	// This is a list of critical alerts that can be ignored while upgrading of controlplane occurs
+	ControlPlaneCriticals []string `yaml:"controlPlaneCriticals"`
+}
+
+func (cfg *maintenanceConfig) IsValid() error {
+	if cfg.ControlPlaneTime <= 0 {
+		return fmt.Errorf("Config maintenace controlPlaneTime out is invalid")
+	}
+
+	return nil
+}
+
+func (cfg *maintenanceConfig) GetControlPlaneDuration() time.Duration {
+	return time.Duration(cfg.ControlPlaneTime) * time.Minute
+}
+
+type upgradeWindow struct {
+	TimeOut      int `yaml:"timeOut" default:"120"`
+	DelayTrigger int `yaml:"delayTrigger" default:"30"`
+}
+
+func (cfg *upgradeWindow) GetUpgradeWindowTimeOutDuration() time.Duration {
+	return time.Duration(cfg.TimeOut) * time.Minute
+}
+
+func (cfg *upgradeWindow) GetUpgradeDelayedTriggerDuration() time.Duration {
+	return time.Duration(cfg.DelayTrigger) * time.Minute
+}
+
+type scaleConfig struct {
+	TimeOut int `yaml:"timeOut" default:"30"`
+}
+
+type healthCheck struct {
+	IgnoredCriticals []string `yaml:"ignoredCriticals"`
+}
+
+type verification struct {
+	IgnoredNamespaces        []string `yaml:"ignoredNamespaces"`
+	NamespacePrefixesToCheck []string `yaml:"namespacePrefixesToCheck"`
+}
+
+func (cfg *aroUpgradeConfig) IsValid() error {
+	if err := cfg.Maintenance.IsValid(); err != nil {
+		return err
+	}
+	if cfg.Scale.TimeOut <= 0 {
+		return fmt.Errorf("Config scale timeOut is invalid")
+	}
+	if cfg.NodeDrain.Timeout <= 0 {
+		return fmt.Errorf("Config nodeDrain timeOut is invalid")
+	}
+	if cfg.NodeDrain.ExpectedNodeDrainTime <= 0 {
+		return fmt.Errorf("Config nodeDrain expectedNodeDrainTime is invalid")
+	}
+	if cfg.UpgradeWindow.DelayTrigger < 0 {
+		return fmt.Errorf("Config upgrade window delay trigger is invalid")
+	}
+	if cfg.UpgradeWindow.TimeOut < 0 {
+		return fmt.Errorf("Config upgrade window time out is invalid")
+	}
+	if len(cfg.ExtDependencyAvailabilityCheck.HTTP.URLS) > 0 && cfg.ExtDependencyAvailabilityCheck.HTTP.Timeout <= 0 || cfg.ExtDependencyAvailabilityCheck.HTTP.Timeout > 60 {
+		return fmt.Errorf("Config HTTP timeout is invalid (Requires int between 1 - 60 inclusive)")
+	}
+	return nil
+}
+
+func (cfg *aroUpgradeConfig) GetScaleDuration() time.Duration {
+	return time.Duration(cfg.Scale.TimeOut) * time.Minute
+}

--- a/pkg/upgraders/aro/upgrader.go
+++ b/pkg/upgraders/aro/upgrader.go
@@ -1,0 +1,94 @@
+package aro
+
+import (
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	upgradev1alpha1 "github.com/openshift/managed-upgrade-operator/pkg/apis/upgrade/v1alpha1"
+	ac "github.com/openshift/managed-upgrade-operator/pkg/availabilitychecks"
+	cv "github.com/openshift/managed-upgrade-operator/pkg/clusterversion"
+	"github.com/openshift/managed-upgrade-operator/pkg/configmanager"
+	"github.com/openshift/managed-upgrade-operator/pkg/drain"
+	"github.com/openshift/managed-upgrade-operator/pkg/eventmanager"
+	"github.com/openshift/managed-upgrade-operator/pkg/machinery"
+	"github.com/openshift/managed-upgrade-operator/pkg/maintenance"
+	"github.com/openshift/managed-upgrade-operator/pkg/metrics"
+	"github.com/openshift/managed-upgrade-operator/pkg/scaler"
+)
+
+var (
+	steps                  UpgradeSteps
+	aroUpgradeStepOrdering = []upgradev1alpha1.UpgradeConditionType{}
+)
+
+// Represents a named series of steps as part of an upgrade process
+type UpgradeSteps map[upgradev1alpha1.UpgradeConditionType]UpgradeStep
+
+// Represents an individual step in the upgrade process
+type UpgradeStep func(client.Client, *aroUpgradeConfig, scaler.Scaler, drain.NodeDrainStrategyBuilder, metrics.Metrics, maintenance.Maintenance, cv.ClusterVersion, eventmanager.EventManager, *upgradev1alpha1.UpgradeConfig, machinery.Machinery, ac.AvailabilityCheckers, logr.Logger) (bool, error)
+
+// Represents the order in which to undertake upgrade steps
+type UpgradeStepOrdering []upgradev1alpha1.UpgradeConditionType
+
+func NewClient(c client.Client, cfm configmanager.ConfigManager, mc metrics.Metrics, notifier eventmanager.EventManager) (*aroClusterUpgrader, error) {
+	cfg := &aroUpgradeConfig{}
+	err := cfm.Into(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	m, err := maintenance.NewBuilder().NewClient(c)
+	if err != nil {
+		return nil, err
+	}
+
+	acs, err := ac.GetAvailabilityCheckers(&cfg.ExtDependencyAvailabilityCheck)
+	if err != nil {
+		return nil, err
+	}
+
+	steps = map[upgradev1alpha1.UpgradeConditionType]UpgradeStep{}
+
+	return &aroClusterUpgrader{
+		Steps:                steps,
+		Ordering:             aroUpgradeStepOrdering,
+		client:               c,
+		maintenance:          m,
+		metrics:              mc,
+		scaler:               scaler.NewScaler(),
+		drainstrategyBuilder: drain.NewBuilder(),
+		cvClient:             cv.NewCVClient(c),
+		cfg:                  cfg,
+		machinery:            machinery.NewMachinery(),
+		notifier:             notifier,
+		availabilityCheckers: acs,
+	}, nil
+}
+
+type aroClusterUpgrader struct {
+	Steps                UpgradeSteps
+	Ordering             UpgradeStepOrdering
+	client               client.Client
+	maintenance          maintenance.Maintenance
+	metrics              metrics.Metrics
+	scaler               scaler.Scaler
+	drainstrategyBuilder drain.NodeDrainStrategyBuilder
+	cvClient             cv.ClusterVersion
+	cfg                  *aroUpgradeConfig
+	machinery            machinery.Machinery
+	notifier             eventmanager.EventManager
+	availabilityCheckers ac.AvailabilityCheckers
+}
+
+// This triggers the ARO upgrade process.
+// TODO: Right now it shows dummy message that upgrade is done. Actual implementation pending.
+func (cu aroClusterUpgrader) UpgradeCluster(upgradeConfig *upgradev1alpha1.UpgradeConfig, logger logr.Logger) (upgradev1alpha1.UpgradePhase, *upgradev1alpha1.UpgradeCondition, error) {
+	logger.Info("Upgrading ARO cluster")
+	condition := &upgradev1alpha1.UpgradeCondition{
+		Type:    "UpgradeSuccessful",
+		Status:  "Upgrade is completed",
+		Reason:  "ARO Upgrade",
+		Message: "ARO Upgrade is done",
+	}
+	return upgradev1alpha1.UpgradePhaseUpgraded, condition, nil
+}


### PR DESCRIPTION
### What type of PR is this?
Adding skeleton ARO files to get started with code and tests.

### What this PR does / why we need it?
To create skeleton code files to add ARO as the UpgradeType. The PR does not add any implementation of upgrading ARO clusters yet. Thus, it shows a dummy message of successful upgrade for now. 

### Which Jira/Github issue(s) this PR fixes?
_Fixes #_ [OSD-6919](https://issues.redhat.com/browse/OSD-6919)

### Special notes for your reviewer:
* Created test files based on ginkgo for now with no actual test cases yet.
* The ARO UpgradeType is picked up and shows the following dummy upgrade status for now:
```bash
NAME                 DESIRED_VERSION   PHASE      STAGE               STATUS                 REASON        MESSAGE
osd-upgrade-config   4.7.3             Upgraded   UpgradeSuccessful   Upgrade is completed   ARO Upgrade   ARO Upgrade is done
```

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [X] Ran `make generate` command locally to validate code changes

