### PR TITLE
OHSS-9813 OCM Client must use proxy

### DIFF
--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -54,6 +54,7 @@ type ocmClient struct {
 
 type ocmRoundTripper struct {
 	authorization util.AccessToken
+	proxy *url.URL
 }
 
 func (ort *ocmRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -61,6 +62,9 @@ func (ort *ocmRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 	req.Header.Add("Authorization", authVal)
 	transport := http.Transport{
 		TLSHandshakeTimeout: time.Second * 5,
+	}
+	if ort.proxy != nil {
+		transport.Proxy = http.ProxyURL(ort.proxy)
 	}
 	return transport.RoundTrip(req)
 }


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
The MUO OCM client uses `resty` for interacting with OCM, which does not use the `HTTP_PROXY` and `HTTPS_PROXY` system environment variables by default. The proxy must be set explicitly.

The ocm roundtripper used by the resty client has been updated to set a proxy if the system environment variables define one.

### Which Jira/Github issue(s) this PR fixes?

Observed in [OHSS-9813](https://issues.redhat.com/browse/OHSS-9813)

### Special notes for your reviewer:

I've tested this in the following scenarios:

- A cluster with no proxy configured
- A cluster with a proxy configured
- A cluster with a proxy configured, but with the proxy server temporarily stopped (to verify that syncing should fail, which would indicate that syncing is _definitely_ using the proxy)
