### PR TITLE
move the scale config validation into the upgrade step

### DIFF
--- a/pkg/upgraders/config.go
+++ b/pkg/upgraders/config.go
@@ -41,6 +41,14 @@ func (cfg *maintenanceConfig) GetControlPlaneDuration() time.Duration {
 	return time.Duration(cfg.ControlPlaneTime) * time.Minute
 }
 
+func (cfg *scaleConfig) IsValid() error {
+	if cfg.TimeOut <= 0 {
+		return fmt.Errorf("config scale timeOut is invalid")
+	}
+
+	return nil
+}
+
 type upgradeWindow struct {
 	TimeOut      int `yaml:"timeOut" default:"120"`
 	DelayTrigger int `yaml:"delayTrigger" default:"30"`
@@ -66,9 +74,6 @@ type healthCheck struct {
 func (cfg *upgraderConfig) IsValid() error {
 	if err := cfg.Maintenance.IsValid(); err != nil {
 		return err
-	}
-	if cfg.Scale.TimeOut <= 0 {
-		return fmt.Errorf("config scale timeOut is invalid")
 	}
 	if cfg.NodeDrain.Timeout <= 0 {
 		return fmt.Errorf("config nodeDrain timeOut is invalid")

--- a/pkg/upgraders/scalerstep_test.go
+++ b/pkg/upgraders/scalerstep_test.go
@@ -3,6 +3,7 @@ package upgraders
 import (
 	"context"
 	"fmt"
+
 	"github.com/openshift/managed-upgrade-operator/pkg/notifier"
 
 	. "github.com/onsi/ginkgo"
@@ -108,6 +109,12 @@ var _ = Describe("ScalerStep", func() {
 				Expect(err).To(Not(HaveOccurred()))
 				Expect(ok).To(BeTrue())
 			})
+			It("Should fail when the scale timeout is not set in configmap", func() {
+				config.Scale.TimeOut = 0
+				ok, err := upgrader.EnsureExtraUpgradeWorkers(context.TODO(), logger)
+				Expect(err).NotTo(BeNil())
+				Expect(ok).NotTo(BeTrue())
+			})
 		})
 
 		Context("When capacity reservation is disabled", func() {
@@ -119,7 +126,19 @@ var _ = Describe("ScalerStep", func() {
 				Expect(err).To(Not(HaveOccurred()))
 				Expect(ok).To(BeTrue())
 			})
-			It("Shoud not scale down extra nodes", func() {
+			It("Should not scale down extra nodes", func() {
+				ok, err := upgrader.RemoveExtraScaledNodes(context.TODO(), logger)
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(ok).To(BeTrue())
+			})
+			It("Scale up should not fail if scale timeout is not set in configmap", func() {
+				config.Scale.TimeOut = 0
+				ok, err := upgrader.EnsureExtraUpgradeWorkers(context.TODO(), logger)
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(ok).To(BeTrue())
+			})
+			It("Scale down should not fail if scale timeout is not set in configmap", func() {
+				config.Scale.TimeOut = 0
 				ok, err := upgrader.RemoveExtraScaledNodes(context.TODO(), logger)
 				Expect(err).To(Not(HaveOccurred()))
 				Expect(ok).To(BeTrue())


### PR DESCRIPTION
### What type of PR is this?
_(bug)_


### What this PR does / why we need it?

When the capacity reservation set to false, we do not need to validate the scale related parameter in configmap.
Currently, the validation runs as static steps to check all the configs at the beginning.
With the fix, it will check the config when we run the specific step.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #OSD-7766_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

