### PR TITLE
add LOCAL UpgradeConfig Manager example

### DIFF
--- a/docs/configmanager.md
+++ b/docs/configmanager.md
@@ -49,3 +49,11 @@ The following configuration fields must be set:
 | `source` | Indicates the type of config manager being used | `LOCAL` |
 | `localConfigName` | Name of the Local config being used | `managed-upgrade-config` |
 | `watchInterval` | Frequency* in minutes with which UpgradeConfig CR name being looked | 60 |
+
+Complete example:
+```yaml
+configManager:
+  source: LOCAL
+  localConfigName: managed-upgrade-config
+  watchInterval: 60
+```


### PR DESCRIPTION
### What type of PR is this?
_(documentation_


### What this PR does / why we need it?

Add `LOCAL UpgradeConfig Manager` example to be consistent with `OCM UpgradeConfig Manager` section

