### PR TITLE
OSD-6918 Rename managed CR to managed-upgrade-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you like to contribute to the Managed Upgrade Operator, please read our [Cont
 apiVersion: upgrade.managed.openshift.io/v1alpha1
 kind: UpgradeConfig
 metadata:
-  name: osd-upgrade-config
+  name: managed-upgrade-config
 spec:
   type: "OSD"
   upgradeAt: "2020-01-01T00:00:00Z"

--- a/pkg/controller/upgradeconfig/upgradeconfig_controller_test.go
+++ b/pkg/controller/upgradeconfig/upgradeconfig_controller_test.go
@@ -80,7 +80,7 @@ var _ = Describe("UpgradeConfigController", func() {
 		mockUCMgrBuilder = ucMgrMocks.NewMockUpgradeConfigManagerBuilder(mockCtrl)
 		mockUCMgr = ucMgrMocks.NewMockUpgradeConfigManager(mockCtrl)
 		upgradeConfigName = types.NamespacedName{
-			Name:      "osd-upgrade-config",
+			Name:      "managed-upgrade-config",
 			Namespace: "test-namespace",
 		}
 		upgradeConfig = testStructs.NewUpgradeConfigBuilder().WithNamespacedName(upgradeConfigName).GetUpgradeConfig()

--- a/pkg/eventmanager/eventmanager_test.go
+++ b/pkg/eventmanager/eventmanager_test.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	TEST_OPERATOR_NAMESPACE = "openshift-managed-upgrade-operator"
-	TEST_UPGRADECONFIG_CR   = "osd-upgrade-config"
+	TEST_UPGRADECONFIG_CR   = "managed-upgrade-config"
 	TEST_UPGRADE_VERSION    = "4.4.4"
 	TEST_UPGRADE_TIME       = "2020-06-20T00:00:00Z"
 )

--- a/pkg/upgradeconfigmanager/upgradeconfigmanager.go
+++ b/pkg/upgradeconfigmanager/upgradeconfigmanager.go
@@ -30,7 +30,7 @@ var log = logf.Log.WithName("upgrade-config-manager")
 
 const (
 	// Name of the Custom Resource that the provider will manage
-	UPGRADECONFIG_CR_NAME = "osd-upgrade-config"
+	UPGRADECONFIG_CR_NAME = "managed-upgrade-config"
 	// Jitter factor (percentage / 100) used to alter watch interval
 	JITTER_FACTOR         = 0.1
 	INITIAL_SYNC_DURATION = 1 * time.Minute

--- a/test/deploy/upgrade.managed.openshift.io_v1alpha1_upgradeconfig_cr.yaml
+++ b/test/deploy/upgrade.managed.openshift.io_v1alpha1_upgradeconfig_cr.yaml
@@ -1,7 +1,7 @@
 apiVersion: upgrade.managed.openshift.io/v1alpha1
 kind: UpgradeConfig
 metadata:
-  name: osd-upgrade-config
+  name: managed-upgrade-config
 spec:
   type: "OSD"
   upgradeAt: "2020-01-01T00:00:00Z"


### PR DESCRIPTION
### What type of PR is this?

Refactor

### What this PR does / why we need it?

[OSD-6918](https://issues.redhat.com/browse/OSD-6918) largely turned into a small refactoring exercise, as fortunately all of the building blocks to support multi-types are already built in the controller and left me with very little to actually do to support separate upgrade types.

So what this PR does is rename the managed Custom Resource from `osd-upgrade-config` to `managed-upgrade-config`. The UpgradeConfig controller will now only reconcile over CRs that are named that.

This has minimal impact _except_ if the operator happens to be mid-upgrade when this change lands (it will never report upgrade completion to OCM), or if a cluster has an automatic upgrade scheduled (it will leave an orphaned osd-upgrade-config CR).

I am proposing a temporary `managed-cluster-config` job which will rename the `osd-upgrade-config` CR on any clusters:

https://github.com/mrbarge/managed-cluster-config/tree/osd-6918/deploy/osd-6918-muo-cr-rename 

This cronjob has been successfully tested on a MUO upgrade to rename the CR in-flight during an upgrade.

### Which Jira/Github issue(s) this PR fixes?

[OSD-6918](https://issues.redhat.com/browse/OSD-6918)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster (OSD upgrade type)
- [X] Tested latest changes against a cluster (ARO upgrade type)
- [X] Tested latest changes against a cluster (updated operator to this release mid-upgrade and applied cron CR fix)
