### PR TITLE
OSD-6525 Metric Crashloops

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -257,7 +257,6 @@ func addMetrics(ctx context.Context, cfg *rest.Config) error {
 	// necessary to configure Prometheus to scrape metrics from this operator.
 	services := []*v1.Service{service}
 
-	var serviceMonitors []*monitoringv1.ServiceMonitor
 	mclient := monclientv1.NewForConfigOrDie(cfg)
 
 	for _, s := range services {
@@ -271,7 +270,7 @@ func addMetrics(ctx context.Context, cfg *rest.Config) error {
 
 		log.Info(fmt.Sprintf("Attempting to create service monitor %s", sm.Name))
 		// TODO: Get SM and compare to see if an UPDATE is required
-		smc, err := mclient.ServiceMonitors(operatorNs).Create(sm)
+		_, err := mclient.ServiceMonitors(operatorNs).Create(sm)
 		if err != nil {
 			if err.Error() != ErrSMMetricsExists {
 				return err
@@ -279,7 +278,6 @@ func addMetrics(ctx context.Context, cfg *rest.Config) error {
 			log.Info("ServiceMonitor already exists")
 		}
 		log.Info(fmt.Sprintf("Successfully created service monitor %s", sm.Name))
-		serviceMonitors = append(serviceMonitors, smc)
 	}
 	return nil
 }

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	monclientv1 "github.com/coreos/prometheus-operator/pkg/client/versioned/typed/monitoring/v1"
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	machineapi "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
@@ -37,20 +38,19 @@ import (
 	"github.com/openshift/managed-upgrade-operator/version"
 	opmetrics "github.com/openshift/operator-custom-metrics/pkg/metrics"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Change below variables to serve metrics on different host or port.
 var (
-	metricsHost               = "0.0.0.0"
-	metricsPort         int32 = 8383
-	operatorMetricsPort int32 = 8686
-	customMetricsPath         = "/metrics"
+	metricsHost             = "0.0.0.0"
+	metricsPort       int32 = 8383
+	customMetricsPath       = "/metrics"
 )
 var log = logf.Log.WithName("cmd")
 
@@ -242,15 +242,9 @@ func addMetrics(ctx context.Context, cfg *rest.Config) error {
 		}
 	}
 
-	if err := serveCRMetrics(cfg, operatorNs); err != nil {
-		log.Info("Could not generate and serve custom resource metrics", "error", err.Error())
-		return err
-	}
-
 	// Add to the below struct any other metrics ports you want to expose.
 	servicePorts := []v1.ServicePort{
 		{Port: metricsPort, Name: metrics.OperatorPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}},
-		{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
 	}
 
 	// Create Service object to expose the metrics port(s).
@@ -263,42 +257,72 @@ func addMetrics(ctx context.Context, cfg *rest.Config) error {
 	// necessary to configure Prometheus to scrape metrics from this operator.
 	services := []*v1.Service{service}
 
-	// The ServiceMonitor is created in the same namespace where the operator is deployed
-	_, err = metrics.CreateServiceMonitors(cfg, operatorNs, services)
-	if err != nil {
-		log.Info("Could not create ServiceMonitor object", "error", err.Error())
-		// If this operator is deployed to a cluster without the prometheus-operator running, it will return
-		// ErrServiceMonitorNotPresent, which can be used to safely skip ServiceMonitor creation.
-		if err == metrics.ErrServiceMonitorNotPresent {
-			log.Info("Install prometheus-operator in your cluster to create ServiceMonitor objects", "error", err.Error())
-		}
+	var serviceMonitors []*monitoringv1.ServiceMonitor
+	mclient := monclientv1.NewForConfigOrDie(cfg)
 
+	for _, s := range services {
+		if s == nil {
+			continue
+		}
+		sm := GenerateServiceMonitor(s)
+
+		// ErrSMMetricsExists is used to detect if the -metrics ServiceMonitor already exists
+		var ErrSMMetricsExists = fmt.Sprintf("servicemonitors.monitoring.coreos.com \"%s-metrics\" already exists", muocfg.OperatorName)
+
+		log.Info(fmt.Sprintf("Attempting to create service monitor %s", sm.Name))
+		// TODO: Get SM and compare to see if an UPDATE is required
+		smc, err := mclient.ServiceMonitors(operatorNs).Create(sm)
+		if err != nil {
+			if err.Error() != ErrSMMetricsExists {
+				return err
+			}
+			log.Info("ServiceMonitor already exists")
+		}
+		log.Info(fmt.Sprintf("Successfully created service monitor %s", sm.Name))
+		serviceMonitors = append(serviceMonitors, smc)
 	}
 	return nil
 }
 
-// serveCRMetrics gets the Operator/CustomResource GVKs and generates metrics based on those types.
-// It serves those metrics on "http://metricsHost:operatorMetricsPort".
-func serveCRMetrics(cfg *rest.Config, operatorNs string) error {
-	// The function below returns a list of filtered operator/CR specific GVKs. For more control, override the GVK list below
-	// with your own custom logic. Note that if you are adding third party API schemas, probably you will need to
-	// customize this implementation to avoid permissions issues.
-	filteredGVK, err := k8sutil.GetGVKsFromAddToScheme(apis.AddToScheme)
-	if err != nil {
-		return err
+// GenerateServiceMonitor generates a prometheus-operator ServiceMonitor object
+// based on the passed Service object.
+func GenerateServiceMonitor(s *v1.Service) *monitoringv1.ServiceMonitor {
+	labels := make(map[string]string)
+	for k, v := range s.ObjectMeta.Labels {
+		labels[k] = v
 	}
+	endpoints := populateEndpointsFromServicePorts(s)
+	boolTrue := true
 
-	// The metrics will be generated from the namespaces which are returned here.
-	// NOTE that passing nil or an empty list of namespaces in GenerateAndServeCRMetrics will result in an error.
-	ns, err := kubemetrics.GetNamespacesForMetrics(operatorNs)
-	if err != nil {
-		return err
+	return &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      s.ObjectMeta.Name,
+			Namespace: s.ObjectMeta.Namespace,
+			Labels:    labels,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "v1",
+					BlockOwnerDeletion: &boolTrue,
+					Controller:         &boolTrue,
+					Kind:               "Service",
+					Name:               s.Name,
+					UID:                s.UID,
+				},
+			},
+		},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Endpoints: endpoints,
+		},
 	}
+}
 
-	// Generate and serve custom resource specific metrics.
-	err = kubemetrics.GenerateAndServeCRMetrics(cfg, ns, filteredGVK, metricsHost, operatorMetricsPort)
-	if err != nil {
-		return err
+func populateEndpointsFromServicePorts(s *v1.Service) []monitoringv1.Endpoint {
+	var endpoints []monitoringv1.Endpoint
+	for _, port := range s.Spec.Ports {
+		endpoints = append(endpoints, monitoringv1.Endpoint{Port: port.Name})
 	}
-	return nil
+	return endpoints
 }


### PR DESCRIPTION
### What type of PR is this?
bug/feature

### What this PR does / why we need it? 

This PR enables MUO to tolerate a broken API and continue to start up.

```
{"level":"info","ts":1613702576.7495096,"logger":"cmd","msg":"Registering Components."}
{"level":"info","ts":1613702604.9765215,"logger":"cmd","msg":"Could not generate and serve custom resource metrics","error":"discovering resource information failed for UpgradeConfig in upgrade.managed.openshift.io/v1alpha1: unable to retrieve the complete list of server APIs: webhook.certmanager.k8s.io/v1beta1: the server is currently unable to handle the request"}
{"level":"error","ts":1613702604.9765632,"logger":"cmd","msg":"Metrics service is not added.","error":"discovering resource information failed for UpgradeConfig in upgrade.managed.openshift.io/v1alpha1: unable to retrieve the complete list of server APIs: webhook.certmanager.k8s.io/v1beta1: the server is currently unable to handle the request","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\tpkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\nmain.main\n\t/workdir/cmd/manager/main.go:165\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:203"}
```

It does so by ripping out the metrics start up pieces from the
operator-sdk. Currently the sdk `Lists` all APIs and returns an error on
borken ones. Hence the above logs.

This PR moves that logic into the main.go so we can manipulate as
please. A refactor card will be created to follow this PR up.

How to replicate:

Create a broken apiservice

```
$ curl
https://raw.githubusercontent.com/dofinn/crs/main/api/apiservices/broken/apiservice.yaml
| oc --as backplane-cluster-admin create -f
```

Validate its broken

```
$ oc  api-resources | grep cert
certificatesigningrequests            csr                                certificates.k8s.io/v1                          false        CertificateSigningRequest
certmanagers                                                             operator.cert-manager.io/v1alpha1               true         CertManager
error: unable to retrieve the complete list of server APIs: webhook.certmanager.k8s.io/v1beta1: the server is currently unable to handle the request
```

Run MUO

It now handles this without performing a list of all apiservers and
matching the target api-resources based on GVK.

### Which Jira/Github issue(s) this PR fixes?

[OSD-6525](https://issues.redhat.com/browse/OSD-6525)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

