### PR TITLE
Fix bug to add expectedNodeDrainTime for PDB pod drain

### DIFF
--- a/pkg/drain/nodeDrainStrategy.go
+++ b/pkg/drain/nodeDrainStrategy.go
@@ -49,7 +49,7 @@ func (ds *osdDrainStrategy) Execute(node *corev1.Node) ([]*DrainStrategyResult, 
 				r, err := ds.GetStrategy().Execute(node)
 				me = multierror.Append(err, me)
 				if r.HasExecuted {
-					res = append(res, &DrainStrategyResult{Message: fmt.Sprintf("Drain strategy %s has been executed. %s", ds.GetDescription(), r.Message)})
+					res = append(res, &DrainStrategyResult{Message: fmt.Sprintf("Drain strategy %s has been executed after %s. %s", ds.GetDescription(), drainStrategyDuration(result.AddedAt), r.Message)})
 				}
 			}
 		}
@@ -129,6 +129,10 @@ func (ts *timedStrategy) GetStrategy() DrainStrategy {
 
 func isAfter(t *metav1.Time, d time.Duration) bool {
 	return t != nil && t.Add(d).Before(metav1.Now().Time)
+}
+
+func drainStrategyDuration(t *metav1.Time) time.Duration {
+	return (metav1.Now().Sub(t.Time))
 }
 
 func sortDuration(ts []TimedDrainStrategy) []TimedDrainStrategy {

--- a/pkg/drain/nodeDrainStrategy.go
+++ b/pkg/drain/nodeDrainStrategy.go
@@ -132,7 +132,7 @@ func isAfter(t *metav1.Time, d time.Duration) bool {
 }
 
 func drainStrategyDuration(t *metav1.Time) time.Duration {
-	return (metav1.Now().Sub(t.Time))
+	return (metav1.Now().Sub(t.Time).Round(time.Second))
 }
 
 func sortDuration(ts []TimedDrainStrategy) []TimedDrainStrategy {

--- a/pkg/drain/strategy.go
+++ b/pkg/drain/strategy.go
@@ -69,7 +69,7 @@ func (dsb *drainStrategyBuilder) NewNodeDrainStrategy(c client.Client, uc *upgra
 	isNotPdbPod := isNotPdbPod(pdbList)
 	isPdbPod := isPdbPod(pdbList)
 	defaultDuration := cfg.GetTimeOutDuration()
-	pdbDuration := uc.GetPDBDrainTimeoutDuration()
+	pdbDuration := uc.GetPDBDrainTimeoutDuration() + cfg.GetExpectedDrainDuration()
 	ts := []TimedDrainStrategy{
 		newTimedStrategy(defaultPodDeleteName, "Default pod deletion", defaultDuration, &podDeletionStrategy{
 			client:  c,


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
This PR fixes a bug where the PDB drain strategy used to drain the PDB pods immediately if `PDBForceDrainTimeout` was set to 0. The PR adds `expectedNodeDrainTime` of 8 minutes (default value) in addition to whatever is configured for `PDBForceDrainTimeout`. Additionally, the PR also displays the exact time when the drain strategy was applied from the time that the respective node was cordoned.

### Which Jira/Github issue(s) this PR fixes?
_Fixes #_ [OSD-7899](https://issues.redhat.com/browse/OSD-7899)

### Special notes for your reviewer:
- For now, the `expectedNodeDrainTime` is added **only** for the PDB pod drain strategy.
- BEFORE:
```bash
"Drain strategy PDB pod deletion has been executed. Pod(s) pdb-case-2-97b5b6745-c75gp have been marked for deletion" Request.Name=ip-10-0-225-62.ap-south-1.compute.internal
```
- AFTER:
```bash
"Drain strategy PDB pod deletion has been executed after 8m15.601900733s. Pod(s) pdb-case-2-97b5b6745-xnp65 have been marked for deletion" Request.Name=ip-10-0-156-29.ap-south-1.compute.internal
```

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make generate` command locally to validate code changes

