### PR TITLE
Prevent panic if machine has no noderef

### DIFF
--- a/pkg/scaler/machineSetScaler.go
+++ b/pkg/scaler/machineSetScaler.go
@@ -183,6 +183,9 @@ func getExtraUpgradeNodes(c client.Client) (*corev1.NodeList, error) {
 	for _, machine := range machines.Items {
 		if *machine.Status.Phase == "Running" || *machine.Status.Phase == "Deleting" {
 			for _, node := range nodes.Items {
+				if machine.Status.NodeRef == nil {
+					return nil, fmt.Errorf("an upgrade machine %v exists but has no node association", machine.Name)
+				}
 				if node.Name == machine.Status.NodeRef.Name {
 					extraUpgradeNodes.Items = append(extraUpgradeNodes.Items, node)
 				}


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
When searching for upgrade nodes to execute drain strategies on, MUO first searches through machines belonging to the upgrade machineset.

In the rare edge case where a machine existed which did not have a `NodeRef` set in its Status, this was causing a panic for MUO.

This is an irregular situation so if it happens let's treat it like an error, but not have MUO panic.

### Which Jira/Github issue(s) this PR fixes?

OSD-8511 / OSD-8452

