### PR TITLE
OSD-8564 support type OSD only from OCM

### DIFF
--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -25,6 +25,8 @@ const (
 	UPGRADEPOLICIES_V1_PATH = "upgrade_policies"
 	// STATE_V1_PATH sub-path to the policy state service
 	STATE_V1_PATH = "state"
+	// UPGRADE_TYPE_OSD is the only supported type.
+	UPGRADE_TYPE_OSD = "OSD"
 )
 
 var (
@@ -117,6 +119,12 @@ func (s *ocmClient) GetClusterUpgradePolicies(clusterId string) (*UpgradePolicyL
 	upUrl.Path = path.Join(upUrl.Path, CLUSTERS_V1_PATH, clusterId, UPGRADEPOLICIES_V1_PATH)
 
 	response, err := s.httpClient.R().
+		SetQueryParams(map[string]string{
+			"page": "1",
+			"size": "1",
+			// OCM also provides types [ADDON, CVE] which are currently unsupported.
+			"search": fmt.Sprintf("upgrade_type = '%s'", UPGRADE_TYPE_OSD),
+		}).
 		SetResult(&UpgradePolicyList{}).
 		ExpectContentType("application/json").
 		Get(upUrl.String())
@@ -130,6 +138,7 @@ func (s *ocmClient) GetClusterUpgradePolicies(clusterId string) (*UpgradePolicyL
 	}
 
 	upgradeResponse := response.Result().(*UpgradePolicyList)
+
 	return upgradeResponse, nil
 }
 

--- a/pkg/ocm/client_test.go
+++ b/pkg/ocm/client_test.go
@@ -25,6 +25,7 @@ const (
 	// Upgrade policy constants
 	TEST_OPERATOR_NAMESPACE         = "test-managed-upgrade-operator"
 	TEST_UPGRADEPOLICY_UPGRADETYPE  = "OSD"
+	TEST_UPGRADEPOLICY_ADDON        = "ADDON"
 	TEST_UPGRADEPOLICY_TIME         = "2020-06-20T00:00:00Z"
 	TEST_UPGRADEPOLICY_VERSION      = "4.4.5"
 	TEST_UPGRADEPOLICY_CHANNELGROUP = "fast"
@@ -98,6 +99,17 @@ var _ = Describe("OCM Client", func() {
 					NextRun:      TEST_UPGRADEPOLICY_TIME,
 					ClusterId:    TEST_CLUSTER_ID,
 				},
+				{
+					Id:           TEST_POLICY_ID_MANUAL,
+					Kind:         "UpgradePolicy",
+					Href:         "test",
+					Schedule:     "test",
+					ScheduleType: "manual",
+					UpgradeType:  TEST_UPGRADEPOLICY_ADDON,
+					Version:      TEST_UPGRADEPOLICY_VERSION,
+					NextRun:      TEST_UPGRADEPOLICY_TIME,
+					ClusterId:    TEST_CLUSTER_ID,
+				},
 			},
 		}
 		upgradePolicyStateResponse = UpgradePolicyState{
@@ -142,7 +154,7 @@ var _ = Describe("OCM Client", func() {
 	})
 
 	Context("When getting upgrade policies", func() {
-		It("returns the correct info", func() {
+		It("retrieves OSD type only", func() {
 
 			upResponder, _ := httpmock.NewJsonResponder(http.StatusOK, upgradePolicyListResponse)
 			upUrl := path.Join(CLUSTERS_V1_PATH, TEST_CLUSTER_ID, UPGRADEPOLICIES_V1_PATH)
@@ -150,7 +162,7 @@ var _ = Describe("OCM Client", func() {
 
 			result, err := oc.GetClusterUpgradePolicies(TEST_CLUSTER_ID)
 
-			Expect(*result).To(Equal(upgradePolicyListResponse))
+			Expect(result.Items[0]).To(Equal(upgradePolicyListResponse.Items[0]))
 			Expect(err).To(BeNil())
 		})
 	})


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
upgrade_type: ADDON has been introduced into OCM. MUO needs to explicity retrieve only upgrade_type:OSD

### Which Jira/Github issue(s) this PR fixes?
[OSD-8564](https://issues.redhat.com/browse/OSD-8564)

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

