### PR TITLE
handle broken APIs

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	monclientv1 "github.com/coreos/prometheus-operator/pkg/client/versioned/typed/monitoring/v1"
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	machineapi "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
@@ -37,20 +38,19 @@ import (
 	"github.com/openshift/managed-upgrade-operator/version"
 	opmetrics "github.com/openshift/operator-custom-metrics/pkg/metrics"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Change below variables to serve metrics on different host or port.
 var (
-	metricsHost               = "0.0.0.0"
-	metricsPort         int32 = 8383
-	operatorMetricsPort int32 = 8686
-	customMetricsPath         = "/metrics"
+	metricsHost             = "0.0.0.0"
+	metricsPort       int32 = 8383
+	customMetricsPath       = "/metrics"
 )
 var log = logf.Log.WithName("cmd")
 
@@ -242,15 +242,9 @@ func addMetrics(ctx context.Context, cfg *rest.Config) error {
 		}
 	}
 
-	if err := serveCRMetrics(cfg, operatorNs); err != nil {
-		log.Info("Could not generate and serve custom resource metrics", "error", err.Error())
-		return err
-	}
-
 	// Add to the below struct any other metrics ports you want to expose.
 	servicePorts := []v1.ServicePort{
 		{Port: metricsPort, Name: metrics.OperatorPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}},
-		{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
 	}
 
 	// Create Service object to expose the metrics port(s).
@@ -259,46 +253,30 @@ func addMetrics(ctx context.Context, cfg *rest.Config) error {
 		log.Info("Could not create metrics Service", "error", err.Error())
 	}
 
-	// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
-	// necessary to configure Prometheus to scrape metrics from this operator.
 	services := []*v1.Service{service}
+	mclient := monclientv1.NewForConfigOrDie(cfg)
+	copts := metav1.CreateOptions{}
 
-	// The ServiceMonitor is created in the same namespace where the operator is deployed
-	_, err = metrics.CreateServiceMonitors(cfg, operatorNs, services)
-	if err != nil {
-		log.Info("Could not create ServiceMonitor object", "error", err.Error())
-		// If this operator is deployed to a cluster without the prometheus-operator running, it will return
-		// ErrServiceMonitorNotPresent, which can be used to safely skip ServiceMonitor creation.
-		if err == metrics.ErrServiceMonitorNotPresent {
-			log.Info("Install prometheus-operator in your cluster to create ServiceMonitor objects", "error", err.Error())
+	for _, s := range services {
+		if s == nil {
+			continue
 		}
 
-	}
-	return nil
-}
+		sm := metrics.GenerateServiceMonitor(s)
 
-// serveCRMetrics gets the Operator/CustomResource GVKs and generates metrics based on those types.
-// It serves those metrics on "http://metricsHost:operatorMetricsPort".
-func serveCRMetrics(cfg *rest.Config, operatorNs string) error {
-	// The function below returns a list of filtered operator/CR specific GVKs. For more control, override the GVK list below
-	// with your own custom logic. Note that if you are adding third party API schemas, probably you will need to
-	// customize this implementation to avoid permissions issues.
-	filteredGVK, err := k8sutil.GetGVKsFromAddToScheme(apis.AddToScheme)
-	if err != nil {
-		return err
-	}
+		// ErrSMMetricsExists is used to detect if the -metrics ServiceMonitor already exists
+		var ErrSMMetricsExists = fmt.Sprintf("servicemonitors.monitoring.coreos.com \"%s-metrics\" already exists", muocfg.OperatorName)
 
-	// The metrics will be generated from the namespaces which are returned here.
-	// NOTE that passing nil or an empty list of namespaces in GenerateAndServeCRMetrics will result in an error.
-	ns, err := kubemetrics.GetNamespacesForMetrics(operatorNs)
-	if err != nil {
-		return err
-	}
-
-	// Generate and serve custom resource specific metrics.
-	err = kubemetrics.GenerateAndServeCRMetrics(cfg, ns, filteredGVK, metricsHost, operatorMetricsPort)
-	if err != nil {
-		return err
+		log.Info(fmt.Sprintf("Attempting to create service monitor %s", sm.Name))
+		// TODO: Get SM and compare to see if an UPDATE is required
+		_, err := mclient.ServiceMonitors(operatorNs).Create(ctx, sm, copts)
+		if err != nil {
+			if err.Error() != ErrSMMetricsExists {
+				return err
+			}
+			log.Info("ServiceMonitor already exists")
+		}
+		log.Info(fmt.Sprintf("Successfully configured service monitor %s", sm.Name))
 	}
 	return nil
 }


### PR DESCRIPTION
### What type of PR is this?
bug/feature

### What this PR does / why we need it? 

This PR enables MUO to tolerate a broken API and continue to start up.

```
{"level":"info","ts":1613702576.7495096,"logger":"cmd","msg":"Registering Components."}
{"level":"info","ts":1613702604.9765215,"logger":"cmd","msg":"Could not generate and serve custom resource metrics","error":"discovering resource information failed for UpgradeConfig in upgrade.managed.openshift.io/v1alpha1: unable to retrieve the complete list of server APIs: webhook.certmanager.k8s.io/v1beta1: the server is currently unable to handle the request"}
{"level":"error","ts":1613702604.9765632,"logger":"cmd","msg":"Metrics service is not added.","error":"discovering resource information failed for UpgradeConfig in upgrade.managed.openshift.io/v1alpha1: unable to retrieve the complete list of server APIs: webhook.certmanager.k8s.io/v1beta1: the server is currently unable to handle the request","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\tpkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\nmain.main\n\t/workdir/cmd/manager/main.go:165\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:203"}
```

It does so by ripping out the metrics start up pieces from the
operator-sdk. Currently the sdk `Lists` all APIs and returns an error on
borken ones. Hence the above logs.

This PR moves that logic into the main.go so we can manipulate as
please. A refactor card will be created to follow this PR up.

How to replicate:

Create a broken apiservice

```
$ curl
https://raw.githubusercontent.com/dofinn/crs/main/api/apiservices/broken/apiservice.yaml
| oc --as backplane-cluster-admin create -f -
```

Validate its broken

```
$ oc  api-resources | grep cert
certificatesigningrequests            csr                                certificates.k8s.io/v1                          false        CertificateSigningRequest
certmanagers                                                             operator.cert-manager.io/v1alpha1               true         CertManager
error: unable to retrieve the complete list of server APIs: webhook.certmanager.k8s.io/v1beta1: the server is currently unable to handle the request
```

Run MUO

It now handles this without performing a list of all apiservers and
matching the target api-resources based on GVK.

### Which Jira/Github issue(s) this PR fixes?

[OSD-6525](https://issues.redhat.com/browse/OSD-6525)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR