### PR TITLE
OSD-7557 Part 1 configmanager refactor 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,27 @@
 include boilerplate/generated-includes.mk
 
+OPERATOR_NAME=managed-upgrade-operator
+
 .PHONY: boilerplate-update
-boilerplate-update:
+boilerplate-update: ## Make boilerplate update itself
 	@boilerplate/update
 
 .PHONY: run
-run: 
+run: ## Wrapper around operator sdk run. Requires OPERATOR_NAMESPACE to be set. See run-standard for defaults. 
 	operator-sdk run --local --watch-namespace ""
 
+.PHONY: run-standard
+run-standard: ## Run locally with openshift-managed-upgrade-operator as OPERATOR_NAMESPACE.
+	OPERATOR_NAMESPACE=openshift-managed-upgrade-operator operator-sdk run --local --watch-namespace ""
+
 .PHONY: tools
-tools:
+tools: ## Install local go tools for MUO
 	cat tools.go | grep _ | awk -F'"' '{print $$2}' | xargs -tI % go install %
+
+.PHONY: help
+help: ## Show this help screen.
+		@echo 'Usage: make <OPTIONS> ... <TARGETS>'
+		@echo ''
+		@echo 'Available targets are:'
+		@echo ''
+		@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | sed 's/##//g' | awk 'BEGIN {FS = ":"}; {printf "\033[36m%-30s\033[0m %s\n", $$2, $$3}'

--- a/config/config.go
+++ b/config/config.go
@@ -1,13 +1,45 @@
 package config
 
-import "time"
+import (
+	"time"
 
-// TODO: put the name of the config in here
+	"github.com/openshift/managed-upgrade-operator/pkg/configmanager"
+	"github.com/openshift/managed-upgrade-operator/util"
+)
+
 const (
 	// OperatorName is the name of the operator
 	OperatorName string = "managed-upgrade-operator"
 	// OperatorNamespace is the namespace of the operator
-	OperatorNamespace string = "managed-upgrade-operator"
+	OperatorNamespace string = "openshift-managed-upgrade-operator"
 	// SyncPeriodDefault reconciles a sync period for each controller
 	SyncPeriodDefault = 5 * time.Minute
+	// ConfigMapName is the name of the ConfigMap for the operator
+	ConfigMapName string = OperatorName + "-config"
+	// ConfigField is the name of field within the ConfigMap
+	ConfigField string = "config.yaml"
 )
+
+type CMTarget configmanager.Target
+
+// NewCMTarget acts as a wrapper around configmanager.Target to enable
+// MUO defaults that can be set outside of the configmanager pkg itself.
+func (c *CMTarget) NewCMTarget() (configmanager.Target, error) {
+	var err error
+	if c.Name == "" {
+		c.Name = ConfigMapName
+	}
+
+	if c.Namespace == "" {
+		c.Namespace, err = util.GetOperatorNamespace()
+	}
+
+	if c.ConfigKey == "" {
+		c.ConfigKey = ConfigField
+	}
+	return configmanager.Target{
+		Name:      c.Name,
+		Namespace: c.Namespace,
+		ConfigKey: c.ConfigKey,
+	}, err
+}

--- a/pkg/configmanager/mocks/configmanagerbuilder.go
+++ b/pkg/configmanager/mocks/configmanagerbuilder.go
@@ -35,7 +35,7 @@ func (m *MockConfigManagerBuilder) EXPECT() *MockConfigManagerBuilderMockRecorde
 }
 
 // New mocks base method
-func (m *MockConfigManagerBuilder) New(arg0 client.Client, arg1 string) configmanager.ConfigManager {
+func (m *MockConfigManagerBuilder) New(arg0 client.Client, arg1 configmanager.Target) configmanager.ConfigManager {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "New", arg0, arg1)
 	ret0, _ := ret[0].(configmanager.ConfigManager)

--- a/pkg/controller/nodekeeper/nodekeeper_controller.go
+++ b/pkg/controller/nodekeeper/nodekeeper_controller.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/openshift/managed-upgrade-operator/util"
+	"github.com/openshift/managed-upgrade-operator/config"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -138,11 +138,13 @@ func (r *ReconcileNodeKeeper) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, nil
 	}
 
-	operatorNamespace, err := util.GetOperatorNamespace()
+	target := config.CMTarget{}
+	cmTarget, err := target.NewCMTarget()
 	if err != nil {
-		return reconcile.Result{}, nil
+		return reconcile.Result{}, err
 	}
-	cfm := r.configManagerBuilder.New(r.client, operatorNamespace)
+
+	cfm := r.configManagerBuilder.New(r.client, cmTarget)
 	cfg := &nodeKeeperConfig{}
 	err = cfm.Into(cfg)
 	if err != nil {

--- a/pkg/controller/upgradeconfig/upgradeconfig_controller.go
+++ b/pkg/controller/upgradeconfig/upgradeconfig_controller.go
@@ -186,7 +186,13 @@ func (r *ReconcileUpgradeConfig) Reconcile(ctx context.Context, request reconcil
 		}
 		reqLogger.Info("UpgradeConfig validated and confirmed for upgrade.")
 
-		cfm := r.configManagerBuilder.New(r.client, request.Namespace)
+		target := muocfg.CMTarget{Namespace: request.Namespace}
+		cmTarget, err := target.NewCMTarget()
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		cfm := r.configManagerBuilder.New(r.client, cmTarget)
 		cfg := &config{}
 		err = cfm.Into(cfg)
 		if err != nil {
@@ -258,7 +264,14 @@ func (r *ReconcileUpgradeConfig) Reconcile(ctx context.Context, request reconcil
 
 	case upgradev1alpha1.UpgradePhaseUpgrading:
 		reqLogger.Info("Cluster detected as already upgrading.")
-		cfm := r.configManagerBuilder.New(r.client, request.Namespace)
+
+		target := muocfg.CMTarget{Namespace: request.Namespace}
+		cmTarget, err := target.NewCMTarget()
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		cfm := r.configManagerBuilder.New(r.client, cmTarget)
 		upgrader, err := r.clusterUpgraderBuilder.NewClient(r.client, cfm, metricsClient, eventClient, instance.Spec.Type)
 		if err != nil {
 			return reconcile.Result{}, err

--- a/pkg/notifier/notifier.go
+++ b/pkg/notifier/notifier.go
@@ -6,9 +6,9 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/openshift/managed-upgrade-operator/config"
 	"github.com/openshift/managed-upgrade-operator/pkg/configmanager"
 	"github.com/openshift/managed-upgrade-operator/pkg/upgradeconfigmanager"
-	"github.com/openshift/managed-upgrade-operator/util"
 )
 
 // Notifier is an interface that enables implementation of a Notifier
@@ -83,31 +83,36 @@ func (nb *notifierBuilder) New(client client.Client, cfgBuilder configmanager.Co
 
 // Read notifier configuration
 func readNotifierConfig(client client.Client, cfb configmanager.ConfigManagerBuilder) (*NotifierConfig, error) {
-	ns, err := util.GetOperatorNamespace()
-	if err != nil {
-		return nil, err
-	}
-	cfm := cfb.New(client, ns)
 	cfg := &NotifierConfig{}
+
+	target := config.CMTarget{}
+	cmTarget, err := target.NewCMTarget()
+	if err != nil {
+		return cfg, err
+	}
+
+	cfm := cfb.New(client, cmTarget)
 	err = cfm.Into(cfg)
 	if err != nil {
-		return nil, err
+		return cfg, err
 	}
 	return cfg, cfg.IsValid()
 }
 
 // Read OCM provider configuration
 func readOcmNotifierConfig(client client.Client, cfb configmanager.ConfigManagerBuilder) (*OcmNotifierConfig, error) {
-	// Fetch the provider config
-	ns, err := util.GetOperatorNamespace()
-	if err != nil {
-		return nil, err
-	}
-	cfm := cfb.New(client, ns)
 	cfg := &OcmNotifierConfig{}
+
+	target := config.CMTarget{}
+	cmTarget, err := target.NewCMTarget()
+	if err != nil {
+		return cfg, err
+	}
+
+	cfm := cfb.New(client, cmTarget)
 	err = cfm.Into(cfg)
 	if err != nil {
-		return nil, err
+		return cfg, err
 	}
 	return cfg, cfg.IsValid()
 }

--- a/pkg/specprovider/specprovider.go
+++ b/pkg/specprovider/specprovider.go
@@ -6,11 +6,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/openshift/managed-upgrade-operator/config"
 	upgradev1alpha1 "github.com/openshift/managed-upgrade-operator/pkg/apis/upgrade/v1alpha1"
 	"github.com/openshift/managed-upgrade-operator/pkg/configmanager"
 	"github.com/openshift/managed-upgrade-operator/pkg/localprovider"
 	"github.com/openshift/managed-upgrade-operator/pkg/ocmprovider"
-	"github.com/openshift/managed-upgrade-operator/util"
 )
 
 // SpecProvider is an interface that enables an implementation of a spec provider
@@ -70,46 +70,53 @@ func (ppb *specProviderBuilder) New(client client.Client, builder configmanager.
 
 // Read spec provider configuration
 func readSpecProviderConfig(client client.Client, cfb configmanager.ConfigManagerBuilder) (*SpecProviderConfig, error) {
-	ns, err := util.GetOperatorNamespace()
-	if err != nil {
-		return nil, err
-	}
-	cfm := cfb.New(client, ns)
 	cfg := &SpecProviderConfig{}
+	target := config.CMTarget{}
+	cmTarget, err := target.NewCMTarget()
+	if err != nil {
+		return cfg, err
+	}
+
+	cfm := cfb.New(client, cmTarget)
 	err = cfm.Into(cfg)
 	if err != nil {
-		return nil, err
+		return cfg, err
 	}
 	return cfg, cfg.IsValid()
 }
 
 // Read OCM provider configuration
 func readOcmProviderConfig(client client.Client, cfb configmanager.ConfigManagerBuilder) (*ocmprovider.OcmProviderConfig, error) {
-	// Fetch the provider config
-	ns, err := util.GetOperatorNamespace()
-	if err != nil {
-		return nil, err
-	}
-	cfm := cfb.New(client, ns)
 	cfg := &ocmprovider.OcmProviderConfig{}
+
+	target := config.CMTarget{}
+	cmTarget, err := target.NewCMTarget()
+	if err != nil {
+		return cfg, err
+	}
+
+	cfm := cfb.New(client, cmTarget)
 	err = cfm.Into(cfg)
 	if err != nil {
-		return nil, err
+		return cfg, err
 	}
 	return cfg, cfg.IsValid()
 }
 
 // Read Local Provider configuration
 func readLocalProviderConfig(client client.Client, cfb configmanager.ConfigManagerBuilder) (*localprovider.LocalProviderConfig, error) {
-	ns, err := util.GetOperatorNamespace()
-	if err != nil {
-		return nil, err
-	}
-	cfm := cfb.New(client, ns)
 	cfg := &localprovider.LocalProviderConfig{}
+
+	target := config.CMTarget{}
+	cmTarget, err := target.NewCMTarget()
+	if err != nil {
+		return cfg, err
+	}
+
+	cfm := cfb.New(client, cmTarget)
 	err = cfm.Into(cfg)
 	if err != nil {
-		return nil, err
+		return cfg, err
 	}
 
 	return cfg, cfg.IsValid()


### PR DESCRIPTION
### What type of PR is this?
refactor

### What this PR does / why we need it?

This was a byproduct of a following PR. Enables a more expansible implementation of configmanager. 

### Which Jira/Github issue(s) this PR fixes?
[OSD-7557](https://issues.redhat.com/browse/OSD-7557)

### Special notes for your reviewer:

* added help notes/functionality to `Makefile`
* added `Makefile` commands to consistently execute run local modes of MUO
* Moved MUO config specific data to `config/config.go` rather then remain in the implementation of the `configmanager` pkg.
* refactored `configmanager` to receive a `target` that provides defualts rather then a namespace string

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [] Ran `make generate` command locally to validate code changes
- [x] Included documentation changes with PR

