### PR TITLE
OSD-7860 Don't ignore deleting machines during scaledown

### DIFF
--- a/pkg/scaler/machineSetScaler.go
+++ b/pkg/scaler/machineSetScaler.go
@@ -181,7 +181,7 @@ func getExtraUpgradeNodes(c client.Client) (*corev1.NodeList, error) {
 
 	extraUpgradeNodes := &corev1.NodeList{}
 	for _, machine := range machines.Items {
-		if *machine.Status.Phase == string(corev1.NodeRunning) {
+		if *machine.Status.Phase == "Running" || *machine.Status.Phase == "Deleting" {
 			for _, node := range nodes.Items {
 				if node.Name == machine.Status.NodeRef.Name {
 					extraUpgradeNodes.Items = append(extraUpgradeNodes.Items, node)


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
Since the cyclomatic complexity fix was implemented, we've been observing consistent failures in E2E because our PDB/Finalizer "disruptive" workloads schedule onto the scaled-capacity worker, preventing successful scale-down.
(Examples: [1](https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/origin-ci-test/logs/osde2e-stage-gcp-e2e-upgrade-to-latest/1428024076428906496), [2](https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/origin-ci-test/logs/osde2e-stage-gcp-e2e-upgrade-to-latest/1427903320894214144), [3](https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/origin-ci-test/logs/osde2e-stage-gcp-e2e-upgrade-to-latest/1427782586133909504), [4](https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/origin-ci-test/logs/osde2e-stage-gcp-e2e-upgrade-to-latest/1427420066776879104))

The issue is due to an additional check inserted into the function which identifies the capacity-scaled machine to confirm that the machine is `Running`. When the scale-down occurs, the machine will very likely be `Deleting`, so this check does not succeed - and so our drain policies stopped executing during scale-down.

The fix is easy - let's add `Deleting` to the list of valid Phases to consider our scaled-capacity worker can be in.

Unfortunately this has to be a hardcoded string right now because the phase is [not an exported variable](https://github.com/openshift/machine-api-operator/blob/6a003c5f473fa7c2caaf61b66684b09faef35db7/pkg/controller/machine/controller.go#L93) in machine-api-operator. :( 
(also we shouldn't be comparing against `corev1.NodeDeleting` as that's a node phase, not a machine phase).

This change should not have any adverse side-effects because the only function that calls it is the scale-down step.

### Which Jira/Github issue(s) this PR fixes?

OSD-7860.

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

