### PR TITLE
make the namespace in health check configurable

### DIFF
--- a/pkg/upgraders/osd/config.go
+++ b/pkg/upgraders/osd/config.go
@@ -59,7 +59,8 @@ type scaleConfig struct {
 }
 
 type healthCheck struct {
-	IgnoredCriticals []string `yaml:"ignoredCriticals"`
+	IgnoredCriticals  []string `yaml:"ignoredCriticals"`
+	IgnoredNamespaces []string `yaml:"ignoredNamespaces"`
 }
 
 func (cfg *osdUpgradeConfig) IsValid() error {

--- a/pkg/upgraders/osd/upgrader.go
+++ b/pkg/upgraders/osd/upgrader.go
@@ -584,7 +584,15 @@ func performClusterHealthCheck(c client.Client, metricsClient metrics.Metrics, c
 	if len(ic) > 0 {
 		icQuery = `,alertname!="` + strings.Join(ic, `",alertname!="`) + `"`
 	}
-	healthCheckQuery := `ALERTS{alertstate="firing",severity="critical",namespace=~"^openshift.*|^kube-.*|^default$",namespace!="openshift-customer-monitoring",namespace!="openshift-logging",namespace!="openshift-operators"` + icQuery + "}"
+
+	ignoredNamespace := cfg.HealthCheck.IgnoredNamespaces
+	ignoredNamespaceQuery := ""
+	if len(ignoredNamespace) > 0 {
+		ignoredNamespaceQuery = `,namespace!="` + strings.Join(ignoredNamespace, `",namespace!="`) + `"`
+	}
+
+	healthCheckQuery := `ALERTS{alertstate="firing",severity="critical",namespace=~"^openshift.*|^kube-.*|^default$"` + ignoredNamespaceQuery + icQuery + "}"
+
 	alerts, err := metricsClient.Query(healthCheckQuery)
 	if err != nil {
 		return false, fmt.Errorf("unable to query critical alerts: %s", err)

--- a/pkg/upgraders/osd/upgrader_verification_test.go
+++ b/pkg/upgraders/osd/upgrader_verification_test.go
@@ -74,7 +74,8 @@ var _ = Describe("ClusterUpgrader verification and health tests", func() {
 				TimeOut: 30,
 			},
 			HealthCheck: healthCheck{
-				IgnoredCriticals: []string{"alert1", "alert2"},
+				IgnoredCriticals:  []string{"alert1", "alert2"},
+				IgnoredNamespaces: []string{"ns1"},
 			},
 			NodeDrain: drain.NodeDrain{
 				ExpectedNodeDrainTime: 8,
@@ -127,6 +128,19 @@ var _ = Describe("ClusterUpgrader verification and health tests", func() {
 				)
 				result, err := PostClusterHealthCheck(mockKubeClient, config, mockScaler, mockDrainStrategyBuilder, mockMetricsClient, mockMaintClient, mockCVClient, mockEMClient, upgradeConfig, mockMachinery, []ac.AvailabilityChecker{mockAC}, logger)
 				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+			})
+			It("will have ignored alerts in specified namespaces", func() {
+				mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(false, nil)
+				mockMetricsClient.EXPECT().Query(gomock.Any()).DoAndReturn(
+					func(query string) (*metrics.AlertResponse, error) {
+						Expect(strings.Contains(query, `namespace!="`+config.HealthCheck.IgnoredNamespaces[0]+`"`)).To(BeTrue())
+						return &metrics.AlertResponse{}, nil
+					})
+				mockCVClient.EXPECT().HasDegradedOperators().Return(&clusterversion.HasDegradedOperatorsResult{Degraded: []string{}}, nil)
+				mockMetricsClient.EXPECT().UpdateMetricClusterCheckSucceeded(upgradeConfig.Name)
+				result, err := PreClusterHealthCheck(mockKubeClient, config, mockScaler, mockDrainStrategyBuilder, mockMetricsClient, mockMaintClient, mockCVClient, mockEMClient, upgradeConfig, mockMachinery, []ac.AvailabilityChecker{mockAC}, logger)
+				Expect(err).To(Not(HaveOccurred()))
 				Expect(result).To(BeTrue())
 			})
 		})

--- a/test/deploy/managed-upgrade-operator-config.yaml
+++ b/test/deploy/managed-upgrade-operator-config.yaml
@@ -27,3 +27,8 @@ data:
       - MetricsClientSendFailingSRE
       - UpgradeNodeScalingFailedSRE
       - UpgradeClusterCheckFailedSRE
+      ignoredNamespaces:
+      - openshift-logging
+      - openshift-customer-monitoring
+      - openshift-operators
+      - openshift-redhat-marketplace


### PR DESCRIPTION
### What type of PR is this?
_feature_


### What this PR does / why we need it?
Make the ignored namespace configurable in health check, so that we could change it easily 

### Which Jira/Github issue(s) this PR fixes?

_Fixes OSD-5943_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

