### PR TITLE
Revert "OSD-8005 - Updating Policy API version from v1beta1 to v1 for PDB

### DIFF
--- a/pkg/drain/osd_drain_strategy_test.go
+++ b/pkg/drain/osd_drain_strategy_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/managed-upgrade-operator/pkg/machinery"
@@ -248,13 +248,13 @@ var _ = Describe("OSD Drain Strategy", func() {
 				pdbPodName  = "test-pdb-pod"
 				pdbAppKey   = "app"
 				pdbAppValue = "app1"
-				pdbList     *policyv1.PodDisruptionBudgetList
+				pdbList     *policyv1beta1.PodDisruptionBudgetList
 			)
 			BeforeEach(func() {
-				pdbList = &policyv1.PodDisruptionBudgetList{
-					Items: []policyv1.PodDisruptionBudget{
+				pdbList = &policyv1beta1.PodDisruptionBudgetList{
+					Items: []policyv1beta1.PodDisruptionBudget{
 						{
-							Spec: policyv1.PodDisruptionBudgetSpec{
+							Spec: policyv1beta1.PodDisruptionBudgetSpec{
 								Selector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
 										pdbAppKey: pdbAppValue,
@@ -263,7 +263,7 @@ var _ = Describe("OSD Drain Strategy", func() {
 							},
 						},
 						{
-							Spec: policyv1.PodDisruptionBudgetSpec{
+							Spec: policyv1beta1.PodDisruptionBudgetSpec{
 								Selector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
 										"non-existent-pod-selector": "",

--- a/pkg/drain/pod_predicates.go
+++ b/pkg/drain/pod_predicates.go
@@ -2,18 +2,18 @@ package drain
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 
 	"github.com/openshift/managed-upgrade-operator/pkg/pod"
 )
 
-func isPdbPod(pdbList *policyv1.PodDisruptionBudgetList) pod.PodPredicate {
+func isPdbPod(pdbList *policyv1beta1.PodDisruptionBudgetList) pod.PodPredicate {
 	return func(p corev1.Pod) bool {
 		return containsMatchLabel(p, pdbList)
 	}
 }
 
-func isNotPdbPod(pdbList *policyv1.PodDisruptionBudgetList) pod.PodPredicate {
+func isNotPdbPod(pdbList *policyv1beta1.PodDisruptionBudgetList) pod.PodPredicate {
 	return func(p corev1.Pod) bool {
 		return !containsMatchLabel(p, pdbList)
 	}
@@ -42,7 +42,7 @@ func isNotDaemonSet(pod corev1.Pod) bool {
 	return !isDaemonSet(pod)
 }
 
-func containsMatchLabel(p corev1.Pod, pdbList *policyv1.PodDisruptionBudgetList) bool {
+func containsMatchLabel(p corev1.Pod, pdbList *policyv1beta1.PodDisruptionBudgetList) bool {
 	isPdbPod := false
 	for _, pdb := range pdbList.Items {
 		for mlKey, mlValue := range pdb.Spec.Selector.MatchLabels {

--- a/pkg/drain/strategy.go
+++ b/pkg/drain/strategy.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	upgradev1alpha1 "github.com/openshift/managed-upgrade-operator/pkg/apis/upgrade/v1alpha1"
@@ -59,7 +59,7 @@ func newTimedStrategy(name string, description string, waitDuration time.Duratio
 
 // NewNodeDrainStrategy returns a NodeDrainStrategy
 func (dsb *drainStrategyBuilder) NewNodeDrainStrategy(c client.Client, uc *upgradev1alpha1.UpgradeConfig, cfg *NodeDrain) (NodeDrainStrategy, error) {
-	pdbList := &policyv1.PodDisruptionBudgetList{}
+	pdbList := &policyv1beta1.PodDisruptionBudgetList{}
 	err := c.List(context.TODO(), pdbList)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This reverts commit 149861a4110146f8c03e10b13c6577e3b3086487.

### What type of PR is this?
_(cleanup)_

### What this PR does / why we need it?
Reverts #282 

### Special notes for your reviewer:
4.7 to 4.8 upgrades will fail due to this commit since 4.7 doesn't have policy/v1 API at all. This update of API version can't happen unless all clusters are atleast on 4.8 (1.21 k8s) version.
