### PR TITLE
[OSD-8543] Make MUO messaging for capacity reservation failure to be provider-agnostic

### DIFF
--- a/pkg/eventmanager/eventmanager.go
+++ b/pkg/eventmanager/eventmanager.go
@@ -30,7 +30,7 @@ const (
 	// UPGRADE_SCALE_DELAY_DESC describes the upgrade scaling delayed
 	UPGRADE_SCALE_DELAY_DESC = "Cluster upgrade to version %s is experiencing a delay attempting to scale up an additional worker node. The upgrade will continue to retry. This is an informational notification and no action is required by you."
 	// UPGRADE_SCALE_DELAY_SKIP_DESC describes the upgrade scaling skipped after delay
-	UPGRADE_SCALE_DELAY_SKIP_DESC = "Cluster upgrade to version %s has experienced an issue during capacity reservation efforts. This could be caused by AWS account service quota limitations or temporary connectivity issues to/from the new worker node. The upgrade will continue without extra compute. This is an informational notification and no action is required by you."
+	UPGRADE_SCALE_DELAY_SKIP_DESC = "Cluster upgrade to version %s has experienced an issue during capacity reservation efforts. This could be caused by cloud service provider quota limitations or temporary connectivity issues to/from the new worker node. The upgrade will continue without extra compute. This is an informational notification and no action is required by you."
 )
 
 // EventManager enables implementation of an EventManager


### PR DESCRIPTION

### What type of PR is this?
_(refactor)_


### What this PR does / why we need it?

To make MUO messaging for capacity reservation failure provider-agnostic

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_OSD-8543

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x ] Ran `boilerplate/_lib/container-make` command locally to validate code changes

