### PR TITLE
[OSD-6433] Ignore openshift-operators and add core kube-* namespaces

### DIFF
--- a/pkg/upgraders/osd/upgrader.go
+++ b/pkg/upgraders/osd/upgrader.go
@@ -662,7 +662,7 @@ func performClusterHealthCheck(c client.Client, metricsClient metrics.Metrics, c
 	if len(ic) > 0 {
 		icQuery = `,alertname!="` + strings.Join(ic, `",alertname!="`) + `"`
 	}
-	healthCheckQuery := `ALERTS{alertstate="firing",severity="critical",namespace=~"^openshift.*|^kube.*|^default$",namespace!="openshift-customer-monitoring",namespace!="openshift-logging"` + icQuery + "}"
+	healthCheckQuery := `ALERTS{alertstate="firing",severity="critical",namespace=~"^openshift.*|^kube-.*|^default$",namespace!="openshift-customer-monitoring",namespace!="openshift-logging",namespace!="openshift-operators"` + icQuery + "}"
 	alerts, err := metricsClient.Query(healthCheckQuery)
 	if err != nil {
 		return false, fmt.Errorf("Unable to query critical alerts: %s", err)


### PR DESCRIPTION
### What type of PR is this?
_Bug_


### What this PR does / why we need it?
This PR includes two changes:
1. Change `kube*` to `kube-*` to include alerts.
2. Add `openshift-operators` namespace to ignored namespace for alerts.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #[OSD-6433](https://issues.redhat.com/browse/OSD-6433)_

### Special notes for your reviewer:
Alert query works as expected in Prometheus

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make generate` command locally to validate code changes

