### PR TITLE
[OSD-7104] Change scheduling of MUO on master nodes

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,16 +16,18 @@ spec:
       serviceAccountName: managed-upgrade-operator
       affinity:
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - preference:
-              matchExpressions:
-              - key: node-role.kubernetes.io/infra
-                operator: Exists
-            weight: 1
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: In
+                values:
+                - ""
       tolerations:
-        - operator: Exists
-          key: node-role.kubernetes.io/infra
-          effect: NoSchedule
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoExecute
+        key: node-role.kubernetes.io/master
       containers:
         - name: managed-upgrade-operator
           # Replace this with the built image name


### PR DESCRIPTION
### What type of PR is this?
_Deployment change_

### What this PR does / why we need it?
As per [OSD-7104](https://issues.redhat.com/browse/OSD-7104), this PR would change the scheduling of MUO pod from infra node to master node (similar to CVO). The reason for this change is because upgrades got stuck when MUO pod is OOM killed on infra node when Prometheus pod consumes high memory. Since MUO pod currently does not have any priorityClass set, it has a low priority which easily qualifies for it to be OOM killed and possibly compete with customer workloads due to "preferred" affinity for infra node. This PR would separate out MUO scheduling to master nodes which doesn't interfere with infra/customer workloads at all. Considering the resource consumption is low for MUO pod, this was considered acceptable.

cc: @cblecker , @jewzaam 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #[OSD-7104](https://issues.redhat.com/browse/OSD-7104)_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make generate` command locally to validate code changes

