### PR TITLE
Send notification when the scale up node timeout, and continue the upgrade

### DIFF
--- a/pkg/eventmanager/eventmanager.go
+++ b/pkg/eventmanager/eventmanager.go
@@ -30,7 +30,7 @@ const (
 	// UPGRADE_SCALE_DELAY_DESC describes the upgrade scaling delayed
 	UPGRADE_SCALE_DELAY_DESC = "Cluster upgrade to version %s is experiencing a delay attempting to scale up an additional worker node. The upgrade will continue to retry. This is an informational notification and no action is required by you."
 	// UPGRADE_SCALE_DELAY_SKIP_DESC describes the upgrade scaling skipped after delay
-	UPGRADE_SCALE_DELAY_SKIP_DESC = "Cluster upgrade to version %s has experienced issue during capacity reservation efforts. This could be caused by the AWS account service quota limitation, or the temporary connectivity issue from the new worker node to the masters or the external services. The upgrade will continue without extra compute. This is an informational notification and no action is required by you."
+	UPGRADE_SCALE_DELAY_SKIP_DESC = "Cluster upgrade to version %s has experienced an issue during capacity reservation efforts. This could be caused by AWS account service quota limitations or temporary connectivity issues to/from the new worker node. The upgrade will continue without extra compute. This is an informational notification and no action is required by you."
 )
 
 // EventManager enables implementation of an EventManager

--- a/pkg/eventmanager/eventmanager_test.go
+++ b/pkg/eventmanager/eventmanager_test.go
@@ -65,7 +65,7 @@ var _ = Describe("OCM Notifier", func() {
 
 	Context("When notifying a completed state", func() {
 		var uc upgradev1alpha1.UpgradeConfig
-		var testState = notifier.StateCompleted
+		var testState = notifier.MuoStateCompleted
 		BeforeEach(func() {
 			upgradeConfigName = types.NamespacedName{
 				Name:      TEST_UPGRADECONFIG_CR,
@@ -116,7 +116,7 @@ var _ = Describe("OCM Notifier", func() {
 
 	Context("When notifying a failed state", func() {
 		var uc upgradev1alpha1.UpgradeConfig
-		var testState = notifier.StateFailed
+		var testState = notifier.MuoStateFailed
 		BeforeEach(func() {
 			upgradeConfigName = types.NamespacedName{
 				Name:      TEST_UPGRADECONFIG_CR,
@@ -220,7 +220,7 @@ var _ = Describe("OCM Notifier", func() {
 
 	Context("When notifying a delayed state", func() {
 		var uc upgradev1alpha1.UpgradeConfig
-		var testState = notifier.StateDelayed
+		var testState = notifier.MuoStateDelayed
 		BeforeEach(func() {
 			upgradeConfigName = types.NamespacedName{
 				Name:      TEST_UPGRADECONFIG_CR,

--- a/pkg/eventmanager/mocks/eventmanager.go
+++ b/pkg/eventmanager/mocks/eventmanager.go
@@ -34,7 +34,7 @@ func (m *MockEventManager) EXPECT() *MockEventManagerMockRecorder {
 }
 
 // Notify mocks base method
-func (m *MockEventManager) Notify(arg0 notifier.NotifyState) error {
+func (m *MockEventManager) Notify(arg0 notifier.MuoState) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Notify", arg0)
 	ret0, _ := ret[0].(error)

--- a/pkg/notifier/lognotifier.go
+++ b/pkg/notifier/lognotifier.go
@@ -1,6 +1,10 @@
 package notifier
 
-import logf "sigs.k8s.io/controller-runtime/pkg/log"
+import (
+	"fmt"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
 
 // NewLogNotifier returns a new logNotifier
 func NewLogNotifier() (*logNotifier, error) {
@@ -12,7 +16,7 @@ type logNotifier struct{}
 
 var log = logf.Log.WithName("event-notifier")
 
-func (s *logNotifier) NotifyState(value NotifyState, description string) error {
-	log.Info("Upgrade-State:%s Description:%s", string(value), description)
+func (s *logNotifier) NotifyState(value MuoState, description string) error {
+	log.Info(fmt.Sprintf("Upgrade-State: %s Description: %s", string(value), description))
 	return nil
 }

--- a/pkg/notifier/mocks/notifier.go
+++ b/pkg/notifier/mocks/notifier.go
@@ -34,7 +34,7 @@ func (m *MockNotifier) EXPECT() *MockNotifierMockRecorder {
 }
 
 // NotifyState mocks base method
-func (m *MockNotifier) NotifyState(arg0 notifier.NotifyState, arg1 string) error {
+func (m *MockNotifier) NotifyState(arg0 notifier.MuoState, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NotifyState", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/pkg/notifier/notifier.go
+++ b/pkg/notifier/notifier.go
@@ -14,7 +14,7 @@ import (
 // Notifier is an interface that enables implementation of a Notifier
 //go:generate mockgen -destination=mocks/notifier.go -package=mocks github.com/openshift/managed-upgrade-operator/pkg/notifier Notifier
 type Notifier interface {
-	NotifyState(value NotifyState, description string) error
+	NotifyState(value MuoState, description string) error
 }
 
 // NotifierBuilder is an interface that enables implementation of a NotifierBuilder
@@ -25,17 +25,18 @@ type NotifierBuilder interface {
 
 // Represents valid notify states that can be reported
 const (
-	StatePending   NotifyState = "pending"
-	StateStarted   NotifyState = "started"
-	StateCompleted NotifyState = "completed"
-	StateDelayed   NotifyState = "delayed"
-	StateFailed    NotifyState = "failed"
-	StateCancelled NotifyState = "cancelled"
-	StateScheduled NotifyState = "scheduled"
+	MuoStatePending   MuoState = "StatePending"
+	MuoStateStarted   MuoState = "StateStarted"
+	MuoStateCompleted MuoState = "StateCompleted"
+	MuoStateDelayed   MuoState = "StateDelayed"
+	MuoStateFailed    MuoState = "StateFailed"
+	MuoStateCancelled MuoState = "StateCancelled"
+	MuoStateScheduled MuoState = "StateScheduled"
+	MuoStateSkipped   MuoState = "StateSkipped"
 )
 
-// NotifyState is a type
-type NotifyState string
+// MuoState is a type
+type MuoState string
 
 // Errors
 var (

--- a/pkg/notifier/ocmnotifier_test.go
+++ b/pkg/notifier/ocmnotifier_test.go
@@ -32,7 +32,8 @@ const (
 	TEST_UPGRADEPOLICY_PDB_TIME     = 60
 
 	// State constants
-	TEST_STATE_VALUE       = StateStarted
+	TEST_MUO_STATE_VALUE   = MuoStateStarted
+	TEST_OCM_STATE_VALUE   = OcmStateStarted
 	TEST_STATE_DESCRIPTION = "test-description"
 )
 
@@ -103,7 +104,7 @@ var _ = Describe("OCM Notifier", func() {
 				},
 			}
 			upgradePolicyState = ocm.UpgradePolicyState{
-				Value:       string(TEST_STATE_VALUE),
+				Value:       string(TEST_OCM_STATE_VALUE),
 				Description: TEST_STATE_DESCRIPTION,
 			}
 
@@ -124,7 +125,7 @@ var _ = Describe("OCM Notifier", func() {
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 					mockOcmClient.EXPECT().GetClusterUpgradePolicies(cluster.Id).Return(nil, fmt.Errorf("fake error")),
 				)
-				err := notifier.NotifyState(TEST_STATE_VALUE, TEST_STATE_DESCRIPTION)
+				err := notifier.NotifyState(TEST_MUO_STATE_VALUE, TEST_STATE_DESCRIPTION)
 				Expect(err).NotTo(BeNil())
 				Expect(err.Error()).To(ContainSubstring("can't determine policy ID"))
 			})
@@ -144,7 +145,7 @@ var _ = Describe("OCM Notifier", func() {
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 					mockOcmClient.EXPECT().GetClusterUpgradePolicies(TEST_CLUSTER_ID).Return(&upgradePolicyListResponse, nil),
 				)
-				err := notifier.NotifyState(TEST_STATE_VALUE, TEST_STATE_DESCRIPTION)
+				err := notifier.NotifyState(TEST_MUO_STATE_VALUE, TEST_STATE_DESCRIPTION)
 				Expect(err).NotTo(BeNil())
 				Expect(err.Error()).To(ContainSubstring("can't determine policy ID"))
 			})
@@ -164,7 +165,7 @@ var _ = Describe("OCM Notifier", func() {
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 					mockOcmClient.EXPECT().GetClusterUpgradePolicies(TEST_CLUSTER_ID).Return(&upgradePolicyListResponse, nil),
 				)
-				err := notifier.NotifyState(TEST_STATE_VALUE, TEST_STATE_DESCRIPTION)
+				err := notifier.NotifyState(TEST_MUO_STATE_VALUE, TEST_STATE_DESCRIPTION)
 				Expect(err).NotTo(BeNil())
 				Expect(err.Error()).To(ContainSubstring("can't determine policy ID"))
 			})
@@ -186,7 +187,7 @@ var _ = Describe("OCM Notifier", func() {
 						mockOcmClient.EXPECT().GetClusterUpgradePolicies(TEST_CLUSTER_ID).Return(&upgradePolicyListResponse, nil),
 						mockOcmClient.EXPECT().GetClusterUpgradePolicyState(TEST_POLICY_ID, TEST_CLUSTER_ID).Return(&upgradePolicyState, nil),
 					)
-					err := notifier.NotifyState(TEST_STATE_VALUE, TEST_STATE_DESCRIPTION)
+					err := notifier.NotifyState(TEST_MUO_STATE_VALUE, TEST_STATE_DESCRIPTION)
 					Expect(err).To(BeNil())
 				})
 			})
@@ -204,9 +205,9 @@ var _ = Describe("OCM Notifier", func() {
 						mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 						mockOcmClient.EXPECT().GetClusterUpgradePolicies(TEST_CLUSTER_ID).Return(&upgradePolicyListResponse, nil),
 						mockOcmClient.EXPECT().GetClusterUpgradePolicyState(TEST_POLICY_ID, TEST_CLUSTER_ID).Return(&upgradePolicyState, nil),
-						mockOcmClient.EXPECT().SetState(string(StateCompleted), TEST_STATE_DESCRIPTION, TEST_POLICY_ID, TEST_CLUSTER_ID),
+						mockOcmClient.EXPECT().SetState(string(stateMap[MuoStateCompleted]), TEST_STATE_DESCRIPTION, TEST_POLICY_ID, TEST_CLUSTER_ID),
 					)
-					err := notifier.NotifyState(StateCompleted, TEST_STATE_DESCRIPTION)
+					err := notifier.NotifyState(MuoStateCompleted, TEST_STATE_DESCRIPTION)
 					Expect(err).To(BeNil())
 				})
 			})

--- a/pkg/scaler/machineSetScaler.go
+++ b/pkg/scaler/machineSetScaler.go
@@ -271,9 +271,11 @@ func getExtraUpgradeNodes(c client.Client) (*corev1.NodeList, error) {
 
 	extraUpgradeNodes := &corev1.NodeList{}
 	for _, machine := range machines.Items {
-		for _, node := range nodes.Items {
-			if node.Name == machine.Status.NodeRef.Name {
-				extraUpgradeNodes.Items = append(extraUpgradeNodes.Items, node)
+		if *machine.Status.Phase == string(corev1.NodeRunning) {
+			for _, node := range nodes.Items {
+				if node.Name == machine.Status.NodeRef.Name {
+					extraUpgradeNodes.Items = append(extraUpgradeNodes.Items, node)
+				}
 			}
 		}
 	}

--- a/pkg/scaler/scaling_test.go
+++ b/pkg/scaler/scaling_test.go
@@ -501,6 +501,7 @@ var _ = Describe("Node scaling tests", func() {
 			mockDrainStrategy := mockDrain.NewMockNodeDrainStrategy(mockCtrl)
 			var replicas int32 = 1
 			var node1Name = "test-node-1"
+			var nodePhase = "Running"
 			originalMachineSets := &machineapi.MachineSetList{
 				Items: []machineapi.MachineSet{
 					{
@@ -525,6 +526,7 @@ var _ = Describe("Node scaling tests", func() {
 							NodeRef: &corev1.ObjectReference{
 								Name: node1Name,
 							},
+							Phase: &nodePhase,
 						},
 					},
 				},

--- a/pkg/upgraders/osd/upgrader.go
+++ b/pkg/upgraders/osd/upgrader.go
@@ -164,6 +164,11 @@ func EnsureExtraUpgradeWorkers(c client.Client, cfg *osdUpgradeConfig, s scaler.
 	if err != nil {
 		if scaler.IsScaleTimeOutError(err) {
 			metricsClient.UpdateMetricScalingFailed(upgradeConfig.Name)
+			err := nc.Notify(notifier.MuoStateSkipped)
+			if err != nil {
+				return false, err
+			}
+			return true, nil
 		}
 		return false, err
 	}
@@ -403,7 +408,7 @@ func ControlPlaneUpgraded(c client.Client, cfg *osdUpgradeConfig, scaler scaler.
 
 // SendStartedNotification sends a notification on upgrade commencement
 func SendStartedNotification(c client.Client, cfg *osdUpgradeConfig, scaler scaler.Scaler, dsb drain.NodeDrainStrategyBuilder, metricsClient metrics.Metrics, m maintenance.Maintenance, cvClient cv.ClusterVersion, nc eventmanager.EventManager, upgradeConfig *upgradev1alpha1.UpgradeConfig, machinery machinery.Machinery, availabilityCheckers ac.AvailabilityCheckers, logger logr.Logger) (bool, error) {
-	err := nc.Notify(notifier.StateStarted)
+	err := nc.Notify(notifier.MuoStateStarted)
 	if err != nil {
 		return false, err
 	}
@@ -433,7 +438,7 @@ func UpgradeDelayedCheck(c client.Client, cfg *osdUpgradeConfig, scaler scaler.S
 	delayTimeoutTrigger := cfg.UpgradeWindow.GetUpgradeDelayedTriggerDuration()
 	// Send notification if the managed upgrade started but did not hit the controlplane upgrade phase in delayTimeoutTrigger minutes
 	if !startTime.IsZero() && delayTimeoutTrigger > 0 && time.Now().After(startTime.Add(delayTimeoutTrigger)) {
-		err := nc.Notify(notifier.StateDelayed)
+		err := nc.Notify(notifier.MuoStateDelayed)
 		if err != nil {
 			return false, err
 		}
@@ -443,7 +448,7 @@ func UpgradeDelayedCheck(c client.Client, cfg *osdUpgradeConfig, scaler scaler.S
 
 // SendCompletedNotification sends a notification on upgrade completion
 func SendCompletedNotification(c client.Client, cfg *osdUpgradeConfig, scaler scaler.Scaler, dsb drain.NodeDrainStrategyBuilder, metricsClient metrics.Metrics, m maintenance.Maintenance, cvClient cv.ClusterVersion, nc eventmanager.EventManager, upgradeConfig *upgradev1alpha1.UpgradeConfig, machinery machinery.Machinery, availabilityCheckers ac.AvailabilityCheckers, logger logr.Logger) (bool, error) {
-	err := nc.Notify(notifier.StateCompleted)
+	err := nc.Notify(notifier.MuoStateCompleted)
 	if err != nil {
 		return false, err
 	}
@@ -530,7 +535,7 @@ func performUpgradeFailure(c client.Client, metricsClient metrics.Metrics, s sca
 	}
 
 	// Notify of failure
-	err = nc.Notify(notifier.StateFailed)
+	err = nc.Notify(notifier.MuoStateFailed)
 	if err != nil {
 		return err
 	}

--- a/pkg/upgraders/osd/upgrader_test.go
+++ b/pkg/upgraders/osd/upgrader_test.go
@@ -178,11 +178,12 @@ var _ = Describe("ClusterUpgrader", func() {
 					mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(false, nil),
 					mockScalerClient.EXPECT().EnsureScaleUpNodes(gomock.Any(), config.GetScaleDuration(), gomock.Any()).Return(false, scaler.NewScaleTimeOutError("test scale timed out")),
 					mockMetricsClient.EXPECT().UpdateMetricScalingFailed(gomock.Any()),
+					mockEMClient.EXPECT().Notify(notifier.MuoStateSkipped),
 				)
 
 				ok, err := EnsureExtraUpgradeWorkers(mockKubeClient, config, mockScalerClient, mockDrainStrategyBuilder, mockMetricsClient, mockMaintClient, mockCVClient, mockEMClient, upgradeConfig, mockMachineryClient, []ac.AvailabilityChecker{mockAC}, logger)
-				Expect(err).To(HaveOccurred())
-				Expect(ok).To(BeFalse())
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(ok).To(BeTrue())
 			})
 		})
 		Context("When capacity reservation is disabled", func() {
@@ -351,7 +352,7 @@ var _ = Describe("ClusterUpgrader", func() {
 	Context("When running the send-started-notification phase", func() {
 		It("will send the correct notification", func() {
 			gomock.InOrder(
-				mockEMClient.EXPECT().Notify(notifier.StateStarted),
+				mockEMClient.EXPECT().Notify(notifier.MuoStateStarted),
 			)
 			result, err := SendStartedNotification(mockKubeClient, config, mockScalerClient, mockDrainStrategyBuilder, mockMetricsClient, mockMaintClient, mockCVClient, mockEMClient, upgradeConfig, mockMachineryClient, []ac.AvailabilityChecker{mockAC}, logger)
 			Expect(err).NotTo(HaveOccurred())
@@ -360,7 +361,7 @@ var _ = Describe("ClusterUpgrader", func() {
 		It("will not succeed if it can't send the notification", func() {
 			fakeErr := fmt.Errorf("fake error")
 			gomock.InOrder(
-				mockEMClient.EXPECT().Notify(notifier.StateStarted).Return(fakeErr),
+				mockEMClient.EXPECT().Notify(notifier.MuoStateStarted).Return(fakeErr),
 			)
 			result, err := SendStartedNotification(mockKubeClient, config, mockScalerClient, mockDrainStrategyBuilder, mockMetricsClient, mockMaintClient, mockCVClient, mockEMClient, upgradeConfig, mockMachineryClient, []ac.AvailabilityChecker{mockAC}, logger)
 			Expect(err).To(HaveOccurred())
@@ -371,7 +372,7 @@ var _ = Describe("ClusterUpgrader", func() {
 	Context("When running the send-completed-notification phase", func() {
 		It("will send the notification", func() {
 			gomock.InOrder(
-				mockEMClient.EXPECT().Notify(notifier.StateCompleted),
+				mockEMClient.EXPECT().Notify(notifier.MuoStateCompleted),
 			)
 			result, err := SendCompletedNotification(mockKubeClient, config, mockScalerClient, mockDrainStrategyBuilder, mockMetricsClient, mockMaintClient, mockCVClient, mockEMClient, upgradeConfig, mockMachineryClient, []ac.AvailabilityChecker{mockAC}, logger)
 			Expect(err).NotTo(HaveOccurred())
@@ -380,7 +381,7 @@ var _ = Describe("ClusterUpgrader", func() {
 		It("will not succeed if it can't send the notification", func() {
 			fakeErr := fmt.Errorf("fake error")
 			gomock.InOrder(
-				mockEMClient.EXPECT().Notify(notifier.StateCompleted).Return(fakeErr),
+				mockEMClient.EXPECT().Notify(notifier.MuoStateCompleted).Return(fakeErr),
 			)
 			result, err := SendCompletedNotification(mockKubeClient, config, mockScalerClient, mockDrainStrategyBuilder, mockMetricsClient, mockMaintClient, mockCVClient, mockEMClient, upgradeConfig, mockMachineryClient, []ac.AvailabilityChecker{mockAC}, logger)
 			Expect(err).To(HaveOccurred())
@@ -416,7 +417,7 @@ var _ = Describe("ClusterUpgrader", func() {
 				It("will send a notification", func() {
 					gomock.InOrder(
 						mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(false, nil),
-						mockEMClient.EXPECT().Notify(notifier.StateDelayed).Return(nil),
+						mockEMClient.EXPECT().Notify(notifier.MuoStateDelayed).Return(nil),
 					)
 
 					result, err := UpgradeDelayedCheck(mockKubeClient, config, mockScalerClient, mockDrainStrategyBuilder, mockMetricsClient, mockMaintClient, mockCVClient, mockEMClient, upgradeConfig, mockMachineryClient, []ac.AvailabilityChecker{mockAC}, logger)
@@ -427,7 +428,7 @@ var _ = Describe("ClusterUpgrader", func() {
 					fakeError := fmt.Errorf("fake error")
 					gomock.InOrder(
 						mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(false, nil),
-						mockEMClient.EXPECT().Notify(notifier.StateDelayed).Return(fakeError),
+						mockEMClient.EXPECT().Notify(notifier.MuoStateDelayed).Return(fakeError),
 					)
 					result, err := UpgradeDelayedCheck(mockKubeClient, config, mockScalerClient, mockDrainStrategyBuilder, mockMetricsClient, mockMaintClient, mockCVClient, mockEMClient, upgradeConfig, mockMachineryClient, []ac.AvailabilityChecker{mockAC}, logger)
 					Expect(err).To(HaveOccurred())
@@ -592,7 +593,7 @@ var _ = Describe("ClusterUpgrader", func() {
 					gomock.InOrder(
 						mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(false, nil),
 						mockScalerClient.EXPECT().EnsureScaleDownNodes(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil),
-						mockEMClient.EXPECT().Notify(notifier.StateFailed),
+						mockEMClient.EXPECT().Notify(notifier.MuoStateFailed),
 						mockMetricsClient.EXPECT().UpdateMetricUpgradeWindowBreached(upgradeConfig.Name),
 						mockMetricsClient.EXPECT().ResetFailureMetrics(),
 					)


### PR DESCRIPTION
### What type of PR is this?
_feature_


### What this PR does / why we need it?
As upgrade best practice, we would like to proceed the upgrade event if when the scale extra node for upgrade timeout. And notify CU about this.

### Which Jira/Github issue(s) this PR fixes?

_Fixes OSD-7108_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

