### PR TITLE
Add ocm operation ID to logger

### DIFF
--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -12,6 +12,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/openshift/managed-upgrade-operator/util"
 )
@@ -28,6 +29,8 @@ const (
 	// UPGRADE_TYPE_OSD is the only supported type.
 	UPGRADE_TYPE_OSD = "OSD"
 )
+
+var log = logf.Log.WithName("ocm-client")
 
 var (
 	// ErrClusterIdNotFound is an error describing the cluster ID can not be found
@@ -54,7 +57,7 @@ type ocmClient struct {
 
 type ocmRoundTripper struct {
 	authorization util.AccessToken
-	proxy *url.URL
+	proxy         *url.URL
 }
 
 func (ort *ocmRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -105,6 +108,8 @@ func (s *ocmClient) GetCluster() (*ClusterInfo, error) {
 		return nil, fmt.Errorf("request to '%v' received error code %v, operation id '%v'", csUrl.String(), response.StatusCode(), operationId)
 	}
 
+	log.Info(fmt.Sprintf("request to '%v' received response code %v, operation id: '%v'", csUrl.String(), response.StatusCode(), operationId))
+
 	listResponse := response.Result().(*ClusterList)
 	if listResponse.Size != 1 || len(listResponse.Items) != 1 {
 		return nil, ErrClusterIdNotFound
@@ -140,6 +145,8 @@ func (s *ocmClient) GetClusterUpgradePolicies(clusterId string) (*UpgradePolicyL
 	if response.IsError() {
 		return nil, fmt.Errorf("request to '%v' received error code '%v' from OCM upgrade policy service, operation id '%v'", upUrl.String(), response.StatusCode(), operationId)
 	}
+
+	log.Info(fmt.Sprintf("request to '%v' received response code '%v' from OCM upgrade policy service, operation id: '%v'", upUrl.String(), response.StatusCode(), operationId))
 
 	upgradeResponse := response.Result().(*UpgradePolicyList)
 


### PR DESCRIPTION
### What type of PR is this?

Add additional info to the MUO logger with OCM operation ID when connecting to ocm for cluster details and upgrade policies

example:
```
ts=2022-02-16T11:53:41Z level=info logger=ocm-client msg="request to 'https://<ocm-url>/api/clusters_mgmt/v1/clusters' received response code 200, operation id: 'c21c10ff-29c0-4248-aede-a6bfae6a25f1'"
ts=2022-02-16T11:53:43Z level=info logger=ocm-client msg="request to 'https://<ocm-url>/api/clusters_mgmt/v1/clusters/<cluster-id>/upgrade_policies' received response code '200' from OCM upgrade policy service, operation id: '6ec38d03-b52d-4642-adfb-1a9179ba846f'"
```


### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

