### PR TITLE
Add support for upgrades using image digest reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ If you like to contribute to the Managed Upgrade Operator, please read our [Cont
      * As steps are launched or complete, they are added to the `UpgradeConfig`'s Status History. 
 5. Once all steps have been completed, the upgrade is considered complete and a Status History entry is written to indicate that the `UpgradeConfig` has been applied.
 
-### Example Input Custom Resource
+## Sample UpgradeConfig CR definition
+
+### Example 1 - OSD upgrade using to version 4.4.6 using fast channel
 
 ```yaml
 apiVersion: upgrade.managed.openshift.io/v1alpha1
@@ -65,4 +67,20 @@ spec:
   desired:
     channel: "fast-4.4"
     version: "4.4.6"
+```
+
+### Example 2 - OSD upgrade using to 4.7.13 using image digest
+
+```yaml
+apiVersion: upgrade.managed.openshift.io/v1alpha1
+kind: UpgradeConfig
+metadata:
+  name: managed-upgrade-config
+spec:
+  type: "OSD"
+  upgradeAt: "2021-01-01T00:00:00Z"
+  PDBForceDrainTimeout: 60
+  desired:
+    image: "quay.io/openshift-release-dev/ocp-release@sha256:783a2c963f35ccab38e82e6a8c7fa954c3a4551e07d2f43c06098828dd986ed4"
+    version: "4.7.13"
 ```

--- a/deploy/crds/upgrade.managed.openshift.io_upgradeconfigs_crd.yaml
+++ b/deploy/crds/upgrade.managed.openshift.io_upgradeconfigs_crd.yaml
@@ -61,12 +61,12 @@ spec:
                 channel:
                   description: Channel used for upgrades
                   type: string
+                image:
+                  description: Image reference used for upgrades
+                  type: string
                 version:
                   description: Version of openshift release
                   type: string
-              required:
-                - channel
-                - version
               type: object
             type:
               description: Type indicates the ClusterUpgrader implementation to use to perform an upgrade of the cluster

--- a/docs/design.md
+++ b/docs/design.md
@@ -33,6 +33,7 @@ For the purpose of upgrading a cluster, an `UpgradeConfig` resource _must_ be co
 | `PDBForceDrainTimeout` | Duration in minutes that a PDB-blocked node is allowed to drain before a drain is forced | `120` |
 | `desired.version` | The desired OCP release to upgrade to | `4.4.6` |
 | `desired.channel` | The [channel](https://github.com/openshift/cincinnati/blob/master/docs/design/openshift.md#Channels) the Cluster Version Operator should be using to validate update versions | `fast-4.4` |
+| `desired.image`   | The image digest that CVO should use to upgrade cluster. To be used with `version`. | quay.io/openshift-release-dev/ocp-release@sha256:783a2c963f35ccab38e82e6a8c7fa954c3a4551e07d2f43c06098828dd986ed4 |
 | `capacityReservation` | If extra worker node(s) are needed during the upgrade to hold the customer workload | `true` |
 
 A populated `UpgradeConfig` example is presented below:

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/onsi/gomega v1.10.2
 	github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible
 	github.com/openshift/cluster-version-operator v3.11.1-0.20190629164025-08cac1c02538+incompatible
+	github.com/openshift/library-go v0.0.0-20200831114015-2ab0c61c15de
 	github.com/openshift/machine-api-operator v0.2.1-0.20200226185612-9b0170a1ba07
 	github.com/openshift/machine-config-operator v0.0.1-0.20200913004441-7eba765c69c9
 	github.com/openshift/operator-custom-metrics v0.4.2

--- a/go.sum
+++ b/go.sum
@@ -844,6 +844,7 @@ github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGm
 github.com/openshift/cluster-version-operator v3.11.1-0.20190629164025-08cac1c02538+incompatible h1:aLjroKDBGQ7oW2R8876TsB1nKIl+loREmjEVm0aqTno=
 github.com/openshift/cluster-version-operator v3.11.1-0.20190629164025-08cac1c02538+incompatible/go.mod h1:0BbpR1mrN0F2ZRae5N1XHcytmkvVPaeKgSQwRRBWugc=
 github.com/openshift/library-go v0.0.0-20191003152030-97c62d8a2901/go.mod h1:NBttNjZpWwup/nthuLbPAPSYC8Qyo+BBK5bCtFoyYjo=
+github.com/openshift/library-go v0.0.0-20200831114015-2ab0c61c15de h1:V984tJombwXeUvZaMiMSzN6yOiHUdd1kWLHS1a54Yrw=
 github.com/openshift/library-go v0.0.0-20200831114015-2ab0c61c15de/go.mod h1:6vwp+YhYOIlj8MpkQKkebTTSn2TuYyvgiAFQ206jIEQ=
 github.com/openshift/machine-api-operator v0.2.1-0.20200226185612-9b0170a1ba07 h1:S5OTK8uPzYJrnoHlYaQzQg6VbEfbY1UFL6cx5mHw87M=
 github.com/openshift/machine-api-operator v0.2.1-0.20200226185612-9b0170a1ba07/go.mod h1:b3huCV+DbroXP1sHtsU5xBwx97zqc6GKB5owyl2zsNM=

--- a/pkg/apis/upgrade/v1alpha1/upgradeconfig_types.go
+++ b/pkg/apis/upgrade/v1alpha1/upgradeconfig_types.go
@@ -189,9 +189,14 @@ type UpgradeConfigList struct {
 type Update struct {
 	// Version of openshift release
 	// +kubebuilder:validation:Type=string
-	Version string `json:"version"`
+	// +optional
+	Version string `json:"version,omitempty"`
 	// Channel used for upgrades
-	Channel string `json:"channel"`
+	// +optional
+	Channel string `json:"channel,omitempty"`
+	// Image reference used for upgrades
+	// +optional
+	Image string `json:"image,omitempty"`
 }
 
 // IsTrue Condition whether the condition status is "True".

--- a/pkg/clusterversion/clusterversion_test.go
+++ b/pkg/clusterversion/clusterversion_test.go
@@ -115,7 +115,7 @@ var _ = Describe("ClusterVersion client and utils", func() {
 								return nil
 							}),
 					)
-					isCompleted, err := cvClient.EnsureDesiredVersion(upgradeConfig)
+					isCompleted, err := cvClient.EnsureDesiredConfig(upgradeConfig)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(isCompleted).To(BeTrue())
 				})
@@ -146,7 +146,7 @@ var _ = Describe("ClusterVersion client and utils", func() {
 								return nil
 							}),
 					)
-					isCompleted, err := cvClient.EnsureDesiredVersion(upgradeConfig)
+					isCompleted, err := cvClient.EnsureDesiredConfig(upgradeConfig)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(isCompleted).To(BeTrue())
 				})
@@ -179,7 +179,7 @@ var _ = Describe("ClusterVersion client and utils", func() {
 								return nil
 							}),
 					)
-					isCompleted, err := cvClient.EnsureDesiredVersion(upgradeConfig)
+					isCompleted, err := cvClient.EnsureDesiredConfig(upgradeConfig)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(isCompleted).To(BeTrue())
 				})

--- a/pkg/clusterversion/cv.go
+++ b/pkg/clusterversion/cv.go
@@ -10,14 +10,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	upgradev1alpha1 "github.com/openshift/managed-upgrade-operator/pkg/apis/upgrade/v1alpha1"
 )
 
 var (
 	// OSD_CV_NAME is the name of cluster version singleton
-	OSD_CV_NAME = "version"
-	logger      logr.Logger
+	OSD_CV_NAME             = "version"
+	logger      logr.Logger = logf.Log.WithName("clusterversion")
 )
 
 // ClusterVersion interface enables implementations of the ClusterVersion

--- a/pkg/clusterversion/cv.go
+++ b/pkg/clusterversion/cv.go
@@ -127,8 +127,9 @@ func (c *clusterVersionClient) EnsureDesiredConfig(uc *upgradev1alpha1.UpgradeCo
 	}
 
 	// If neither (version+channel) nor (image) is defined, throw error.
+	// TODO OSD-7609 to remove (image+version) dependency
 	if (empty(desired.Version) && empty(desired.Channel)) && empty(desired.Image) {
-		return false, fmt.Errorf("need atleast (version+channel) or (image) defined in UpgradeConfig")
+		return false, fmt.Errorf("need either (version+channel) or (image+version) defined in UpgradeConfig")
 	}
 
 	return true, nil

--- a/pkg/clusterversion/mocks/mockClusterVersion.go
+++ b/pkg/clusterversion/mocks/mockClusterVersion.go
@@ -35,19 +35,19 @@ func (m *MockClusterVersion) EXPECT() *MockClusterVersionMockRecorder {
 	return m.recorder
 }
 
-// EnsureDesiredVersion mocks base method
-func (m *MockClusterVersion) EnsureDesiredVersion(arg0 *v1alpha1.UpgradeConfig) (bool, error) {
+// EnsureDesiredConfig mocks base method
+func (m *MockClusterVersion) EnsureDesiredConfig(arg0 *v1alpha1.UpgradeConfig) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureDesiredVersion", arg0)
+	ret := m.ctrl.Call(m, "EnsureDesiredConfig", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// EnsureDesiredVersion indicates an expected call of EnsureDesiredVersion
-func (mr *MockClusterVersionMockRecorder) EnsureDesiredVersion(arg0 interface{}) *gomock.Call {
+// EnsureDesiredConfig indicates an expected call of EnsureDesiredConfig
+func (mr *MockClusterVersionMockRecorder) EnsureDesiredConfig(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureDesiredVersion", reflect.TypeOf((*MockClusterVersion)(nil).EnsureDesiredVersion), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureDesiredConfig", reflect.TypeOf((*MockClusterVersion)(nil).EnsureDesiredConfig), arg0)
 }
 
 // GetClusterVersion mocks base method

--- a/pkg/upgraders/osd/upgrader.go
+++ b/pkg/upgraders/osd/upgrader.go
@@ -127,13 +127,8 @@ func PreClusterHealthCheck(c client.Client, cfg *osdUpgradeConfig, scaler scaler
 		return false, err
 	}
 
-	desired := upgradeConfig.Spec.Desired
 	if upgradeCommenced {
-		if len(desired.Channel) > 0 && len(desired.Version) > 0 {
-			logger.Info(fmt.Sprintf("ClusterVersion is already set to Channel %s Version %s, skipping %s", desired.Channel, desired.Version, upgradev1alpha1.UpgradePreHealthCheck))
-		} else if len(desired.Image) > 0 && len(desired.Version) > 0 {
-			logger.Info(fmt.Sprintf("ClusterVersion is already set to Image %s, skipping %s", desired.Image, upgradev1alpha1.UpgradePreHealthCheck))
-		}
+		logger.Info(fmt.Sprintf("Skipping upgrade step %s", upgradev1alpha1.UpgradePreHealthCheck))
 		return true, nil
 	}
 
@@ -160,13 +155,8 @@ func EnsureExtraUpgradeWorkers(c client.Client, cfg *osdUpgradeConfig, s scaler.
 		return false, err
 	}
 
-	desired := upgradeConfig.Spec.Desired
 	if upgradeCommenced {
-		if len(desired.Channel) > 0 && len(desired.Version) > 0 {
-			logger.Info(fmt.Sprintf("ClusterVersion is already set to Channel %s Version %s, skipping %s", desired.Channel, desired.Version, upgradev1alpha1.UpgradeScaleUpExtraNodes))
-		} else if len(desired.Image) > 0 && len(desired.Version) > 0 {
-			logger.Info(fmt.Sprintf("ClusterVersion is already set to Image %s, skipping %s", desired.Image, upgradev1alpha1.UpgradeScaleUpExtraNodes))
-		}
+		logger.Info(fmt.Sprintf("Skipping upgrade step %s", upgradev1alpha1.UpgradeScaleUpExtraNodes))
 		return true, nil
 	}
 
@@ -192,13 +182,8 @@ func ExternalDependencyAvailabilityCheck(c client.Client, cfg *osdUpgradeConfig,
 		return false, err
 	}
 
-	desired := upgradeConfig.Spec.Desired
 	if upgradeCommenced {
-		if len(desired.Channel) > 0 && len(desired.Version) > 0 {
-			logger.Info(fmt.Sprintf("ClusterVersion is already set to Channel %s Version %s, skipping %s", desired.Channel, desired.Version, upgradev1alpha1.ExtDepAvailabilityCheck))
-		} else if len(desired.Image) > 0 && len(desired.Version) > 0 {
-			logger.Info(fmt.Sprintf("ClusterVersion is already set to Image %s, skipping %s", desired.Image, upgradev1alpha1.ExtDepAvailabilityCheck))
-		}
+		logger.Info(fmt.Sprintf("Skipping upgrade step %s", upgradev1alpha1.ExtDepAvailabilityCheck))
 		return true, nil
 	}
 
@@ -230,20 +215,9 @@ func CommenceUpgrade(c client.Client, cfg *osdUpgradeConfig, scaler scaler.Scale
 		return false, err
 	}
 
-	desired := upgradeConfig.Spec.Desired
 	if upgradeCommenced {
-		if len(desired.Channel) > 0 && len(desired.Version) > 0 {
-			logger.Info(fmt.Sprintf("ClusterVersion is already set to Channel %s Version %s, skipping %s", desired.Channel, desired.Version, upgradev1alpha1.CommenceUpgrade))
-		} else if len(desired.Image) > 0 && len(desired.Version) > 0 {
-			logger.Info(fmt.Sprintf("ClusterVersion is already set to Image %s, skipping %s", desired.Image, upgradev1alpha1.CommenceUpgrade))
-		}
+		logger.Info(fmt.Sprintf("Skipping upgrade step %s", upgradev1alpha1.CommenceUpgrade))
 		return true, nil
-	}
-
-	if len(desired.Channel) > 0 && len(desired.Version) > 0 {
-		logger.Info(fmt.Sprintf("Setting ClusterVersion to Channel %s, version %s", desired.Channel, desired.Version))
-	} else if len(desired.Image) > 0 && len(desired.Version) > 0 {
-		logger.Info(fmt.Sprintf("Setting ClusterVersion to Image %s", desired.Image))
 	}
 
 	isComplete, err := cvClient.EnsureDesiredConfig(upgradeConfig)

--- a/pkg/upgraders/osd/upgrader.go
+++ b/pkg/upgraders/osd/upgrader.go
@@ -126,9 +126,14 @@ func PreClusterHealthCheck(c client.Client, cfg *osdUpgradeConfig, scaler scaler
 	if err != nil {
 		return false, err
 	}
+
 	desired := upgradeConfig.Spec.Desired
 	if upgradeCommenced {
-		logger.Info(fmt.Sprintf("ClusterVersion is already set to Channel %s Version %s, skipping %s", desired.Channel, desired.Version, upgradev1alpha1.UpgradePreHealthCheck))
+		if len(desired.Channel) > 0 && len(desired.Version) > 0 {
+			logger.Info(fmt.Sprintf("ClusterVersion is already set to Channel %s Version %s, skipping %s", desired.Channel, desired.Version, upgradev1alpha1.UpgradePreHealthCheck))
+		} else if len(desired.Image) > 0 && len(desired.Version) > 0 {
+			logger.Info(fmt.Sprintf("ClusterVersion is already set to Image %s, skipping %s", desired.Image, upgradev1alpha1.UpgradePreHealthCheck))
+		}
 		return true, nil
 	}
 
@@ -154,9 +159,14 @@ func EnsureExtraUpgradeWorkers(c client.Client, cfg *osdUpgradeConfig, s scaler.
 	if err != nil {
 		return false, err
 	}
+
 	desired := upgradeConfig.Spec.Desired
 	if upgradeCommenced {
-		logger.Info(fmt.Sprintf("ClusterVersion is already set to Channel %s Version %s, skipping %s", desired.Channel, desired.Version, upgradev1alpha1.UpgradeScaleUpExtraNodes))
+		if len(desired.Channel) > 0 && len(desired.Version) > 0 {
+			logger.Info(fmt.Sprintf("ClusterVersion is already set to Channel %s Version %s, skipping %s", desired.Channel, desired.Version, upgradev1alpha1.UpgradeScaleUpExtraNodes))
+		} else if len(desired.Image) > 0 && len(desired.Version) > 0 {
+			logger.Info(fmt.Sprintf("ClusterVersion is already set to Image %s, skipping %s", desired.Image, upgradev1alpha1.UpgradeScaleUpExtraNodes))
+		}
 		return true, nil
 	}
 
@@ -181,9 +191,14 @@ func ExternalDependencyAvailabilityCheck(c client.Client, cfg *osdUpgradeConfig,
 	if err != nil {
 		return false, err
 	}
+
 	desired := upgradeConfig.Spec.Desired
 	if upgradeCommenced {
-		logger.Info(fmt.Sprintf("ClusterVersion is already set to Channel %s Version %s, skipping %s", desired.Channel, desired.Version, upgradev1alpha1.ExtDepAvailabilityCheck))
+		if len(desired.Channel) > 0 && len(desired.Version) > 0 {
+			logger.Info(fmt.Sprintf("ClusterVersion is already set to Channel %s Version %s, skipping %s", desired.Channel, desired.Version, upgradev1alpha1.ExtDepAvailabilityCheck))
+		} else if len(desired.Image) > 0 && len(desired.Version) > 0 {
+			logger.Info(fmt.Sprintf("ClusterVersion is already set to Image %s, skipping %s", desired.Image, upgradev1alpha1.ExtDepAvailabilityCheck))
+		}
 		return true, nil
 	}
 
@@ -214,14 +229,24 @@ func CommenceUpgrade(c client.Client, cfg *osdUpgradeConfig, scaler scaler.Scale
 	if err != nil {
 		return false, err
 	}
+
 	desired := upgradeConfig.Spec.Desired
 	if upgradeCommenced {
-		logger.Info(fmt.Sprintf("ClusterVersion is already set to Channel %s Version %s, skipping %s", desired.Channel, desired.Version, upgradev1alpha1.CommenceUpgrade))
+		if len(desired.Channel) > 0 && len(desired.Version) > 0 {
+			logger.Info(fmt.Sprintf("ClusterVersion is already set to Channel %s Version %s, skipping %s", desired.Channel, desired.Version, upgradev1alpha1.CommenceUpgrade))
+		} else if len(desired.Image) > 0 && len(desired.Version) > 0 {
+			logger.Info(fmt.Sprintf("ClusterVersion is already set to Image %s, skipping %s", desired.Image, upgradev1alpha1.CommenceUpgrade))
+		}
 		return true, nil
 	}
 
-	logger.Info(fmt.Sprintf("Setting ClusterVersion to Channel %s, version %s", desired.Channel, desired.Version))
-	isComplete, err := cvClient.EnsureDesiredVersion(upgradeConfig)
+	if len(desired.Channel) > 0 && len(desired.Version) > 0 {
+		logger.Info(fmt.Sprintf("Setting ClusterVersion to Channel %s, version %s", desired.Channel, desired.Version))
+	} else if len(desired.Image) > 0 && len(desired.Version) > 0 {
+		logger.Info(fmt.Sprintf("Setting ClusterVersion to Image %s", desired.Image))
+	}
+
+	isComplete, err := cvClient.EnsureDesiredConfig(upgradeConfig)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/upgraders/osd/upgrader_test.go
+++ b/pkg/upgraders/osd/upgrader_test.go
@@ -223,7 +223,7 @@ var _ = Describe("ClusterUpgrader", func() {
 				gomock.InOrder(
 					mockMetricsClient.EXPECT().UpdateMetricUpgradeWindowNotBreached(gomock.Any()),
 					mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(false, nil),
-					mockCVClient.EXPECT().EnsureDesiredVersion(gomock.Any()).Return(false, fakeError),
+					mockCVClient.EXPECT().EnsureDesiredConfig(gomock.Any()).Return(false, fakeError),
 				)
 				result, err := CommenceUpgrade(mockKubeClient, config, mockScalerClient, mockDrainStrategyBuilder, mockMetricsClient, mockMaintClient, mockCVClient, mockEMClient, upgradeConfig, mockMachineryClient, []ac.AvailabilityChecker{mockAC}, logger)
 				Expect(err).To(HaveOccurred())

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -262,13 +262,13 @@ func compareVersions(dV semver.Version, cV semver.Version, logger logr.Logger) (
 	result := dV.Compare(cV)
 	switch result {
 	case -1:
-		logger.Info(fmt.Sprintf("%s is less then %s", dV, cV))
+		logger.Info(fmt.Sprintf("%s is less than %s", dV, cV))
 		return VersionDowngrade, nil
 	case 0:
 		logger.Info(fmt.Sprintf("%s is equal to %s", dV, cV))
 		return VersionEqual, nil
 	case 1:
-		logger.Info(fmt.Sprintf("%s is greater then %s", dV, cV))
+		logger.Info(fmt.Sprintf("%s is greater than %s", dV, cV))
 		return VersionUpgrade, nil
 	default:
 		return VersionUnknown, fmt.Errorf("semver comparison failed for unknown reason. Versions %s & %s", dV, cV)


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
With regard to Jira card [OSD-7000](https://issues.redhat.com/browse/OSD-7000), this PR serves the requirement to initiate an upgrade using an image digest reference as well. This would help users to initiate an upgrade when the cluster has no upstream URL or channel configured in `ClusterVersion`. 

### Which Jira/Github issue(s) this PR fixes?
_Fixes #_  [OSD-7000](https://issues.redhat.com/browse/OSD-7000)

### Special notes for your reviewer:
- Currently, the scope of using an image digest is tied up with a mandatory `version` field as well which SHOULD match the version that's in the image's release metadata. This manual verification should be done by the user.
- In future, this verification will be automated and the `image` will be referenced without associated `version`. 
- Will add tests for validation as a separate PR.

### Pre-checks (if applicable):
- [x] Tested two upgrades using `image` and `channel`.
- [x] Ran `make generate` command locally to validate code changes
- [x] Included documentation changes with PR