### PR TITLE
[OSD-4715] Adding more tests to drain package

### DIFF
--- a/pkg/drain/podDeleteStrategy_test.go
+++ b/pkg/drain/podDeleteStrategy_test.go
@@ -1,0 +1,177 @@
+package drain
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang/mock/gomock"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/managed-upgrade-operator/pkg/pod"
+	"github.com/openshift/managed-upgrade-operator/util/mocks"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Pod Delete Strategy", func() {
+
+	var (
+		mockCtrl       *gomock.Controller
+		mockKubeClient *mocks.MockClient
+		pds            *podDeletionStrategy
+		node           *corev1.Node
+		podList        corev1.PodList
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockKubeClient = mocks.NewMockClient(mockCtrl)
+		node = &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "n1",
+			},
+		}
+		pds = &podDeletionStrategy{
+			client:  mockKubeClient,
+			filters: []pod.PodPredicate{isOnNode(node)},
+		}
+
+		podList = corev1.PodList{
+			Items: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "n1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "pod2",
+						DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "n1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod3",
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "n2",
+					},
+				},
+			},
+		}
+	})
+
+	Context("Execute pod delete strategy on a node", func() {
+
+		It("Successfully deletes pods on a node", func() {
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+				mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()),
+			)
+			result, err := pds.Execute(node)
+			Expect(result.HasExecuted).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+
+		It("Does nothing if pod already has deletion time stamp", func() {
+			noDeletePods := corev1.PodList{
+				Items: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "p1",
+							DeletionTimestamp: &metav1.Time{Time: time.Now()},
+						},
+						Spec: corev1.PodSpec{
+							NodeName: "n1",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "p2",
+							DeletionTimestamp: &metav1.Time{Time: time.Now()},
+						},
+						Spec: corev1.PodSpec{
+							NodeName: "n2",
+						},
+					},
+				},
+			}
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, noDeletePods),
+				mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Times(3),
+			)
+			result, err := pds.Execute(node)
+			Expect(result.HasExecuted).To(BeFalse())
+			Expect(err).To(BeNil())
+		})
+
+		It("Returns error if fails to return a list of pods", func() {
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
+			)
+			_, err := pds.Execute(node)
+			Expect(err).To(HaveOccurred())
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("Returns error if failed to delete pod", func() {
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+				mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("fake error")),
+			)
+			_, err := pds.Execute(node)
+			Expect(err).To(HaveOccurred())
+			Expect(err).NotTo(BeNil())
+		})
+	})
+
+	Context("Check if it's still valid to delete a pod", func() {
+		It("Returns true if there are target pods to be deleted", func() {
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+			)
+			valid, err := pds.IsValid(node)
+			Expect(valid).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+
+		It("Returns false if there are any errors while getting list of pods to be deleted", func() {
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
+			)
+			valid, err := pds.IsValid(node)
+			Expect(valid).To(BeFalse())
+			Expect(err).To(HaveOccurred())
+			Expect(err).NotTo(BeNil())
+
+		})
+	})
+
+	Context("Get Pod List to be deleted", func() {
+		It("Returns list of pods with no errors", func() {
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+			)
+			_, err := pds.getPodList(node)
+			Expect(err).To(BeNil())
+		})
+
+		It("Returns no pods if there is any error while listing pods", func() {
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
+			)
+			_, err := pds.getPodList(node)
+			Expect(err).To(HaveOccurred())
+			Expect(err).NotTo(BeNil())
+		})
+	})
+})

--- a/pkg/drain/removeFinalizersStrategy_test.go
+++ b/pkg/drain/removeFinalizersStrategy_test.go
@@ -1,0 +1,178 @@
+package drain
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/mock/gomock"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/managed-upgrade-operator/pkg/pod"
+	"github.com/openshift/managed-upgrade-operator/util/mocks"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	NODENAME = "n1"
+)
+
+var _ = Describe("Remove Finalizer Strategy", func() {
+
+	var (
+		mockCtrl       *gomock.Controller
+		mockKubeClient *mocks.MockClient
+		rfs            *removeFinalizersStrategy
+		node           *corev1.Node
+		podList        corev1.PodList
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockKubeClient = mocks.NewMockClient(mockCtrl)
+		node = &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: NODENAME,
+			},
+		}
+		rfs = &removeFinalizersStrategy{
+			client:  mockKubeClient,
+			filters: []pod.PodPredicate{isOnNode(node), hasFinalizers},
+		}
+
+		podList = corev1.PodList{
+			Items: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+						Finalizers: []string{
+							"finalizer1",
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: NODENAME,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod2",
+						Finalizers: []string{
+							"finalizer2",
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "dummy",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod3",
+					},
+					Spec: corev1.PodSpec{
+						NodeName: NODENAME,
+					},
+				},
+			},
+		}
+	})
+
+	Context("Execute remove finalizers strategy on a node", func() {
+		It("Successfully removes finalizers from pod with finalizer", func() {
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+				mockKubeClient.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, pod *corev1.Pod) error {
+						Expect(len(pod.ObjectMeta.Finalizers)).To(Equal(0))
+						return nil
+					}),
+			)
+			result, err := rfs.Execute(node)
+			Expect(result.HasExecuted).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+
+		It("Does nothing if no pod found with finalizer", func() {
+			noFinalizerPods := corev1.PodList{
+				Items: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "dummy-pod",
+						},
+						Spec: corev1.PodSpec{
+							NodeName: NODENAME,
+						},
+					},
+				},
+			}
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, noFinalizerPods),
+			)
+			result, err := rfs.Execute(node)
+			Expect(result.HasExecuted).To(BeFalse())
+			Expect(err).To(BeNil())
+		})
+
+		It("Returns error if fails to return a list of pods", func() {
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
+			)
+			_, err := rfs.Execute(node)
+			Expect(err).To(HaveOccurred())
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("Returns error if failed to remove finalizer from the pod", func() {
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+				mockKubeClient.EXPECT().Update(gomock.Any(), gomock.Any()).Return(fmt.Errorf("fake error")),
+			)
+			_, err := rfs.Execute(node)
+			Expect(err).To(HaveOccurred())
+			Expect(err).NotTo(BeNil())
+		})
+	})
+
+	Context("Check if it's still valid to apply removeFinalizerStrategy on a node", func() {
+		It("Returns true if there are target pods with finalizers", func() {
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+			)
+			valid, err := rfs.IsValid(node)
+			Expect(valid).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+
+		It("Returns false if there are any errors while getting list of pods", func() {
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
+			)
+			valid, err := rfs.IsValid(node)
+			Expect(valid).To(BeFalse())
+			Expect(err).To(HaveOccurred())
+			Expect(err).NotTo(BeNil())
+
+		})
+	})
+
+	Context("Get Pod List with finalizers", func() {
+		It("Returns list of pods with no errors", func() {
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+			)
+			_, err := rfs.getPodList(node)
+			Expect(err).To(BeNil())
+		})
+
+		It("Returns no pods if there is any error while listing pods", func() {
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
+			)
+			_, err := rfs.getPodList(node)
+			Expect(err).To(HaveOccurred())
+			Expect(err).NotTo(BeNil())
+		})
+	})
+})

--- a/pkg/drain/stuckTerminatingStrategy.go
+++ b/pkg/drain/stuckTerminatingStrategy.go
@@ -2,6 +2,7 @@ package drain
 
 import (
 	"context"
+
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/pkg/drain/stuckTerminatingStrategy_test.go
+++ b/pkg/drain/stuckTerminatingStrategy_test.go
@@ -1,0 +1,184 @@
+package drain
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang/mock/gomock"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/managed-upgrade-operator/pkg/pod"
+	"github.com/openshift/managed-upgrade-operator/util/mocks"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Stuck Terminating Strategy", func() {
+
+	var (
+		mockCtrl       *gomock.Controller
+		mockKubeClient *mocks.MockClient
+		sts            *stuckTerminatingStrategy
+		node           *corev1.Node
+		podList        corev1.PodList
+
+		NODENAME string
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockKubeClient = mocks.NewMockClient(mockCtrl)
+		NODENAME = "n1"
+
+		node = &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: NODENAME,
+			},
+		}
+		sts = &stuckTerminatingStrategy{
+			client:  mockKubeClient,
+			filters: []pod.PodPredicate{isOnNode(node), hasNoFinalizers, isTerminating},
+		}
+
+		podList = corev1.PodList{
+			Items: []corev1.Pod{
+				{
+
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "pod1",
+						DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: NODENAME,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "pod2",
+						DeletionTimestamp: &metav1.Time{Time: time.Now()},
+						Finalizers: []string{
+							"finalizer2",
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: NODENAME,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "pod3",
+						DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "n2",
+					},
+				},
+			},
+		}
+	})
+
+	Context("Execute stuck terminating strategy on a node", func() {
+
+		It("Successfully deletes pods stuck in terminating state", func() {
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+				mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()),
+			)
+			result, err := sts.Execute(node)
+			Expect(result.HasExecuted).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+
+		It("Does nothing if no pod found in terminating state", func() {
+			noTerminatingPods := corev1.PodList{
+				Items: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "p1",
+						},
+						Spec: corev1.PodSpec{
+							NodeName: NODENAME,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "p2",
+						},
+						Spec: corev1.PodSpec{
+							NodeName: NODENAME,
+						},
+					},
+				},
+			}
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, noTerminatingPods),
+			)
+			result, err := sts.Execute(node)
+			Expect(result.HasExecuted).To(BeFalse())
+			Expect(err).To(BeNil())
+		})
+
+		It("Returns error if fails to return a list of pods", func() {
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
+			)
+			_, err := sts.Execute(node)
+			Expect(err).To(HaveOccurred())
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("Returns error if failed to delete pod stuck in terminating state", func() {
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+				mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("fake error")),
+			)
+			_, err := sts.Execute(node)
+			Expect(err).To(HaveOccurred())
+			Expect(err).NotTo(BeNil())
+		})
+	})
+
+	Context("Check if it's still valid to apply stuckTerminating strategy on a node", func() {
+		It("Returns true if there are target pods stuck in terminating with no finalizers", func() {
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+			)
+			valid, err := sts.IsValid(node)
+			Expect(valid).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+
+		It("Returns false if there are any errors while getting list of pods stuck in terminating wtih no finalizers", func() {
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
+			)
+			valid, err := sts.IsValid(node)
+			Expect(valid).To(BeFalse())
+			Expect(err).To(HaveOccurred())
+			Expect(err).NotTo(BeNil())
+
+		})
+	})
+
+	Context("Get Pod List with no finalizers and stuck in terminating state", func() {
+		It("Returns list of pods with no errors", func() {
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+			)
+			_, err := sts.getPodList(node)
+			Expect(err).To(BeNil())
+		})
+
+		It("Returns no pods if there is any error while listing pods", func() {
+			gomock.InOrder(
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
+			)
+			_, err := sts.getPodList(node)
+			Expect(err).To(HaveOccurred())
+			Expect(err).NotTo(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
### What type of PR is this?
_(test)_

### What this PR does / why we need it?
This PR adds tests for the following following strategies for `pkg/drain` package.
- removeFinalizerStrategy
- stuckTerminatingStrategy
- podDeleteStrategy

### Which Jira/Github issue(s) this PR fixes?
_Fixes #_ https://issues.redhat.com/browse/OSD-4715 

### Special notes for your reviewer:
- Some of the tests/scenarios already covered in [pod_test.go](https://github.com/openshift/managed-upgrade-operator/blob/master/pkg/pod/pod_test.go) so kept current tests cover overview cases.
- Might have missed some scenarios/tests which can add further

### Pre-checks (if applicable):
- [x] Ran `make test` locally to validate that the tests are running fine.

