### PR TITLE
Set validation failed metric correctly

### DIFF
--- a/pkg/controller/upgradeconfig/upgradeconfig_controller.go
+++ b/pkg/controller/upgradeconfig/upgradeconfig_controller.go
@@ -170,15 +170,12 @@ func (r *ReconcileUpgradeConfig) Reconcile(ctx context.Context, request reconcil
 
 		// Validate UpgradeConfig instance
 		validatorResult, err := validator.IsValidUpgradeConfig(r.client, instance, clusterVersion, reqLogger)
-		if err != nil {
-			reqLogger.Info("An error occurred while validating UpgradeConfig")
+		if !validatorResult.IsValid || err != nil {
+			reqLogger.Info(fmt.Sprintf("An error occurred while validating UpgradeConfig: %v", validatorResult.Message))
+			metricsClient.UpdateMetricValidationFailed(instance.Name)
 			return reconcile.Result{}, err
 		}
-		if !validatorResult.IsValid {
-			reqLogger.Info(validatorResult.Message)
-			metricsClient.UpdateMetricValidationFailed(instance.Name)
-			return reconcile.Result{}, nil
-		}
+
 		metricsClient.UpdateMetricValidationSucceeded(instance.Name)
 		if !validatorResult.IsAvailableUpdate {
 			reqLogger.Info(validatorResult.Message)


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
I happened to notice (whilst trying to fix our E2E tests) that MUO has not been setting the `upgradeconfig_validation_failed` metric when it should be. The behaviour seems to have been introduced during some earlier refactoring of the validation code. This PR corrects that behaviour so that the metric is set when it should.


