### PR TITLE
[OSD-7556] update muo deployment docs

### DIFF
--- a/docs/quay.md
+++ b/docs/quay.md
@@ -1,0 +1,17 @@
+#### Prepare quay repo
+
+- Create new repo in quay.io:
+  - Navigate to https://quay.io/new/ and create new empty repository named `managed-upgrade-operator`
+
+- Create service account for the repo:
+  - Navigate https://quay.io/repository/<quay_username>/managed-upgrade-operator?tab=settings
+  - Click dropdown icon under "select user" and create new robot account and give `write` permission to the repo
+
+- Generate account token:
+  - Click on robot account name and select `docker login`
+
+- Login with a service account:
+
+```shell
+podman login -u="<QUAY_SERVICE_ACCOUNT>" -p="<QUAY_SERVICE_ACCOUNT_TOKEN>" quay.io 
+```

--- a/test/deploy/cluster_role_binding.yaml
+++ b/test/deploy/cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: managed-upgrade-operator
+subjects:
+- kind: ServiceAccount
+  name: managed-upgrade-operator
+  namespace: test-managed-upgrade-operator
+roleRef:
+  kind: ClusterRole
+  name: managed-upgrade-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/test/deploy/namespace.yaml
+++ b/test/deploy/namespace.yaml
@@ -1,6 +1,6 @@
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: openshift-managed-upgrade-operator
+  name: test-managed-upgrade-operator
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/test/deploy/operator.yaml
+++ b/test/deploy/operator.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: managed-upgrade-operator
+  namespace: test-managed-upgrade-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: managed-upgrade-operator
+  template:
+    metadata:
+      labels:
+        name: managed-upgrade-operator
+    spec:
+      serviceAccountName: managed-upgrade-operator
+      containers:
+        - name: managed-upgrade-operator
+          # Replace this with the built image name
+          # This will get replaced on deploy by /hack/generate-operator-bundle.py
+          image: quay.io/app-sre/managed-upgrade-operator:latest
+          command:
+          - managed-upgrade-operator
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 20m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 200Mi
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPERATOR_NAME
+              value: "managed-upgrade-operator"

--- a/test/deploy/service_account.yaml
+++ b/test/deploy/service_account.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: managed-upgrade-operator
-  namespace: openshift-managed-upgrade-operator
+  namespace: test-managed-upgrade-operator

--- a/test/deploy/upgrade.managed.openshift.io_v1alpha1_upgradeconfig_cr.yaml
+++ b/test/deploy/upgrade.managed.openshift.io_v1alpha1_upgradeconfig_cr.yaml
@@ -7,5 +7,5 @@ spec:
   upgradeAt: "2020-01-01T00:00:00Z"
   PDBForceDrainTimeout: 60
   desired:
-    channel: "fast-4.4"
-    version: "4.3.19"
+    channel: "fast-4.7"
+    version: "4.7.18"


### PR DESCRIPTION
### What type of PR is this?
_documentation_

### What this PR does / why we need it?

- Update development docs to add section on updating MUO with steps for
  - Building and pushing image to a registry
  - Updating MUO on a cluster

### Which Jira/Github issue(s) this PR fixes?

_Fixes #OSD-7556_

### Instructions for testing
#### Optional
- Build and push MUO image to quay (follow instructions on [setting up quay](https://github.com/openshift/managed-upgrade-operator/blob/OSD-7556/docs/quay.md))
```
operator-sdk build quay.io/<QUAY_USERNAME>/managed-upgrade-operator:latest
podman login -u="<QUAY_SERVICE_ACCOUNT>" -p="<QUAY_SERVICE_ACCOUNT_TOKEN>" quay.io 
podman push quay.io/<QUAY_USERNAME>/managed-upgrade-operator:latest
```
- Update image path in `test/deploy/operator.yaml`
```
sed -i 's/quay.io\/app-sre/quay.io\/<QUAY_USERNAME>/g' test/deploy/operator.yaml
```
#### Desired
- Create new cluster
```
export MY_CLUSTERNAME=
ocm create cluster ${MY_CLUSTERNAME} --version 4.7.16 --provider gcp --region australia-southeast1
```
- Login to the cluster
```
backplane-login ${MY_CLUSTERNAME}
```
- Login to oc
```
export MY_CLUSTERID=
ocm get /api/clusters_mgmt/v1/clusters/${MY_CLUSTERID}/credentials | jq -r .kubeconfig > /tmp/kubeconfig.txt
export KUBECONFIG=/tmp/kubeconfig.txt
```
- Scale down current muo
```
oc scale deployment managed-upgrade-operator -n openshift-managed-upgrade-operator --replicas=0
```
- Create new project
```
oc new-project test-managed-upgrade-operator
```
- Deploy resources, run upgrade
```
oc create -f deploy/cluster_role.yaml
oc create -f test/deploy/cluster_role_binding.yaml
oc create -f test/deploy/service_account.yaml
oc create -f test/deploy/managed-upgrade-operator-config.yaml
oc create -f test/deploy/operator.yaml
oc create -f test/deploy/upgrade.managed.openshift.io_v1alpha1_upgradeconfig_cr.yaml
```
- Wait for deploy to finish
```
oc get clusterversion -w
```

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make generate` command locally to validate code changes
- [x] Included documentation changes with PR

