### PR TITLE
OSD-7555 Reduce MUO memory footprint

### DIFF
--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -1,0 +1,17 @@
+// +build testrunmain
+
+package main
+
+import (
+  "net/http"
+  _ "net/http/pprof"
+  "testing"
+)
+
+func TestRunMain(t *testing.T) {
+  go func() {
+    http.ListenAndServe(":6060", nil)
+  }()
+
+  main()
+}

--- a/pkg/drain/podDeleteStrategy.go
+++ b/pkg/drain/podDeleteStrategy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/managed-upgrade-operator/pkg/pod"
@@ -42,8 +43,16 @@ func (pds *podDeletionStrategy) IsValid(node *corev1.Node) (bool, error) {
 }
 
 func (pds *podDeletionStrategy) getPodList(node *corev1.Node) (*corev1.PodList, error) {
+
+	fieldSelector, err := fields.ParseSelector("spec.nodeName=" + node.Name)
+	if err != nil {
+		return nil, err
+	}
+
 	allPods := &corev1.PodList{}
-	err := pds.client.List(context.TODO(), allPods)
+	err = pds.client.List(context.TODO(), allPods, &client.ListOptions{
+		FieldSelector: fieldSelector,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/drain/podDeleteStrategy_test.go
+++ b/pkg/drain/podDeleteStrategy_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Pod Delete Strategy", func() {
 
 		It("Successfully deletes pods on a node", func() {
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, podList),
 				mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()),
 			)
 			result, err := pds.Execute(node)
@@ -106,7 +106,7 @@ var _ = Describe("Pod Delete Strategy", func() {
 				},
 			}
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, noDeletePods),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, noDeletePods),
 				mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Times(3),
 			)
 			result, err := pds.Execute(node)
@@ -116,7 +116,7 @@ var _ = Describe("Pod Delete Strategy", func() {
 
 		It("Returns error if fails to return a list of pods", func() {
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
 			)
 			_, err := pds.Execute(node)
 			Expect(err).To(HaveOccurred())
@@ -125,7 +125,7 @@ var _ = Describe("Pod Delete Strategy", func() {
 
 		It("Returns error if failed to delete pod", func() {
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, podList),
 				mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("fake error")),
 			)
 			_, err := pds.Execute(node)
@@ -137,7 +137,7 @@ var _ = Describe("Pod Delete Strategy", func() {
 	Context("Check if it's still valid to delete a pod", func() {
 		It("Returns true if there are target pods to be deleted", func() {
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, podList),
 			)
 			valid, err := pds.IsValid(node)
 			Expect(valid).To(BeTrue())
@@ -146,7 +146,7 @@ var _ = Describe("Pod Delete Strategy", func() {
 
 		It("Returns false if there are any errors while getting list of pods to be deleted", func() {
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
 			)
 			valid, err := pds.IsValid(node)
 			Expect(valid).To(BeFalse())
@@ -159,7 +159,7 @@ var _ = Describe("Pod Delete Strategy", func() {
 	Context("Get Pod List to be deleted", func() {
 		It("Returns list of pods with no errors", func() {
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, podList),
 			)
 			_, err := pds.getPodList(node)
 			Expect(err).To(BeNil())
@@ -167,7 +167,7 @@ var _ = Describe("Pod Delete Strategy", func() {
 
 		It("Returns no pods if there is any error while listing pods", func() {
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
 			)
 			_, err := pds.getPodList(node)
 			Expect(err).To(HaveOccurred())

--- a/pkg/drain/removeFinalizersStrategy.go
+++ b/pkg/drain/removeFinalizersStrategy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/managed-upgrade-operator/pkg/pod"
@@ -41,8 +42,16 @@ func (rfs *removeFinalizersStrategy) IsValid(node *corev1.Node) (bool, error) {
 }
 
 func (rfs *removeFinalizersStrategy) getPodList(node *corev1.Node) (*corev1.PodList, error) {
+
+	fieldSelector, err := fields.ParseSelector("spec.nodeName=" + node.Name)
+	if err != nil {
+		return nil, err
+	}
+
 	allPods := &corev1.PodList{}
-	err := rfs.client.List(context.TODO(), allPods)
+	err = rfs.client.List(context.TODO(), allPods, &client.ListOptions{
+		FieldSelector: fieldSelector,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/drain/removeFinalizersStrategy_test.go
+++ b/pkg/drain/removeFinalizersStrategy_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Remove Finalizer Strategy", func() {
 	Context("Execute remove finalizers strategy on a node", func() {
 		It("Successfully removes finalizers from pod with finalizer", func() {
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, podList),
 				mockKubeClient.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(
 					func(ctx context.Context, pod *corev1.Pod) error {
 						Expect(len(pod.ObjectMeta.Finalizers)).To(Equal(0))
@@ -108,7 +108,7 @@ var _ = Describe("Remove Finalizer Strategy", func() {
 				},
 			}
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, noFinalizerPods),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, noFinalizerPods),
 			)
 			result, err := rfs.Execute(node)
 			Expect(result.HasExecuted).To(BeFalse())
@@ -117,7 +117,7 @@ var _ = Describe("Remove Finalizer Strategy", func() {
 
 		It("Returns error if fails to return a list of pods", func() {
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
 			)
 			_, err := rfs.Execute(node)
 			Expect(err).To(HaveOccurred())
@@ -126,7 +126,7 @@ var _ = Describe("Remove Finalizer Strategy", func() {
 
 		It("Returns error if failed to remove finalizer from the pod", func() {
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, podList),
 				mockKubeClient.EXPECT().Update(gomock.Any(), gomock.Any()).Return(fmt.Errorf("fake error")),
 			)
 			_, err := rfs.Execute(node)
@@ -138,7 +138,7 @@ var _ = Describe("Remove Finalizer Strategy", func() {
 	Context("Check if it's still valid to apply removeFinalizerStrategy on a node", func() {
 		It("Returns true if there are target pods with finalizers", func() {
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, podList),
 			)
 			valid, err := rfs.IsValid(node)
 			Expect(valid).To(BeTrue())
@@ -147,7 +147,7 @@ var _ = Describe("Remove Finalizer Strategy", func() {
 
 		It("Returns false if there are any errors while getting list of pods", func() {
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
 			)
 			valid, err := rfs.IsValid(node)
 			Expect(valid).To(BeFalse())
@@ -160,7 +160,7 @@ var _ = Describe("Remove Finalizer Strategy", func() {
 	Context("Get Pod List with finalizers", func() {
 		It("Returns list of pods with no errors", func() {
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, podList),
 			)
 			_, err := rfs.getPodList(node)
 			Expect(err).To(BeNil())
@@ -168,7 +168,7 @@ var _ = Describe("Remove Finalizer Strategy", func() {
 
 		It("Returns no pods if there is any error while listing pods", func() {
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
 			)
 			_, err := rfs.getPodList(node)
 			Expect(err).To(HaveOccurred())

--- a/pkg/drain/stuckTerminatingStrategy.go
+++ b/pkg/drain/stuckTerminatingStrategy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/managed-upgrade-operator/pkg/pod"
@@ -42,8 +43,16 @@ func (sts *stuckTerminatingStrategy) IsValid(node *corev1.Node) (bool, error) {
 }
 
 func (sts *stuckTerminatingStrategy) getPodList(node *corev1.Node) (*corev1.PodList, error) {
+
+	fieldSelector, err := fields.ParseSelector("spec.nodeName=" + node.Name)
+	if err != nil {
+		return nil, err
+	}
+
 	allPods := &corev1.PodList{}
-	err := sts.client.List(context.TODO(), allPods)
+	err = sts.client.List(context.TODO(), allPods, &client.ListOptions{
+		FieldSelector: fieldSelector,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/drain/stuckTerminatingStrategy_test.go
+++ b/pkg/drain/stuckTerminatingStrategy_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Stuck Terminating Strategy", func() {
 
 		It("Successfully deletes pods stuck in terminating state", func() {
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, podList),
 				mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()),
 			)
 			result, err := sts.Execute(node)
@@ -114,7 +114,7 @@ var _ = Describe("Stuck Terminating Strategy", func() {
 				},
 			}
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, noTerminatingPods),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, noTerminatingPods),
 			)
 			result, err := sts.Execute(node)
 			Expect(result.HasExecuted).To(BeFalse())
@@ -123,7 +123,7 @@ var _ = Describe("Stuck Terminating Strategy", func() {
 
 		It("Returns error if fails to return a list of pods", func() {
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
 			)
 			_, err := sts.Execute(node)
 			Expect(err).To(HaveOccurred())
@@ -132,7 +132,7 @@ var _ = Describe("Stuck Terminating Strategy", func() {
 
 		It("Returns error if failed to delete pod stuck in terminating state", func() {
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, podList),
 				mockKubeClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("fake error")),
 			)
 			_, err := sts.Execute(node)
@@ -144,7 +144,7 @@ var _ = Describe("Stuck Terminating Strategy", func() {
 	Context("Check if it's still valid to apply stuckTerminating strategy on a node", func() {
 		It("Returns true if there are target pods stuck in terminating with no finalizers", func() {
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, podList),
 			)
 			valid, err := sts.IsValid(node)
 			Expect(valid).To(BeTrue())
@@ -153,7 +153,7 @@ var _ = Describe("Stuck Terminating Strategy", func() {
 
 		It("Returns false if there are any errors while getting list of pods stuck in terminating wtih no finalizers", func() {
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
 			)
 			valid, err := sts.IsValid(node)
 			Expect(valid).To(BeFalse())
@@ -166,7 +166,7 @@ var _ = Describe("Stuck Terminating Strategy", func() {
 	Context("Get Pod List with no finalizers and stuck in terminating state", func() {
 		It("Returns list of pods with no errors", func() {
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, podList),
 			)
 			_, err := sts.getPodList(node)
 			Expect(err).To(BeNil())
@@ -174,7 +174,7 @@ var _ = Describe("Stuck Terminating Strategy", func() {
 
 		It("Returns no pods if there is any error while listing pods", func() {
 			gomock.InOrder(
-				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, podList).Return(fmt.Errorf("fake error")),
 			)
 			_, err := sts.getPodList(node)
 			Expect(err).To(HaveOccurred())

--- a/pkg/upgradeconfigmanager/upgradeconfigmanager.go
+++ b/pkg/upgradeconfigmanager/upgradeconfigmanager.go
@@ -144,9 +144,11 @@ func (s *upgradeConfigManager) StartSync(stopCh context.Context) {
 	}
 
 	duration := durationWithJitter(INITIAL_SYNC_DURATION, JITTER_FACTOR)
+	timeout := time.NewTimer(duration)
+	defer timeout.Stop()
 	for {
 		select {
-		case <-time.After(duration):
+		case <-timeout.C:
 			_, err := s.Refresh()
 			if err != nil {
 				waitDuration := s.backoffCounter.Duration()
@@ -162,6 +164,7 @@ func (s *upgradeConfigManager) StartSync(stopCh context.Context) {
 			log.Info("Stopping the upgradeConfigManager")
 			break
 		}
+		timeout.Reset(duration)
 	}
 }
 


### PR DESCRIPTION
### What type of PR is this?
Cleanup/refactor

### What this PR does / why we need it?
This PR introduces some optimizations to improve MUO's overall memory footprint during upgrades.

- Fixed a potential memory leak in the `UpgradeConfigManager` where `time.After()` may not be being garbage collected.
- Drain strategies no longer pull the full list of pods from the cluster before filtering on pod predicates, and instead will only target pods running on the node being reconciled by the nodekeeper.

### Which Jira/Github issue(s) this PR fixes?

[OSD-7555](https://issues.redhat.com/browse/OSD-7555)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [X] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

