### PR TITLE
CRD validation for PDBForceDrainTimeout field

### DIFF
--- a/deploy/crds/upgrade.managed.openshift.io_upgradeconfigs.yaml
+++ b/deploy/crds/upgrade.managed.openshift.io_upgradeconfigs.yaml
@@ -63,6 +63,7 @@ spec:
                   is blocked by a Pod Disruption Budget, before that drain is forced.
                   Measured in minutes.
                 format: int32
+                minimum: 0
                 type: integer
               capacityReservation:
                 description: Specify if scaling up an extra node for capacity reservation

--- a/deploy/crds/upgrade.managed.openshift.io_upgradeconfigs.yaml
+++ b/deploy/crds/upgrade.managed.openshift.io_upgradeconfigs.yaml
@@ -61,7 +61,9 @@ spec:
               PDBForceDrainTimeout:
                 description: The maximum grace period granted to a node whose drain
                   is blocked by a Pod Disruption Budget, before that drain is forced.
-                  Measured in minutes.
+                  Measured in minutes. The minimum accepted value is 0 and in this
+                  case it will trigger force drain after the expectedNodeDrainTime
+                  lapsed.
                 format: int32
                 minimum: 0
                 type: integer

--- a/pkg/apis/upgrade/v1alpha1/upgradeconfig_types.go
+++ b/pkg/apis/upgrade/v1alpha1/upgradeconfig_types.go
@@ -25,6 +25,7 @@ type UpgradeConfigSpec struct {
 	// Specify the upgrade start time
 	UpgradeAt string `json:"upgradeAt"`
 
+	// +kubebuilder:validation:Minimum:=0
 	// The maximum grace period granted to a node whose drain is blocked by a Pod Disruption Budget, before that drain is forced. Measured in minutes.
 	PDBForceDrainTimeout int32 `json:"PDBForceDrainTimeout"`
 

--- a/pkg/apis/upgrade/v1alpha1/upgradeconfig_types.go
+++ b/pkg/apis/upgrade/v1alpha1/upgradeconfig_types.go
@@ -26,7 +26,7 @@ type UpgradeConfigSpec struct {
 	UpgradeAt string `json:"upgradeAt"`
 
 	// +kubebuilder:validation:Minimum:=0
-	// The maximum grace period granted to a node whose drain is blocked by a Pod Disruption Budget, before that drain is forced. Measured in minutes.
+	// The maximum grace period granted to a node whose drain is blocked by a Pod Disruption Budget, before that drain is forced. Measured in minutes. The minimum accepted value is 0 and in this case it will trigger force drain after the expectedNodeDrainTime lapsed. 
 	PDBForceDrainTimeout int32 `json:"PDBForceDrainTimeout"`
 
 	// +kubebuilder:validation:Enum={"OSD","ARO"}


### PR DESCRIPTION
### What type of PR is this?
refactor

### What this PR does / why we need it?
CRD validation for  PDBForceDrainTimeout field in the upgradeconfig CR. It will throw validation error if we put negative integer value for this parameter.

### Which Jira/Github issue(s) this PR fixes?
[OSD-7898](https://issues.redhat.com/browse/OSD-7898)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

