### PR TITLE
OSD-6434 - MUO should log alertname during health check

### DIFF
--- a/pkg/upgraders/osd/upgrader.go
+++ b/pkg/upgraders/osd/upgrader.go
@@ -595,8 +595,8 @@ func performClusterHealthCheck(c client.Client, metricsClient metrics.Metrics, c
 		alert := []string{}
 		uniqueAlerts := make(map[string]bool)
 
-		for i := range alerts.Data.Result {
-			a := alerts.Data.Result[i].Metric["alertname"]
+		for _, r := range alerts.Data.Result {
+			a := r.Metric["alertname"]
 
 			if uniqueAlerts[a] {
 				continue

--- a/pkg/upgraders/osd/upgrader.go
+++ b/pkg/upgraders/osd/upgrader.go
@@ -615,6 +615,7 @@ func performClusterHealthCheck(c client.Client, metricsClient metrics.Metrics, c
 	}
 	if len(result.Degraded) > 0 {
 		logger.Info(fmt.Sprintf("Degraded operators: %s", strings.Join(result.Degraded, ", ")))
+		// Send the metrics for the cluster check failed if we have degraded operators
 		return false, fmt.Errorf("degraded operators: %s", strings.Join(result.Degraded, ", "))
 	}
 

--- a/pkg/upgraders/osd/upgrader.go
+++ b/pkg/upgraders/osd/upgrader.go
@@ -606,15 +606,16 @@ func performClusterHealthCheck(c client.Client, metricsClient metrics.Metrics, c
 		}
 
 		logger.Info(fmt.Sprintf("Critical alert(s) firing: %s. Cannot continue upgrade", strings.Join(alert, ", ")))
-
-		result, err := cvClient.HasDegradedOperators()
-		if err != nil {
-			return false, err
-		}
-		if len(result.Degraded) > 0 {
-			logger.Info(fmt.Sprintf("Degraded operators: %s", strings.Join(result.Degraded, ", ")))
-		}
 		return false, fmt.Errorf("critical alert(s) firing: %s", strings.Join(alert, ", "))
+	}
+
+	result, err := cvClient.HasDegradedOperators()
+	if err != nil {
+		return false, err
+	}
+	if len(result.Degraded) > 0 {
+		logger.Info(fmt.Sprintf("Degraded operators: %s", strings.Join(result.Degraded, ", ")))
+		return false, fmt.Errorf("degraded operators: %s", strings.Join(result.Degraded, ", "))
 	}
 
 	return true, nil


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
For SRE oncall, it would be helpful to show the names of the critical alerts firing instead of just showing the count of critical alerts firing. 

### Which Jira/Github issue(s) this PR fixes?
_Fixes #[OSD-6434](https://issues.redhat.com/browse/OSD-6434)_

### Special notes for your reviewer:
1. For now, have shown only the unique alerts as an overview since `ClusterOperatorDown` and `ClusterOperatorDegraded` can be firing for multiple components.
2. Logs look like following:
```bash
{"level":"info","ts":1622539718.527709,"logger":"controller_upgradeconfig","msg":"Critical alert(s) firing: ClusterOperatorDegraded, ClusterOperatorDown, etcdMembersDown. Cannot continue upgrade","Request.Namespace":"openshift-managed-upgrade-operator","Request.Name":"managed-upgrade-config"}
```

and `UpgradeConfig` looks like:
```bash
$ oc get upgrade    
NAME                     DESIRED_VERSION   PHASE       STAGE            STATUS   REASON                    MESSAGE
managed-upgrade-config   4.7.2             Upgrading   PreHealthCheck   False    PreHealthCheck not done   critical alert(s) firing: ClusterOperatorDegraded, ClusterOperatorDown, etcdMembersDown
```
Let me know if any changes required.

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make generate` command locally to validate code changes

