### PR TITLE
OSD-7557 Use Services over Routes for prom/AM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ run-standard-routes: ## Run locally with openshift-managed-upgrade-operator as O
 tools: ## Install local go tools for MUO
 	cat tools.go | grep _ | awk -F'"' '{print $$2}' | xargs -tI % go install %
 
-.DEFAULT_GOAL := help
 .PHONY: help
 help: ## Show this help screen.
 		@echo 'Usage: make <OPTIONS> ... <TARGETS>'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 include boilerplate/generated-includes.mk
 
+OPERATOR_NAME=managed-upgrade-operator
+
 .PHONY: boilerplate-update
 boilerplate-update: ## Make boilerplate update itself
 	@boilerplate/update

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,34 @@
 include boilerplate/generated-includes.mk
 
 .PHONY: boilerplate-update
-boilerplate-update:
+boilerplate-update: ## Make boilerplate update itself
 	@boilerplate/update
 
 .PHONY: run
-run: 
+run: ## Wrapper around operator sdk run. Requires OPERATOR_NAMESPACE to be set. See run-standard for defaults. 
 	operator-sdk run --local --watch-namespace ""
 
+.PHONY: run-routes
+run-routes: ## Same as `run`, however will use ROUTE objects to contact prometheus and alertmanager. Use of routes is non-standard but convenient for local development.
+	ROUTES=true operator-sdk run --local --watch-namespace ""
+
+.PHONY: run-standard
+run-standard: ## Run locally with openshift-managed-upgrade-operator as OPERATOR_NAMESPACE.
+	OPERATOR_NAMESPACE=openshift-managed-upgrade-operator operator-sdk run --local --watch-namespace ""
+
+.PHONY: run-standard-routes
+run-standard-routes: ## Run locally with openshift-managed-upgrade-operator as OPERATOR_NAMESPACE and use of non-standard routes.
+	OPERATOR_NAMESPACE=openshift-managed-upgrade-operator ROUTES=true operator-sdk run --local --watch-namespace ""
+
 .PHONY: tools
-tools:
+tools: ## Install local go tools for MUO
 	cat tools.go | grep _ | awk -F'"' '{print $$2}' | xargs -tI % go install %
+
+.DEFAULT_GOAL := help
+.PHONY: help
+help: ## Show this help screen.
+		@echo 'Usage: make <OPTIONS> ... <TARGETS>'
+		@echo ''
+		@echo 'Available targets are:'
+		@echo ''
+		@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | sed 's/##//g' | awk 'BEGIN {FS = ":"}; {printf "\033[36m%-30s\033[0m %s\n", $$2, $$3}'

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -100,7 +100,8 @@ CONVENTION_DIR := boilerplate/openshift/golang-osd-operator
 # https://www.gnu.org/software/make/manual/make.html#index-_002eDEFAULT_005fGOAL-_0028define-default-goal_0029
 .DEFAULT_GOAL :=
 .PHONY: default
-default: go-check go-test go-build
+#default: go-check go-test go-build
+default: go-check go-build
 
 .PHONY: clean
 clean:
@@ -196,7 +197,7 @@ go-build: ## Build binary
 	${GOENV} GOOS=linux go build ${GOBUILDFLAGS} -o ${BINFILE} ${MAINPACKAGE}
 
 .PHONY: go-test
-go-test:
+go-test: ## runs go test across operator
 	${GOENV} go test $(TESTOPTS) $(TESTTARGETS)
 
 .PHONY: python-venv

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -100,8 +100,7 @@ CONVENTION_DIR := boilerplate/openshift/golang-osd-operator
 # https://www.gnu.org/software/make/manual/make.html#index-_002eDEFAULT_005fGOAL-_0028define-default-goal_0029
 .DEFAULT_GOAL :=
 .PHONY: default
-#default: go-check go-test go-build
-default: go-check go-build
+default: go-check go-test go-build
 
 .PHONY: clean
 clean:
@@ -197,7 +196,7 @@ go-build: ## Build binary
 	${GOENV} GOOS=linux go build ${GOBUILDFLAGS} -o ${BINFILE} ${MAINPACKAGE}
 
 .PHONY: go-test
-go-test: ## runs go test across operator
+go-test:
 	${GOENV} go test $(TESTOPTS) $(TESTTARGETS)
 
 .PHONY: python-venv

--- a/config/config.go
+++ b/config/config.go
@@ -1,13 +1,50 @@
 package config
 
-import "time"
+import (
+	"os"
+	"time"
 
-// TODO: put the name of the config in here
+	"github.com/openshift/managed-upgrade-operator/pkg/configmanager"
+)
+
 const (
 	// OperatorName is the name of the operator
 	OperatorName string = "managed-upgrade-operator"
 	// OperatorNamespace is the namespace of the operator
-	OperatorNamespace string = "managed-upgrade-operator"
+	OperatorNamespace string = "openshift-managed-upgrade-operator"
 	// SyncPeriodDefault reconciles a sync period for each controller
 	SyncPeriodDefault = 5 * time.Minute
+	// ConfigMapName is the name of the ConfigMap for the operator
+	ConfigMapName string = OperatorName + "-config"
+	// ConfigField is the name of field within the ConfigMap
+	ConfigField string = "config.yaml"
+	// EnvRoutes is used to determine if routes should be used during development
+	EnvRoutes string = "ROUTES"
 )
+
+type CMTarget configmanager.Target
+
+// NewCMTarget acts as a wrapper around configmanager.Target to enable
+// MUO defaults that can be set outside of the configmanager pkg itself.
+func (c *CMTarget) NewCMTarget() configmanager.Target {
+	if c.Name == "" {
+		c.Name = ConfigMapName
+	}
+
+	if c.Namespace == "" {
+		c.Namespace = OperatorNamespace
+	}
+
+	if c.ConfigKey == "" {
+		c.ConfigKey = ConfigField
+	}
+	return configmanager.Target{
+		Name:      c.Name,
+		Namespace: c.Namespace,
+		ConfigKey: c.ConfigKey,
+	}
+}
+
+func UseRoutes() bool {
+	return os.Getenv(EnvRoutes) == "true"
+}

--- a/development/port-forwards
+++ b/development/port-forwards
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+###
+# Use for local development to utilize in cluster service addresses rather then Route objects
+###
+
+set -e
+
+for ARG in $@;
+do
+    if [[ "$ARG" == "-h"* ]] || [[ "$ARG" == "--h"* ]]
+    then
+        echo "Setup port forwarding for local development using internal svc"
+		echo "usage ${0##} context (to execute oc commands as). This is useful if you are running the actual operator the MUO service account [OPTIONAL]"
+        echo "example: ${0##} default/dofinn-20210802/dofinn.openshift" 
+		echo
+        exit 1
+    fi 
+done
+
+OC=$(which oc)
+
+if [[ ! -z ${1+x} ]]
+then
+	OC="$(which oc) --context="$1""
+fi
+
+# Setup for local resolution
+grep 'prometheus' /etc/hosts > /dev/null
+if [[ $? == 1 ]]
+then
+	sudo -- sh -c "echo 127.0.0.1 prometheus-k8s.openshift-monitoring.svc.cluster.local alertmanager-main.openshift-monitoring.svc.cluster.local >> /etc/hosts"
+fi
+
+# Setup prometheus and alertmanager port-forwards
+while true; do $OC port-forward -n openshift-monitoring svc/prometheus-k8s 9091:9091;done &
+while true; do $OC port-forward -n openshift-monitoring svc/alertmanager-main 9094:9094;done &

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,7 +11,10 @@
   - [Build using boilerplate container](#build-using-boilerplate-container)
   - [How to run](#how-to-run)
     - [Locally](#locally)
+    - [Run using internal cluster services](#run-using-internal-cluster-services)
+    - [Run using cluster routes](#run-using-cluster-routes)
     - [Remotely](#remotely)
+    - [Trigger Reconcile](#trigger-reconcile)
   - [Monitoring ongoing upgrade](#monitoring-ongoing-upgrade)
 
 This document should entail all you need to develop this operator locally.
@@ -37,6 +40,28 @@ Ensure this is installed and available in your `$PATH`.
 ```shell
 $ operator-sdk version
 operator-sdk version: "v0.18.2", commit: "f059b5e17447b0bbcef50846859519340c17ffad", kubernetes version: "v1.18.2", go version: "go1.13.10 linux/amd64"
+```
+
+## Makefile
+
+All available standardized commands for the `Makefile` are available via:
+
+```shell
+$ make
+Usage: make <OPTIONS> ... <TARGETS>
+
+Available targets are:
+
+go-build                         Build binary
+go-check                         Golang linting and other static analysis
+go-test                          runs go test across operator
+boilerplate-update               Make boilerplate update itself
+help                             Show this help screen.
+run-routes                       Same as `run`, however will use ROUTE objects to contact prometheus and alertmanager. Use of routes is non-standard but convenient for local development.
+run-standard-routes              Run locally with openshift-managed-upgrade-operator as OPERATOR_NAMESPACE and use of non-standard routes.
+run-standard                     Run locally with openshift-managed-upgrade-operator as OPERATOR_NAMESPACE.
+run                              Wrapper around operator sdk run. Requires OPERATOR_NAMESPACE to be set. See run-standard for defaults.
+tools                            Install local go tools for MUO
 ```
 
 ## Dependencies
@@ -72,7 +97,7 @@ $ make lint
 To run unit tests locally, call `make test`
 
 ```shell
-$ make test
+$ make go-test
 ```
 
 ## Building
@@ -99,30 +124,100 @@ Regardless of how you choose to run the operator, before doing so ensure the `Up
 $ oc create -f deploy/crds/upgrade.managed.openshift.io_upgradeconfigs_crd.yaml
 ```
 
+MUO by defaults uses in the internal services to contact prometheus and alertmanager. This enables the use of a firewall to prevent egress calls however increases local development complexity slightly. 
+
+There are now three main modes that MUO can be ran in. 
+
+1. Run in a container in cluster. 
+2. Run locally using port-forwards and `/etc/hosts` entries to replicate production environment. 
+3. Run locally using Routes to access services. This is not true production however is the most simple for local development. 
+
+Modes 2 and 3 can be executed via the `Makefile` optionally setting the `$OPERATOR_NAMESPACE` as explored in the next section. 
+
+```
+run                              Wrapper around operator sdk run. Requires OPERATOR_NAMESPACE to be set. See run-standard for defaults.
+run-standard                     Run locally with openshift-managed-upgrade-operator as OPERATOR_NAMESPACE.
+run-routes                       Same as `run`, however will use ROUTE objects to contact prometheus and alertmanager. Use of routes is non-standard but convenient for local development. Requires OPERATOR_NAMESPACE to be set.
+run-standard-routes              Run locally with openshift-managed-upgrade-operator as OPERATOR_NAMESPACE and use of non-standard routes.
+```
+
+
 ### Locally
 
 - Make sure you have the [operator-sdk](#operator-sdk) `$PATH`.
 
-- If you are not using an account that has `cluster-admin` privileges, you will need to [elevate permissions](https://github.com/openshift/ops-sop/blob/master/v4/knowledge_base/manage-privileges.md) to possess them.
+- You will need to be logged in with an account that meets the [RBAC requirements](https://github.com/openshift/managed-upgrade-operator/blob/master/deploy/cluster_role.yaml) for the MUO service account.
 
+<<<<<<< Updated upstream
 - Create a project for the operator to run inside of:
+=======
+- OPTIONAL: Create a project for the operator to run inside of.
+>>>>>>> Stashed changes
 
 ```
 $ oc new-project test-managed-upgrade-operator
 ```
 
-- Run the operator via the Operator SDK:
+### Run using internal cluster services
+
+The use of internal cluster services requires some changes locally to your environment:
+
+1. Add entries for prometheus and alertmanager to `/etc/hosts` that resolve to `127.0.0.1`
+2. Create port-forwards for each service
+
+You can run this script to set this up for you (Requires `sudo` as it writes to `/etc/hosts`). The script accepts an optional `--context`. This enables setting up of the port-forwards with your personal user in the OpenShift cluster while running the operator locally using the available MUO service account for production like replication.
 
 ```
+<<<<<<< Updated upstream
 $ OPERATOR_NAMESPACE=test-managed-upgrade-operator operator-sdk run --local --watch-namespace=""
+=======
+$ ./development/port-forwards -h
+Setup port forwarding for local development using internal svc
+usage ./development/port-forwards context (to execute oc commands as). This is useful if you are running the actual operator the MUO service account [OPTIONAL]
+example: ./development/port-forwards default/dofinn-20210802/dofinn.openshift
+$ ./development/port-forwards default/dofinn-20210802/dofinn.openshift
+>>>>>>> Stashed changes
 ```
 
-(`make run` will also work here)
+The operator can then be ran as follows. 
 
+<<<<<<< Updated upstream
 - Trigger a reconcile loop by applying an `upgradeconfig` CR with your desired specs:
+=======
+```
+$ oc login $(oc get infrastructures cluster -o json | jq -r '.status.apiServerURL') --token $(oc -n openshift-managed-upgrade-operator serviceaccounts get-token managed-upgrade-operator)
+>>>>>>> Stashed changes
 
-```shell
-$ oc apply -f test/deploy/upgrade.managed.openshift.io_v1alpha1_upgradeconfig_cr.yaml
+Logged into "https://api.dofinn-20210802.8dqo.s1.devshift.org:6443" as "system:serviceaccount:openshift-managed-upgrade-operator:managed-upgrade-operator" using the token provided.
+
+You don't have any projects. Contact your system administrator to request a project.
+```
+
+Then if you are using the standard namespace
+
+```
+$ make run-standard
+```
+
+Else you can provide your own. 
+
+
+```
+$ OPERATOR_NAMESPACE=managed-upgrade-operator make run
+```
+
+### Run using cluster routes
+
+Run locally using standard namespace and cluster routes. 
+
+```
+$ make run-standard-routes
+```
+
+Run locally using custom namespace and cluster routes. 
+
+```
+$ OPERATOR_NAMESPACE=managed-upgrade-operator make run-routes
 ```
 
 ### Remotely
@@ -193,6 +288,14 @@ EOF
 Refer to [fast-4.7](https://access.redhat.com/labs/ocpupgradegraph/update_channel?channel=fast-4.7&arch=x86_64&is_show_hot_fix=false) for currently available versions in `fast-4.7` channel.
 
 ---
+
+### Trigger Reconcile
+
+- Trigger a reconcile loop by applying an `upgradeconfig` CR with your desired specs.
+
+```shell
+$ oc apply -f test/deploy/upgrade.managed.openshift.io_v1alpha1_upgradeconfig_cr.yaml
+```
 
 ## Monitoring ongoing upgrade
 

--- a/pkg/alertmanager/alertManagerSilenceClient.go
+++ b/pkg/alertmanager/alertManagerSilenceClient.go
@@ -38,8 +38,10 @@ func (ams *AlertManagerSilenceClient) Create(matchers amv2Models.Matchers, start
 				Matchers:  matchers,
 			},
 		},
-		Context:    context.TODO(),
-		HTTPClient: &http.Client{},
+		Context: context.TODO(),
+		HTTPClient: &http.Client{
+			Transport: ams.Transport.Transport,
+		},
 	}
 
 	silenceClient := amSilence.New(ams.Transport, strfmt.Default)
@@ -54,9 +56,11 @@ func (ams *AlertManagerSilenceClient) Create(matchers amv2Models.Matchers, start
 // List lists silences in Alertmanager instance defined in Transport
 func (ams *AlertManagerSilenceClient) List(filter []string) (*amSilence.GetSilencesOK, error) {
 	gParams := &amSilence.GetSilencesParams{
-		Filter:     filter,
-		Context:    context.TODO(),
-		HTTPClient: &http.Client{},
+		Filter:  filter,
+		Context: context.TODO(),
+		HTTPClient: &http.Client{
+			Transport: ams.Transport.Transport,
+		},
 	}
 
 	silenceClient := amSilence.New(ams.Transport, strfmt.Default)
@@ -71,9 +75,11 @@ func (ams *AlertManagerSilenceClient) List(filter []string) (*amSilence.GetSilen
 // Delete deletes silence in Alertmanager instance defined in Transport
 func (ams *AlertManagerSilenceClient) Delete(id string) error {
 	dParams := &amSilence.DeleteSilenceParams{
-		SilenceID:  strfmt.UUID(id),
-		Context:    context.TODO(),
-		HTTPClient: &http.Client{},
+		SilenceID: strfmt.UUID(id),
+		Context:   context.TODO(),
+		HTTPClient: &http.Client{
+			Transport: ams.Transport.Transport,
+		},
 	}
 
 	silenceClient := amSilence.New(ams.Transport, strfmt.Default)
@@ -89,9 +95,11 @@ func (ams *AlertManagerSilenceClient) Delete(id string) error {
 func (ams *AlertManagerSilenceClient) Update(id string, endsAt strfmt.DateTime) error {
 	silenceClient := amSilence.New(ams.Transport, strfmt.Default)
 	gParams := &amSilence.GetSilenceParams{
-		SilenceID:  strfmt.UUID(id),
-		Context:    context.TODO(),
-		HTTPClient: &http.Client{},
+		SilenceID: strfmt.UUID(id),
+		Context:   context.TODO(),
+		HTTPClient: &http.Client{
+			Transport: ams.Transport.Transport,
+		},
 	}
 	result, err := silenceClient.GetSilence(gParams)
 	if err != nil {

--- a/pkg/configmanager/mocks/configmanagerbuilder.go
+++ b/pkg/configmanager/mocks/configmanagerbuilder.go
@@ -35,7 +35,7 @@ func (m *MockConfigManagerBuilder) EXPECT() *MockConfigManagerBuilderMockRecorde
 }
 
 // New mocks base method
-func (m *MockConfigManagerBuilder) New(arg0 client.Client, arg1 string) configmanager.ConfigManager {
+func (m *MockConfigManagerBuilder) New(arg0 client.Client, arg1 configmanager.Target) configmanager.ConfigManager {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "New", arg0, arg1)
 	ret0, _ := ret[0].(configmanager.ConfigManager)

--- a/pkg/controller/nodekeeper/nodekeeper_controller.go
+++ b/pkg/controller/nodekeeper/nodekeeper_controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/openshift/managed-upgrade-operator/config"
 	"github.com/openshift/managed-upgrade-operator/util"
 
 	corev1 "k8s.io/api/core/v1"
@@ -142,7 +143,11 @@ func (r *ReconcileNodeKeeper) Reconcile(ctx context.Context, request reconcile.R
 	if err != nil {
 		return reconcile.Result{}, nil
 	}
-	cfm := r.configManagerBuilder.New(r.client, operatorNamespace)
+
+	target := config.CMTarget{Namespace: operatorNamespace}
+	cmTarget := target.NewCMTarget()
+
+	cfm := r.configManagerBuilder.New(r.client, cmTarget)
 	cfg := &nodeKeeperConfig{}
 	err = cfm.Into(cfg)
 	if err != nil {

--- a/pkg/controller/upgradeconfig/upgradeconfig_controller.go
+++ b/pkg/controller/upgradeconfig/upgradeconfig_controller.go
@@ -186,7 +186,10 @@ func (r *ReconcileUpgradeConfig) Reconcile(ctx context.Context, request reconcil
 		}
 		reqLogger.Info("UpgradeConfig validated and confirmed for upgrade.")
 
-		cfm := r.configManagerBuilder.New(r.client, request.Namespace)
+		target := muocfg.CMTarget{Namespace: request.Namespace}
+		cmTarget := target.NewCMTarget()
+
+		cfm := r.configManagerBuilder.New(r.client, cmTarget)
 		cfg := &config{}
 		err = cfm.Into(cfg)
 		if err != nil {
@@ -258,7 +261,11 @@ func (r *ReconcileUpgradeConfig) Reconcile(ctx context.Context, request reconcil
 
 	case upgradev1alpha1.UpgradePhaseUpgrading:
 		reqLogger.Info("Cluster detected as already upgrading.")
-		cfm := r.configManagerBuilder.New(r.client, request.Namespace)
+
+		target := muocfg.CMTarget{Namespace: request.Namespace}
+		cmTarget := target.NewCMTarget()
+
+		cfm := r.configManagerBuilder.New(r.client, cmTarget)
 		upgrader, err := r.clusterUpgraderBuilder.NewClient(r.client, cfm, metricsClient, eventClient, instance.Spec.Type)
 		if err != nil {
 			return reconcile.Result{}, err

--- a/pkg/maintenance/alertmanagerMaintenance.go
+++ b/pkg/maintenance/alertmanagerMaintenance.go
@@ -2,7 +2,9 @@ package maintenance
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -10,18 +12,17 @@ import (
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/go-multierror"
-	routev1 "github.com/openshift/api/route/v1"
-	"github.com/openshift/managed-upgrade-operator/config"
-	"github.com/openshift/managed-upgrade-operator/pkg/alertmanager"
 	amv2Models "github.com/prometheus/alertmanager/api/v2/models"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/managed-upgrade-operator/config"
+	"github.com/openshift/managed-upgrade-operator/pkg/alertmanager"
+	"github.com/openshift/managed-upgrade-operator/pkg/metrics"
 )
 
 var (
-	alertManagerNamespace          = "openshift-monitoring"
-	alertManagerRouteName          = "alertmanager-main"
+	alertManagerApp                = "alertmanager-main"
 	alertManagerServiceAccountName = "prometheus-k8s"
 	alertManagerBasePath           = "/api/v2/"
 	controlPlaneSilenceCommentId   = "OSD control plane"
@@ -41,6 +42,20 @@ func (ammb *alertManagerMaintenanceBuilder) NewClient(client client.Client) (Mai
 		return nil, err
 	}
 
+	useRoutes := config.UseRoutes()
+	tlsConfig := &tls.Config{}
+
+	if !useRoutes {
+		tlsConfig, err = metrics.TLSConfig(client)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	transport.Transport = &http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
+
 	return &alertManagerMaintenance{
 		client: &alertmanager.AlertManagerSilenceClient{
 			Transport: transport,
@@ -54,18 +69,13 @@ type alertManagerMaintenance struct {
 }
 
 func getTransport(c client.Client) (*httptransport.Runtime, error) {
-	amRoute := &routev1.Route{}
-	err := c.Get(
-		context.TODO(),
-		types.NamespacedName{Namespace: alertManagerNamespace, Name: alertManagerRouteName},
-		amRoute,
-	)
+	endpoint, err := metrics.Endpoint(c, metrics.MonitoringNS, alertManagerApp, "web")
 	if err != nil {
 		return nil, err
 	}
 
 	return httptransport.New(
-		amRoute.Spec.Host,
+		endpoint,
 		alertManagerBasePath,
 		[]string{"https"},
 	), nil
@@ -76,7 +86,7 @@ func getAuthentication(c client.Client) (runtime.ClientAuthInfoWriter, error) {
 	err := c.List(
 		context.TODO(),
 		sl,
-		&client.ListOptions{Namespace: alertManagerNamespace},
+		&client.ListOptions{Namespace: metrics.MonitoringNS},
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -2,14 +2,20 @@ package metrics
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
 	routev1 "github.com/openshift/api/route/v1"
+	"github.com/openshift/managed-upgrade-operator/config"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -36,6 +42,12 @@ const (
 	ControlPlaneCompletedStateValue = "control_plane_completed"
 	WorkersStartedStateValue        = "workers_started"
 	WorkersCompletedStateValue      = "workers_completed"
+
+	MonitoringNS              = "openshift-monitoring"
+	MonitoringCAConfigMapName = "serving-certs-ca-bundle"
+	MonitoringConfigField     = "service-ca.crt"
+	promApp                   = "prometheus-k8s"
+	clusterSVCSuffix          = ".svc.cluster.local"
 )
 
 //go:generate mockgen -destination=mocks/metrics.go -package=mocks github.com/openshift/managed-upgrade-operator/pkg/metrics Metrics
@@ -78,21 +90,32 @@ func NewBuilder() MetricsBuilder {
 type metricsBuilder struct{}
 
 func (mb *metricsBuilder) NewClient(c client.Client) (Metrics, error) {
-	promHost, err := getPromHost(c)
+	promEndpoint, err := Endpoint(c, MonitoringNS, promApp, "web")
 	if err != nil {
 		return nil, err
 	}
 
-	token, err := getPrometheusToken(c)
+	token, err := prometheusToken(c)
 	if err != nil {
 		return nil, err
+	}
+
+	useRoutes := config.UseRoutes()
+	tlsConfig := &tls.Config{}
+
+	if !useRoutes {
+		tlsConfig, err = TLSConfig(c)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &Counter{
-		promHost: *promHost,
+		promEndpoint: promEndpoint,
 		promClient: http.Client{
 			Transport: &prometheusRoundTripper{
 				token: *token,
+				tls:   tlsConfig,
 			},
 		},
 	}, nil
@@ -100,19 +123,50 @@ func (mb *metricsBuilder) NewClient(c client.Client) (Metrics, error) {
 
 type prometheusRoundTripper struct {
 	token string
+	tls   *tls.Config
+}
+
+func TLSConfig(c client.Client) (*tls.Config, error) {
+	var tls tls.Config
+
+	cfgMap := &corev1.ConfigMap{}
+	err := c.Get(context.TODO(), client.ObjectKey{Name: MonitoringCAConfigMapName, Namespace: MonitoringNS}, cfgMap)
+	if err != nil {
+		return &tls, err
+	}
+
+	ca := cfgMap.Data[MonitoringConfigField]
+
+	if ca == "" {
+		return &tls, fmt.Errorf("monitoring service CA returned nil")
+	}
+
+	rootCAs, _ := x509.SystemCertPool()
+	if rootCAs == nil {
+		rootCAs = x509.NewCertPool()
+	}
+
+	if ok := rootCAs.AppendCertsFromPEM([]byte(ca)); !ok {
+		return &tls, fmt.Errorf("failed to append certs")
+	}
+
+	tls.RootCAs = rootCAs
+
+	return &tls, nil
 }
 
 func (prt *prometheusRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header.Add("Authorization", "Bearer "+prt.token)
 	transport := http.Transport{
 		TLSHandshakeTimeout: time.Second * 5,
+		TLSClientConfig:     prt.tls,
 	}
 	return transport.RoundTrip(req)
 }
 
 type Counter struct {
-	promClient http.Client
-	promHost   string
+	promClient   http.Client
+	promEndpoint string
 }
 
 var (
@@ -351,20 +405,66 @@ func (c *Counter) IsAlertFiring(alert string, checkedNS, ignoredNS []string) (bo
 	return false, nil
 }
 
-func getPromHost(c client.Client) (*string, error) {
-	route := &routev1.Route{}
-	err := c.Get(context.TODO(), types.NamespacedName{Namespace: "openshift-monitoring", Name: "prometheus-k8s"}, route)
+// GetServiceEndpoint accepts a client,namespace,svcName and portName and attempts to retrive
+// the services endpoint in the form of resolveable.service:portnumber.
+func GetServiceEndpoint(c client.Client, namespace, svcName, portName string) (string, error) {
+	svc := &corev1.Service{}
+	err := c.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: svcName}, svc)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
-	return &route.Spec.Host, nil
+	host := fmt.Sprintf(svcName + "." + namespace + clusterSVCSuffix)
+	var port string
+	for _, p := range svc.Spec.Ports {
+		if p.Name == portName {
+			port = strconv.FormatInt(int64(p.Port), 10)
+		}
+	}
+	endpoint := fmt.Sprint(host + ":" + port)
+	return endpoint, nil
+}
+
+func isRunModeLocal() bool {
+	return os.Getenv(k8sutil.ForceRunModeEnv) == string(k8sutil.LocalRunMode)
+}
+
+func Endpoint(c client.Client, namespace, appName, portName string) (string, error) {
+	var endpoint string
+	var err error
+
+	runLocal := isRunModeLocal()
+	useRoutes := config.UseRoutes()
+
+	if !runLocal || runLocal && !useRoutes {
+		endpoint, err = GetServiceEndpoint(c, namespace, appName, portName)
+		if err != nil {
+			return endpoint, err
+		}
+	} else {
+		endpoint, err = getRouteEndpoint(c, appName)
+		if err != nil {
+			return endpoint, err
+		}
+	}
+
+	return endpoint, nil
+}
+
+func getRouteEndpoint(c client.Client, appName string) (string, error) {
+	route := &routev1.Route{}
+	err := c.Get(context.TODO(), types.NamespacedName{Namespace: MonitoringNS, Name: appName}, route)
+	if err != nil {
+		return "", err
+	}
+
+	return route.Spec.Host, nil
 }
 
 func (c *Counter) Query(query string) (*AlertResponse, error) {
-	req, err := http.NewRequest("GET", "https://"+c.promHost+"/api/v1/query", nil)
+	req, err := http.NewRequest("GET", "https://"+c.promEndpoint+"/api/v1/query", nil)
 	if err != nil {
-		return nil, fmt.Errorf("Could not query Prometheus: %s", err)
+		return nil, fmt.Errorf("could not query prometheus: %s", err)
 	}
 
 	q := req.URL.Query()
@@ -378,7 +478,7 @@ func (c *Counter) Query(query string) (*AlertResponse, error) {
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("Error when querying Prometheus: %s", err)
+		return nil, fmt.Errorf("error when querying prometheus: %s", err)
 	}
 
 	result := &AlertResponse{}
@@ -390,11 +490,11 @@ func (c *Counter) Query(query string) (*AlertResponse, error) {
 	return result, nil
 }
 
-func getPrometheusToken(c client.Client) (*string, error) {
+func prometheusToken(c client.Client) (*string, error) {
 	sa := &corev1.ServiceAccount{}
-	err := c.Get(context.TODO(), types.NamespacedName{Namespace: "openshift-monitoring", Name: "prometheus-k8s"}, sa)
+	err := c.Get(context.TODO(), types.NamespacedName{Namespace: MonitoringNS, Name: promApp}, sa)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to fetch prometheus-k8s service account: %s", err)
+		return nil, fmt.Errorf("unable to fetch prometheus-k8s service account: %s", err)
 	}
 
 	tokenSecret := ""
@@ -404,13 +504,13 @@ func getPrometheusToken(c client.Client) (*string, error) {
 		}
 	}
 	if len(tokenSecret) == 0 {
-		return nil, fmt.Errorf("Failed to find token secret for prommetheus-k8s SA")
+		return nil, fmt.Errorf("failed to find token secret for prometheus-k8s SA")
 	}
 
 	secret := &corev1.Secret{}
-	err = c.Get(context.TODO(), types.NamespacedName{Namespace: "openshift-monitoring", Name: tokenSecret}, secret)
+	err = c.Get(context.TODO(), types.NamespacedName{Namespace: MonitoringNS, Name: tokenSecret}, secret)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to fetch secret %s: %s", tokenSecret, err)
+		return nil, fmt.Errorf("unable to fetch secret %s: %s", tokenSecret, err)
 	}
 
 	token := secret.Data[corev1.ServiceAccountTokenKey]

--- a/pkg/notifier/notifier.go
+++ b/pkg/notifier/notifier.go
@@ -6,6 +6,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/openshift/managed-upgrade-operator/config"
 	"github.com/openshift/managed-upgrade-operator/pkg/configmanager"
 	"github.com/openshift/managed-upgrade-operator/pkg/upgradeconfigmanager"
 	"github.com/openshift/managed-upgrade-operator/util"
@@ -87,7 +88,11 @@ func readNotifierConfig(client client.Client, cfb configmanager.ConfigManagerBui
 	if err != nil {
 		return nil, err
 	}
-	cfm := cfb.New(client, ns)
+
+	target := config.CMTarget{Namespace: ns}
+	cmTarget := target.NewCMTarget()
+
+	cfm := cfb.New(client, cmTarget)
 	cfg := &NotifierConfig{}
 	err = cfm.Into(cfg)
 	if err != nil {
@@ -103,7 +108,11 @@ func readOcmNotifierConfig(client client.Client, cfb configmanager.ConfigManager
 	if err != nil {
 		return nil, err
 	}
-	cfm := cfb.New(client, ns)
+
+	target := config.CMTarget{Namespace: ns}
+	cmTarget := target.NewCMTarget()
+
+	cfm := cfb.New(client, cmTarget)
 	cfg := &OcmNotifierConfig{}
 	err = cfm.Into(cfg)
 	if err != nil {

--- a/pkg/specprovider/specprovider.go
+++ b/pkg/specprovider/specprovider.go
@@ -6,6 +6,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/openshift/managed-upgrade-operator/config"
 	upgradev1alpha1 "github.com/openshift/managed-upgrade-operator/pkg/apis/upgrade/v1alpha1"
 	"github.com/openshift/managed-upgrade-operator/pkg/configmanager"
 	"github.com/openshift/managed-upgrade-operator/pkg/localprovider"
@@ -74,7 +75,11 @@ func readSpecProviderConfig(client client.Client, cfb configmanager.ConfigManage
 	if err != nil {
 		return nil, err
 	}
-	cfm := cfb.New(client, ns)
+
+	target := config.CMTarget{Namespace: ns}
+	cmTarget := target.NewCMTarget()
+
+	cfm := cfb.New(client, cmTarget)
 	cfg := &SpecProviderConfig{}
 	err = cfm.Into(cfg)
 	if err != nil {
@@ -90,7 +95,11 @@ func readOcmProviderConfig(client client.Client, cfb configmanager.ConfigManager
 	if err != nil {
 		return nil, err
 	}
-	cfm := cfb.New(client, ns)
+
+	target := config.CMTarget{Namespace: ns}
+	cmTarget := target.NewCMTarget()
+
+	cfm := cfb.New(client, cmTarget)
 	cfg := &ocmprovider.OcmProviderConfig{}
 	err = cfm.Into(cfg)
 	if err != nil {
@@ -105,7 +114,11 @@ func readLocalProviderConfig(client client.Client, cfb configmanager.ConfigManag
 	if err != nil {
 		return nil, err
 	}
-	cfm := cfb.New(client, ns)
+
+	target := config.CMTarget{Namespace: ns}
+	cmTarget := target.NewCMTarget()
+
+	cfm := cfb.New(client, cmTarget)
 	cfg := &localprovider.LocalProviderConfig{}
 	err = cfm.Into(cfg)
 	if err != nil {

--- a/pkg/upgradeconfigmanager/upgradeconfigmanager.go
+++ b/pkg/upgradeconfigmanager/upgradeconfigmanager.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/openshift/managed-upgrade-operator/config"
 	upgradev1alpha1 "github.com/openshift/managed-upgrade-operator/pkg/apis/upgrade/v1alpha1"
 	cv "github.com/openshift/managed-upgrade-operator/pkg/clusterversion"
 	"github.com/openshift/managed-upgrade-operator/pkg/configmanager"
@@ -140,7 +141,7 @@ func (s *upgradeConfigManager) StartSync(stopCh context.Context) {
 
 	metricsClient, err := s.metricsBuilder.NewClient(s.client)
 	if err != nil {
-		log.Error(err, "can't create metrics client")
+		log.Error(err, "can not create metrics client")
 		return
 	}
 
@@ -270,7 +271,11 @@ func readConfigManagerConfig(client client.Client, cfb configmanager.ConfigManag
 	if err != nil {
 		return nil, err
 	}
-	cfm := cfb.New(client, ns)
+
+	target := config.CMTarget{Namespace: ns}
+	cmTarget := target.NewCMTarget()
+
+	cfm := cfb.New(client, cmTarget)
 	cfg := &UpgradeConfigManagerConfig{}
 	err = cfm.Into(cfg)
 	if err != nil {


### PR DESCRIPTION
### What type of PR is this?
Refactor/Feature

### What this PR does / why we need it?

The use of routes required the cluster to make egress calls. This is not desirable when a firewall preventing egress access is being employed for security. 

### Which Jira/Github issue(s) this PR fixes?
[OSD-7557](https://issues.redhat.com/browse/OSD-7557)

### Special notes for your reviewer:

The use of internal cluster services requires the retrieval of the monitoring services self signed certificate authority to avoid TLS authority errors. This PR gets the `CA` from the `openshift-monitoring` namespace and adds it to both the prometheus and alertmanager transports so secure and error free communication can occur with these internal cluster services. 

* added help notes/functionality to `Makefile`
* added `Makefile` commands to consistently execute run local modes of MUO
* Moved MUO config specific data to `config/config.go` rather then remain in the implementation of the `configmanager` pkg.
* refactored `configmanager` to receive a `target` that provides defualts rather then a namespace string
* Added `port-forwards` script to aid in new local dev requirements
* updated development doc with run modes

### Extra Resources
https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/#trusting-tls-in-a-cluster 

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make generate` command locally to validate code changes
- [x] Included documentation changes with PR

