### PR TITLE
OSD-7502 Enable condition status reporting

### DIFF
--- a/pkg/apis/upgrade/v1alpha1/upgradeconfig_types.go
+++ b/pkg/apis/upgrade/v1alpha1/upgradeconfig_types.go
@@ -99,39 +99,33 @@ type UpgradeCondition struct {
 
 const (
 	// SendStartedNotification is an UpgradeConditionType
-	SendStartedNotification UpgradeConditionType = "SendStartedNotification"
-	// UpgradeDelayedCheck is an UpgradeConditionType
-	UpgradeDelayedCheck UpgradeConditionType = "UpgradeDelayedCheck"
-	// UpgradeValidated is an UpgradeConditionType
-	UpgradeValidated UpgradeConditionType = "Validation"
+	SendStartedNotification UpgradeConditionType = "StartedNotificationSent"
 	// UpgradePreHealthCheck is an UpgradeConditionType
-	UpgradePreHealthCheck UpgradeConditionType = "PreHealthCheck"
+	UpgradePreHealthCheck UpgradeConditionType = "ClusterHealthyBeforeUpgrade"
 	// ExtDepAvailabilityCheck is an UpgradeConditionType
-	ExtDepAvailabilityCheck UpgradeConditionType = "ExternalDependencyAvailabilityCheck"
+	ExtDepAvailabilityCheck UpgradeConditionType = "ExternalDependenciesAvailable"
 	// UpgradeScaleUpExtraNodes is an UpgradeConditionType
-	UpgradeScaleUpExtraNodes UpgradeConditionType = "ScaleUpExtraNodes"
+	UpgradeScaleUpExtraNodes UpgradeConditionType = "ComputeCapacityReserved"
 	// ControlPlaneMaintWindow is an UpgradeConditionType
-	ControlPlaneMaintWindow UpgradeConditionType = "ControlPlaneMaintWindow"
+	ControlPlaneMaintWindow UpgradeConditionType = "ControlPlaneMaintenanceWindowCreated"
 	// CommenceUpgrade is an UpgradeConditionType
-	CommenceUpgrade UpgradeConditionType = "CommenceUpgrade"
+	CommenceUpgrade UpgradeConditionType = "UpgradeCommenced"
 	// ControlPlaneUpgraded is an UpgradeConditionType
 	ControlPlaneUpgraded UpgradeConditionType = "ControlPlaneUpgraded"
 	// RemoveControlPlaneMaintWindow is an UpgradeConditionType
-	RemoveControlPlaneMaintWindow UpgradeConditionType = "RemoveControlPlaneMaintWindow"
+	RemoveControlPlaneMaintWindow UpgradeConditionType = "ControlPlaneMaintenanceWindowRemoved"
 	// WorkersMaintWindow is an UpgradeConditionType
-	WorkersMaintWindow UpgradeConditionType = "WorkersMaintWindow"
+	WorkersMaintWindow UpgradeConditionType = "WorkersMaintenanceWindowCreated"
 	// AllWorkerNodesUpgraded is an UpgradeConditionType
-	AllWorkerNodesUpgraded UpgradeConditionType = "AllWorkerNodesUpgraded"
+	AllWorkerNodesUpgraded UpgradeConditionType = "WorkerNodesUpgraded"
 	// RemoveExtraScaledNodes is an UpgradeConditionType
-	RemoveExtraScaledNodes UpgradeConditionType = "RemoveExtraScaledNodes"
-	// UpdateSubscriptions is an UpgradeConditionType
-	UpdateSubscriptions UpgradeConditionType = "UpdateSubscriptions"
+	RemoveExtraScaledNodes UpgradeConditionType = "ComputeCapacityRemoved"
 	// RemoveMaintWindow is an UpgradeConditionType
-	RemoveMaintWindow UpgradeConditionType = "RemoveMaintWindow"
+	RemoveMaintWindow UpgradeConditionType = "WorkersMaintenanceWindowRemoved"
 	// PostClusterHealthCheck is an UpgradeConditionType
-	PostClusterHealthCheck UpgradeConditionType = "PostClusterHealthCheck"
+	PostClusterHealthCheck UpgradeConditionType = "ClusterHealthyAfterUpgrade"
 	// SendCompletedNotification is an UpgradeConditionType
-	SendCompletedNotification UpgradeConditionType = "SendCompletedNotification"
+	SendCompletedNotification UpgradeConditionType = "CompletedNotificationSent"
 )
 
 // UpgradePhase is a Go string type.

--- a/pkg/controller/upgradeconfig/upgradeconfig_controller.go
+++ b/pkg/controller/upgradeconfig/upgradeconfig_controller.go
@@ -289,11 +289,10 @@ func (r *ReconcileUpgradeConfig) Reconcile(ctx context.Context, request reconcil
 func (r *ReconcileUpgradeConfig) upgradeCluster(upgrader cub.ClusterUpgrader, uc *upgradev1alpha1.UpgradeConfig, logger logr.Logger) (reconcile.Result, error) {
 	me := &multierror.Error{}
 
-	phase, condition, err := upgrader.UpgradeCluster(context.TODO(), uc, logger)
+	phase, err := upgrader.UpgradeCluster(context.TODO(), uc, logger)
 	me = multierror.Append(err, me)
 
 	history := uc.Status.History.GetHistory(uc.Spec.Desired.Version)
-	history.Conditions = upgradev1alpha1.Conditions{*condition}
 	history.Phase = phase
 	if phase == upgradev1alpha1.UpgradePhaseUpgraded {
 		history.CompleteTime = &metav1.Time{Time: time.Now()}

--- a/pkg/controller/upgradeconfig/upgradeconfig_controller_test.go
+++ b/pkg/controller/upgradeconfig/upgradeconfig_controller_test.go
@@ -214,7 +214,7 @@ var _ = Describe("UpgradeConfigController", func() {
 							mockClusterUpgraderBuilder.EXPECT().NewClient(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), upgradeConfig.Spec.Type).Return(mockClusterUpgrader, nil),
 							mockKubeClient.EXPECT().Status().Return(mockUpdater),
 							mockUpdater.EXPECT().Update(gomock.Any(), matcher),
-							mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(upgradev1alpha1.UpgradePhaseUpgrading, &upgradev1alpha1.UpgradeCondition{}, nil),
+							mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(upgradev1alpha1.UpgradePhaseUpgrading, nil),
 							mockKubeClient.EXPECT().Status().Return(mockUpdater),
 							mockUpdater.EXPECT().Update(gomock.Any(), matcher),
 						)
@@ -352,7 +352,7 @@ var _ = Describe("UpgradeConfigController", func() {
 							mockClusterUpgraderBuilder.EXPECT().NewClient(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), upgradeConfig.Spec.Type).Return(mockClusterUpgrader, nil),
 							mockKubeClient.EXPECT().Status().Return(mockUpdater),
 							mockUpdater.EXPECT().Update(gomock.Any(), gomock.Any()),
-							mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(upgradev1alpha1.UpgradePhaseUpgrading, &upgradev1alpha1.UpgradeCondition{Message: "test passed"}, nil),
+							mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(upgradev1alpha1.UpgradePhaseUpgrading, nil),
 							mockKubeClient.EXPECT().Status().Return(mockUpdater),
 							mockUpdater.EXPECT().Update(gomock.Any(), gomock.Any()),
 						)
@@ -397,7 +397,7 @@ var _ = Describe("UpgradeConfigController", func() {
 							mockClusterUpgraderBuilder.EXPECT().NewClient(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), upgradeConfig.Spec.Type).Return(mockClusterUpgrader, nil),
 							mockKubeClient.EXPECT().Status().Return(mockUpdater),
 							mockUpdater.EXPECT().Update(gomock.Any(), gomock.Any()),
-							mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(upgradev1alpha1.UpgradePhaseUpgraded, &upgradev1alpha1.UpgradeCondition{Message: "test passed"}, nil),
+							mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(upgradev1alpha1.UpgradePhaseUpgraded, nil),
 							mockKubeClient.EXPECT().Status().Return(mockUpdater),
 							mockUpdater.EXPECT().Update(gomock.Any(), gomock.Any()),
 						)
@@ -406,7 +406,6 @@ var _ = Describe("UpgradeConfigController", func() {
 						Expect(result.Requeue).To(BeFalse())
 						Expect(result.RequeueAfter).To(Equal(upgradingReconcileTime))
 						Expect(upgradeConfig.Status.History.GetHistory("a version").Phase == upgradev1alpha1.UpgradePhaseUpgraded).To(BeTrue())
-						Expect(upgradeConfig.Status.History.GetHistory("a version").Conditions[0].Message == "test passed").To(BeTrue())
 					})
 				})
 			})
@@ -485,7 +484,7 @@ var _ = Describe("UpgradeConfigController", func() {
 								mockClusterUpgraderBuilder.EXPECT().NewClient(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), upgradeConfig.Spec.Type).Return(mockClusterUpgrader, nil),
 								mockKubeClient.EXPECT().Status().Return(mockUpdater),
 								mockUpdater.EXPECT().Update(gomock.Any(), gomock.Any()),
-								mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(upgradev1alpha1.UpgradePhaseUpgrading, &upgradev1alpha1.UpgradeCondition{}, nil),
+								mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(upgradev1alpha1.UpgradePhaseUpgrading, nil),
 								mockKubeClient.EXPECT().Status().Return(mockUpdater),
 								mockUpdater.EXPECT().Update(gomock.Any(), gomock.Any()),
 							)
@@ -528,7 +527,7 @@ var _ = Describe("UpgradeConfigController", func() {
 								mockClusterUpgraderBuilder.EXPECT().NewClient(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), upgradeConfig.Spec.Type).Return(mockClusterUpgrader, nil),
 								mockKubeClient.EXPECT().Status().Return(mockUpdater),
 								mockUpdater.EXPECT().Update(gomock.Any(), gomock.Any()),
-								mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(upgradev1alpha1.UpgradePhaseUpgrading, &upgradev1alpha1.UpgradeCondition{}, fakeError),
+								mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(upgradev1alpha1.UpgradePhaseUpgrading, fakeError),
 								mockKubeClient.EXPECT().Status().Return(mockUpdater),
 								mockUpdater.EXPECT().Update(gomock.Any(), gomock.Any()),
 							)
@@ -608,7 +607,7 @@ var _ = Describe("UpgradeConfigController", func() {
 							mockKubeClient.EXPECT().Get(gomock.Any(), upgradeConfigName, gomock.Any()).SetArg(2, *upgradeConfig),
 							mockConfigManagerBuilder.EXPECT().New(gomock.Any(), gomock.Any()).Return(mockConfigManager),
 							mockClusterUpgraderBuilder.EXPECT().NewClient(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), upgradeConfig.Spec.Type).Return(mockClusterUpgrader, nil),
-							mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(upgradev1alpha1.UpgradePhaseUpgrading, &upgradev1alpha1.UpgradeCondition{}, nil),
+							mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(upgradev1alpha1.UpgradePhaseUpgrading, nil),
 							mockKubeClient.EXPECT().Status().Return(mockUpdater),
 							mockUpdater.EXPECT().Update(gomock.Any(), gomock.Any()),
 						)
@@ -627,7 +626,7 @@ var _ = Describe("UpgradeConfigController", func() {
 							mockKubeClient.EXPECT().Get(gomock.Any(), upgradeConfigName, gomock.Any()).SetArg(2, *upgradeConfig),
 							mockConfigManagerBuilder.EXPECT().New(gomock.Any(), gomock.Any()).Return(mockConfigManager),
 							mockClusterUpgraderBuilder.EXPECT().NewClient(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), upgradeConfig.Spec.Type).Return(mockClusterUpgrader, nil),
-							mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(upgradev1alpha1.UpgradePhaseUpgrading, &upgradev1alpha1.UpgradeCondition{}, fakeError),
+							mockClusterUpgrader.EXPECT().UpgradeCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(upgradev1alpha1.UpgradePhaseUpgrading, fakeError),
 							mockKubeClient.EXPECT().Status().Return(mockUpdater),
 							mockUpdater.EXPECT().Update(gomock.Any(), gomock.Any()),
 						)

--- a/pkg/upgraders/aroupgrader.go
+++ b/pkg/upgraders/aroupgrader.go
@@ -80,9 +80,8 @@ func NewAROUpgrader(c client.Client, cfm configmanager.ConfigManager, mc metrics
 }
 
 // UpgradeCluster performs the upgrade of the cluster and returns an indication of the
-// last-executed upgrade phase, the success condition of the phase, and any error associated
-// with the phase execution.
-func (u *aroUpgrader) UpgradeCluster(ctx context.Context, upgradeConfig *upgradev1alpha1.UpgradeConfig, logger logr.Logger) (upgradev1alpha1.UpgradePhase, *upgradev1alpha1.UpgradeCondition, error) {
+// last-executed upgrade phase and any error associated with the phase execution.
+func (u *aroUpgrader) UpgradeCluster(ctx context.Context, upgradeConfig *upgradev1alpha1.UpgradeConfig, logger logr.Logger) (upgradev1alpha1.UpgradePhase, error) {
 	u.upgradeConfig = upgradeConfig
 	return u.runSteps(ctx, logger, u.steps)
 }

--- a/pkg/upgraders/builder.go
+++ b/pkg/upgraders/builder.go
@@ -15,7 +15,7 @@ import (
 // Interface describing the functions of a cluster upgrader.
 //go:generate mockgen -destination=mocks/cluster_upgrader.go -package=mocks github.com/openshift/managed-upgrade-operator/pkg/upgraders ClusterUpgrader
 type ClusterUpgrader interface {
-	UpgradeCluster(ctx context.Context, upgradeConfig *upgradev1alpha1.UpgradeConfig, logger logr.Logger) (upgradev1alpha1.UpgradePhase, *upgradev1alpha1.UpgradeCondition, error)
+	UpgradeCluster(ctx context.Context, upgradeConfig *upgradev1alpha1.UpgradeConfig, logger logr.Logger) (upgradev1alpha1.UpgradePhase, error)
 }
 
 // ClusterUpgraderBuilder enables an implementation of a ClusterUpgraderBuilder

--- a/pkg/upgraders/mocks/cluster_upgrader.go
+++ b/pkg/upgraders/mocks/cluster_upgrader.go
@@ -36,13 +36,12 @@ func (m *MockClusterUpgrader) EXPECT() *MockClusterUpgraderMockRecorder {
 }
 
 // UpgradeCluster mocks base method
-func (m *MockClusterUpgrader) UpgradeCluster(arg0 context.Context, arg1 *v1alpha1.UpgradeConfig, arg2 logr.Logger) (v1alpha1.UpgradePhase, *v1alpha1.UpgradeCondition, error) {
+func (m *MockClusterUpgrader) UpgradeCluster(arg0 context.Context, arg1 *v1alpha1.UpgradeConfig, arg2 logr.Logger) (v1alpha1.UpgradePhase, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradeCluster", arg0, arg1, arg2)
 	ret0, _ := ret[0].(v1alpha1.UpgradePhase)
-	ret1, _ := ret[1].(*v1alpha1.UpgradeCondition)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // UpgradeCluster indicates an expected call of UpgradeCluster

--- a/pkg/upgraders/upgrader.go
+++ b/pkg/upgraders/upgrader.go
@@ -58,16 +58,15 @@ type clusterUpgrader struct {
 }
 
 // runSteps runs the upgrader's upgrade steps and returns the last-executed
-// upgrade phase, the success condition of that phase, and any associated error
-func (c *clusterUpgrader) runSteps(ctx context.Context, logger logr.Logger, s []upgradesteps.UpgradeStep) (upgradev1alpha1.UpgradePhase, *upgradev1alpha1.UpgradeCondition, error) {
-	phase, condition, err := upgradesteps.Run(ctx, logger, s)
-	return phase, condition, err
+// upgrade phase and any associated error
+func (c *clusterUpgrader) runSteps(ctx context.Context, logger logr.Logger, s []upgradesteps.UpgradeStep) (upgradev1alpha1.UpgradePhase, error) {
+	phase, err := upgradesteps.Run(ctx, c.upgradeConfig, logger, s)
+	return phase, err
 }
 
 // UpgradeCluster performs the upgrade of the cluster and returns an indication of the
-// last-executed upgrade phase, the success condition of the phase, and any error associated
-// with the phase execution.
-func (c *clusterUpgrader) UpgradeCluster(ctx context.Context, upgradeConfig *upgradev1alpha1.UpgradeConfig, logger logr.Logger) (upgradev1alpha1.UpgradePhase, *upgradev1alpha1.UpgradeCondition, error) {
+// last-executed upgrade phase and any error associated with the phase execution.
+func (c *clusterUpgrader) UpgradeCluster(ctx context.Context, upgradeConfig *upgradev1alpha1.UpgradeConfig, logger logr.Logger) (upgradev1alpha1.UpgradePhase, error) {
 	c.upgradeConfig = upgradeConfig
 	return c.runSteps(ctx, logger, c.steps)
 }

--- a/pkg/upgradesteps/runner.go
+++ b/pkg/upgradesteps/runner.go
@@ -6,6 +6,8 @@ import (
 	"github.com/go-logr/logr"
 	upgradev1alpha1 "github.com/openshift/managed-upgrade-operator/pkg/apis/upgrade/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
 )
 
 // UpgradeStep is the interface for steps that the upgrade runner
@@ -17,27 +19,28 @@ type UpgradeStep interface {
 
 // Run executes the provided steps in order until one fails or all steps
 // are completed. The function returns an indication of the last-completed
-// UpgradePhase, the success condition of that phase, and any associated error.
-func Run(ctx context.Context, logger logr.Logger, steps []UpgradeStep) (upgradev1alpha1.UpgradePhase, *upgradev1alpha1.UpgradeCondition, error) {
+// UpgradePhase any associated error.
+func Run(ctx context.Context, upgradeConfig *upgradev1alpha1.UpgradeConfig, logger logr.Logger, steps []UpgradeStep) (upgradev1alpha1.UpgradePhase, error) {
 	for _, step := range steps {
 		logger.Info(fmt.Sprintf("running step %s", step))
+		setConditionStart(step, upgradeConfig)
 		result, err := step.run(ctx, logger)
 
 		if err != nil {
 			logger.Error(err, fmt.Sprintf("error when %s", step.String()))
-			condition := newUpgradeCondition(fmt.Sprintf("%s not done", step.String()), err.Error(), upgradev1alpha1.UpgradeConditionType(step.String()), corev1.ConditionFalse)
-			return upgradev1alpha1.UpgradePhaseUpgrading, condition, err
+			setConditionInProgress(step, err.Error(), upgradeConfig)
+			return upgradev1alpha1.UpgradePhaseUpgrading, err
 		}
 
 		if !result {
 			logger.Info(fmt.Sprintf("%s not done, skip following steps", step.String()))
-			condition := newUpgradeCondition(fmt.Sprintf("%s not done", step.String()), fmt.Sprintf("%s still in progress", step.String()), upgradev1alpha1.UpgradeConditionType(step.String()), corev1.ConditionFalse)
-			return upgradev1alpha1.UpgradePhaseUpgrading, condition, nil
+			setConditionInProgress(step, fmt.Sprintf("%s still in progress", step.String()), upgradeConfig)
+			return upgradev1alpha1.UpgradePhaseUpgrading, nil
 		}
+
+		setConditionComplete(step, upgradeConfig)
 	}
-	step := steps[len(steps)-1]
-	condition := newUpgradeCondition(fmt.Sprintf("%s done", step.String()), fmt.Sprintf("%s is completed", step.String()), upgradev1alpha1.UpgradeConditionType(step.String()), corev1.ConditionTrue)
-	return upgradev1alpha1.UpgradePhaseUpgraded, condition, nil
+	return upgradev1alpha1.UpgradePhaseUpgraded, nil
 }
 
 // newUpgradeCondition is a helper function for creating and returning
@@ -51,3 +54,53 @@ func newUpgradeCondition(reason, msg string, conditionType upgradev1alpha1.Upgra
 	}
 }
 
+// setConditionStart adds an UpgradeCondition to the UpgradeConfig indicating
+// that a given step has commenced execution.
+// If the UpgradeCondition already exists, no action is taken.
+func setConditionStart(step UpgradeStep, upgradeConfig *upgradev1alpha1.UpgradeConfig) {
+	history := upgradeConfig.Status.History.GetHistory(upgradeConfig.Spec.Desired.Version)
+	c := history.Conditions.GetCondition(upgradev1alpha1.UpgradeConditionType(step.String()))
+	// Only set the condition if it doesn't already exist - the start time should already appear
+	if c == nil {
+		condition := newUpgradeCondition(fmt.Sprintf("%s not done", step.String()),
+			fmt.Sprintf("%s has started", step.String()),
+			upgradev1alpha1.UpgradeConditionType(step.String()),
+			corev1.ConditionFalse)
+		condition.StartTime = &metav1.Time{Time: time.Now()}
+		history.Conditions.SetCondition(*condition)
+		upgradeConfig.Status.History.SetHistory(*history)
+	}
+}
+
+// setConditionInProgress adds or updates an UpgradeCondition in the UpgradeConfig indicating
+// that a given step is currently executing.
+func setConditionInProgress(step UpgradeStep, message string, upgradeConfig *upgradev1alpha1.UpgradeConfig) {
+	history := upgradeConfig.Status.History.GetHistory(upgradeConfig.Spec.Desired.Version)
+	c := history.Conditions.GetCondition(upgradev1alpha1.UpgradeConditionType(step.String()))
+	if c != nil {
+		c.Message = message
+		c.Status = corev1.ConditionFalse
+		// Reset completion time because some steps can fail after an earlier success
+		c.CompleteTime = nil
+		history.Conditions.SetCondition(*c)
+		upgradeConfig.Status.History.SetHistory(*history)
+	}
+}
+
+// setConditionComplete adds or updates an UpgradeCondition in the UpgradeConfig indicating
+// that a given step has completed.
+func setConditionComplete(step UpgradeStep, upgradeConfig *upgradev1alpha1.UpgradeConfig) {
+	history := upgradeConfig.Status.History.GetHistory(upgradeConfig.Spec.Desired.Version)
+	c := history.Conditions.GetCondition(upgradev1alpha1.UpgradeConditionType(step.String()))
+	if c != nil {
+		c.Reason = fmt.Sprintf("%s done", step.String())
+		c.Message = fmt.Sprintf("%s is completed", step.String())
+		c.Status = corev1.ConditionTrue
+		// Only set completion time if it isn't already set
+		if c.CompleteTime == nil {
+			c.CompleteTime = &metav1.Time{Time: time.Now()}
+		}
+		history.Conditions.SetCondition(*c)
+		upgradeConfig.Status.History.SetHistory(*history)
+	}
+}

--- a/pkg/upgradesteps/runner_test.go
+++ b/pkg/upgradesteps/runner_test.go
@@ -3,12 +3,14 @@ package upgradesteps
 import (
 	"context"
 	"fmt"
+	testStructs "github.com/openshift/managed-upgrade-operator/util/mocks/structs"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	upgradev1alpha1 "github.com/openshift/managed-upgrade-operator/pkg/apis/upgrade/v1alpha1"
@@ -28,10 +30,21 @@ var _ = Describe("HealthCheckStep", func() {
 		unsuccessfulStep = func(ctx context.Context, logger logr.Logger) (bool, error) {
 			return false, nil
 		}
+		upgradeConfigName types.NamespacedName
+		upgradeConfig     *upgradev1alpha1.UpgradeConfig
 	)
 
 	BeforeEach(func() {
 		logger = logf.Log.WithName("step runner test logger")
+		upgradeConfigName = types.NamespacedName{
+			Name:      "test-upgradeconfig",
+			Namespace: "test-namespace",
+		}
+		upgradeConfig = testStructs.NewUpgradeConfigBuilder().WithNamespacedName(upgradeConfigName).GetUpgradeConfig()
+		upgradeConfig.Status.History.SetHistory(upgradev1alpha1.UpgradeHistory{
+			Version:            upgradeConfig.Spec.Desired.Version,
+			Phase:              upgradev1alpha1.UpgradePhaseNew,
+		})
 	})
 
 	Context("When all steps return successfully", func() {
@@ -42,60 +55,95 @@ var _ = Describe("HealthCheckStep", func() {
 			Action(finalStepName, successfulStep),
 		}
 		It("should return an upgrade completed phase", func() {
-			phase, _, err := Run(context.TODO(), logger, steps)
+			phase, err := Run(context.TODO(), upgradeConfig, logger, steps)
 			Expect(err).To(BeNil())
 			Expect(phase).To(Equal(upgradev1alpha1.UpgradePhaseUpgraded))
 		})
-		It("should indicate which step was the final condition to be satisfied", func() {
-			phase, condition, err := Run(context.TODO(), logger, steps)
+		It("should have a successful condition for each step", func() {
+			_, err := Run(context.TODO(), upgradeConfig, logger, steps)
 			Expect(err).To(BeNil())
-			Expect(condition.Status).To(Equal(corev1.ConditionTrue))
-			Expect(condition.Type).To(Equal(upgradev1alpha1.UpgradeConditionType(finalStepName)))
-			Expect(phase).To(Equal(upgradev1alpha1.UpgradePhaseUpgraded))
+			history := upgradeConfig.Status.History.GetHistory(upgradeConfig.Spec.Desired.Version)
+			Expect(history).ToNot(BeNil())
+			for _, step := range steps {
+				condition := history.Conditions.GetCondition(upgradev1alpha1.UpgradeConditionType(step.String()))
+				Expect(condition).ToNot(BeNil())
+				Expect(condition.Status).To(Equal(corev1.ConditionTrue))
+				Expect(condition.CompleteTime).ToNot(BeNil())
+			}
 		})
 	})
 
 	Context("When a step is unsuccessful", func() {
 		unsuccessfulStepName := "step that did not finish"
+		successfulStepName := "step 1"
+		notRunStepName := "step 3"
 		steps := []UpgradeStep{
-			Action("step 1", successfulStep),
+			Action(successfulStepName, successfulStep),
 			Action(unsuccessfulStepName, unsuccessfulStep),
-			Action("step 3", successfulStep),
+			Action(notRunStepName, successfulStep),
 		}
 
 		It("should indicate the upgrade is still ongoing", func() {
-			phase, _, err := Run(context.TODO(), logger, steps)
+			phase, err := Run(context.TODO(), upgradeConfig, logger, steps)
 			Expect(err).To(BeNil())
 			Expect(phase).To(Equal(upgradev1alpha1.UpgradePhaseUpgrading))
 		})
-		It("should indicate the upgrade condition which has not passed", func() {
-			_, condition, err := Run(context.TODO(), logger, steps)
+
+		It("should correctly indicate condition states", func() {
+			_, err := Run(context.TODO(), upgradeConfig, logger, steps)
 			Expect(err).To(BeNil())
-			Expect(condition.Status).To(Equal(corev1.ConditionFalse))
-			Expect(condition.Type).To(Equal(upgradev1alpha1.UpgradeConditionType(unsuccessfulStepName)))
+			history := upgradeConfig.Status.History.GetHistory(upgradeConfig.Spec.Desired.Version)
+			Expect(history).ToNot(BeNil())
+			successfulStepCondition := history.Conditions.GetCondition(upgradev1alpha1.UpgradeConditionType(successfulStepName))
+			unsuccessfulStepCondition := history.Conditions.GetCondition(upgradev1alpha1.UpgradeConditionType(unsuccessfulStepName))
+			missingStepCondition := history.Conditions.GetCondition(upgradev1alpha1.UpgradeConditionType(notRunStepName))
+			Expect(missingStepCondition).To(BeNil())
+			Expect(successfulStepCondition).ToNot(BeNil())
+			Expect(successfulStepCondition.Status).To(Equal(corev1.ConditionTrue))
+			Expect(successfulStepCondition.StartTime).ToNot(BeNil())
+			Expect(successfulStepCondition.CompleteTime).ToNot(BeNil())
+			Expect(unsuccessfulStepCondition).ToNot(BeNil())
+			Expect(unsuccessfulStepCondition.Status).To(Equal(corev1.ConditionFalse))
+			Expect(unsuccessfulStepCondition.StartTime).ToNot(BeNil())
+			Expect(unsuccessfulStepCondition.CompleteTime).To(BeNil())
 		})
 	})
 
 	Context("When a step has errored", func() {
 		erroredStepName := "step that errored"
+		successfulStepName := "step 1"
+		notRunStepName := "step 3"
 		steps := []UpgradeStep{
-			Action("step 1", successfulStep),
+			Action(successfulStepName, successfulStep),
 			Action(erroredStepName, erroredStep),
-			Action("step 3", successfulStep),
+			Action(notRunStepName, successfulStep),
 		}
 
 		It("should indicate the upgrade is still ongoing", func() {
-			phase, _, _ := Run(context.TODO(), logger, steps)
+			phase, _ := Run(context.TODO(), upgradeConfig, logger, steps)
 			Expect(phase).To(Equal(upgradev1alpha1.UpgradePhaseUpgrading))
 		})
-		It("should indicate the upgrade condition which has not passed", func() {
-			_, condition, _ := Run(context.TODO(), logger, steps)
-			Expect(condition.Status).To(Equal(corev1.ConditionFalse))
-			Expect(condition.Type).To(Equal(upgradev1alpha1.UpgradeConditionType(erroredStepName)))
-		})
 		It("should indicate the error associated with the failed step", func() {
-			_, _, err := Run(context.TODO(), logger, steps)
+			_, err := Run(context.TODO(), upgradeConfig, logger, steps)
 			Expect(err).To(Equal(err))
+		})
+		It("should correctly indicate condition states", func() {
+			_, err := Run(context.TODO(), upgradeConfig, logger, steps)
+			Expect(err).To(Equal(err))
+			history := upgradeConfig.Status.History.GetHistory(upgradeConfig.Spec.Desired.Version)
+			Expect(history).ToNot(BeNil())
+			successfulStepCondition := history.Conditions.GetCondition(upgradev1alpha1.UpgradeConditionType(successfulStepName))
+			erroredStepCondition := history.Conditions.GetCondition(upgradev1alpha1.UpgradeConditionType(erroredStepName))
+			missingStepCondition := history.Conditions.GetCondition(upgradev1alpha1.UpgradeConditionType(notRunStepName))
+			Expect(missingStepCondition).To(BeNil())
+			Expect(successfulStepCondition).ToNot(BeNil())
+			Expect(successfulStepCondition.Status).To(Equal(corev1.ConditionTrue))
+			Expect(successfulStepCondition.StartTime).ToNot(BeNil())
+			Expect(successfulStepCondition.CompleteTime).ToNot(BeNil())
+			Expect(erroredStepCondition).ToNot(BeNil())
+			Expect(erroredStepCondition.Status).To(Equal(corev1.ConditionFalse))
+			Expect(erroredStepCondition.StartTime).ToNot(BeNil())
+			Expect(erroredStepCondition.CompleteTime).To(BeNil())
 		})
 	})
 })


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
This PR enables more granular reporting of upgrade step progress through `Conditions` reported in the `UpgradeConfig`'s `Status.History` data.

Each upgrade step that the upgrader performs will result in a new entry appended to `conditions` which will indicate:

- the time that the step first attempted to run
- the completion time of the step (the last time the step transitioned from in-progress to complete)
- the status of the step (true = complete, false = not complete)

This allows us to understand how long each step is taking in the upgrade process and expose those metrics.

Implementing this change has resulted in a small refactor - conditions are no longer managed by the controller, because the controller does not have full insight into what conditions have run. Instead, conditions are now managed within the generic upgrade step runner. Because of this, it is no longer necessary to be passing conditions back up the call chain from the step runner to the controller, so that has been removed as a further simplification.

Additional test cases have been added to the step-runner test suite to verify that it is storing conditions correctly.

An example of the condition representation in an UpgradeConfig is presented below:

```
  status:                                                                                     
    history:                                                                                  
    - phase: Upgraded                                                                         
      startTime: "2021-08-16T23:30:58Z"                                                       
      version: 4.6.21                   
      completeTime: "2021-08-17T01:16:29Z"   
      conditions:                                                                             
      - completeTime: "2021-08-17T01:16:29Z"                                                  
        lastProbeTime: "2021-08-17T01:16:29Z"
        lastTransitionTime: "2021-08-17T01:16:29Z"
        message: SendStartedNotification is completed
        reason: SendStartedNotification done                                                
        startTime: "2021-08-17T01:16:25Z"                                                     
        status: "True"                                                                        
        type: SendStartedNotification       
```

### Which Jira/Github issue(s) this PR fixes?

[OSD-7502](https://issues.redhat.com/browse/OSD-7502)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [X] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

