### PR TITLE
OSD-9057 Use trusted-ca-bundle for trusting external https connections

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -28,6 +28,14 @@ spec:
         key: node-role.kubernetes.io/master
       - effect: NoExecute
         key: node-role.kubernetes.io/master
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+            - key: ca-bundle.crt
+              path: tls-ca-bundle.pem
+          name: trusted-ca-bundle
+        name: trusted-ca-bundle
       containers:
         - name: managed-upgrade-operator
           # Replace this with the built image name
@@ -58,3 +66,7 @@ spec:
                   fieldPath: metadata.namespace
             - name: OPERATOR_NAME
               value: "managed-upgrade-operator"
+          volumeMounts:
+          - mountPath: /etc/pki/ca-trust/extracted/pem
+            name: trusted-ca-bundle
+            readOnly: true

--- a/deploy/trusted_ca_bundle_configmap.yaml
+++ b/deploy/trusted_ca_bundle_configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-managed-upgrade-operator
+  name: trusted-ca-bundle
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?

This PR adds a new `trusted-ca-bundle` ConfigMap for MUO which will contain the system CA certs used to authenticate HTTPS connections. [0]

The ConfigMap contains the `config.openshift.io/inject-trusted-cabundle` label so that the user-supplied CA bundle is injected into it.

The ConfigMap is mounted into MUO in the `/etc/pki/ca-trust/extracted/pem` location such that no other work is required to have the application use these CA for verifying server cert authenticity.

This is an approach which aligns with other cluster operators including the console and insights operators. 

[0] https://docs.openshift.com/container-platform/4.9/networking/configuring-a-custom-pki.html

### Which Jira/Github issue(s) this PR fixes?

[OSD-9057](https://issues.redhat.com/browse/OSD-9057) 

### Special notes for your reviewer:

This change has been successfully tested on a proxy-enabled cluster to verify that an upgrade could complete successfully and trust all communications to `api.openshift.com`.

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [X] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR
