### PR TITLE
OSD-10202 fix trailing periods in MUO SLs

### DIFF
--- a/pkg/eventmanager/eventmanager.go
+++ b/pkg/eventmanager/eventmanager.go
@@ -13,24 +13,24 @@ import (
 
 const (
 	// UPGRADE_PRECHECK_FAILED_DESC describes the upgrade pre check failure
-	UPGRADE_PRECHECK_FAILED_DESC = "Cluster upgrade to version %s was cancelled as the cluster did not pass its pre-upgrade verification checks. Automated upgrades will be retried on their next scheduling cycle. If you have manually scheduled an upgrade instead, it must now be rescheduled."
+	UPGRADE_PRECHECK_FAILED_DESC = "Cluster upgrade to version %s was cancelled as the cluster did not pass its pre-upgrade verification checks. Automated upgrades will be retried on their next scheduling cycle. If you have manually scheduled an upgrade instead, it must now be rescheduled"
 	// UPGRADE_PREHEALTHCHECK_FAILED_DESC describes the upgrade pre health check failure
-	UPGRADE_PREHEALTHCHECK_FAILED_DESC = "Cluster upgrade to version %s was cancelled during the Pre-Health Check step. Health alerts are firing in the cluster which could impact the upgrade's operation, so the upgrade did not proceed. Automated upgrades will be retried on their next scheduling cycle. If you have manually scheduled an upgrade instead, it must now be rescheduled."
+	UPGRADE_PREHEALTHCHECK_FAILED_DESC = "Cluster upgrade to version %s was cancelled during the Pre-Health Check step. Health alerts are firing in the cluster which could impact the upgrade's operation, so the upgrade did not proceed. Automated upgrades will be retried on their next scheduling cycle. If you have manually scheduled an upgrade instead, it must now be rescheduled"
 	// UPGRADE_EXTDEPCHECK_FAILED_DESC describes the upgrade external dependency check failure
-	UPGRADE_EXTDEPCHECK_FAILED_DESC = "Cluster upgrade to version %s was cancelled during the External Dependency Availability Check step. A required external dependency of the upgrade was unavailable, so the upgrade did not proceed. Automated upgrades will be retried on their next scheduling cycle. If you have manually scheduled an upgrade instead, it must now be rescheduled."
+	UPGRADE_EXTDEPCHECK_FAILED_DESC = "Cluster upgrade to version %s was cancelled during the External Dependency Availability Check step. A required external dependency of the upgrade was unavailable, so the upgrade did not proceed. Automated upgrades will be retried on their next scheduling cycle. If you have manually scheduled an upgrade instead, it must now be rescheduled"
 	// UPGRADE_SCALE_FAILED_DESC describes the upgrade scaling failed
-	UPGRADE_SCALE_FAILED_DESC = "Cluster upgrade to version %s was cancelled during the Scale-Up Worker Node step. A temporary additional worker node was unable to be created to temporarily house workloads, so the upgrade did not proceed. Automated upgrades will be retried on their next scheduling cycle. If you have manually scheduled an upgrade instead, it must now be rescheduled."
+	UPGRADE_SCALE_FAILED_DESC = "Cluster upgrade to version %s was cancelled during the Scale-Up Worker Node step. A temporary additional worker node was unable to be created to temporarily house workloads, so the upgrade did not proceed. Automated upgrades will be retried on their next scheduling cycle. If you have manually scheduled an upgrade instead, it must now be rescheduled"
 
 	// UPGRADE_DEFAULT_DELAY_DESC describes the upgrade default delay
-	UPGRADE_DEFAULT_DELAY_DESC = "Cluster upgrade to version %s is experiencing a delay whilst it performs necessary pre-upgrade procedures. The upgrade will continue to retry. This is an informational notification and no action is required."
+	UPGRADE_DEFAULT_DELAY_DESC = "Cluster upgrade to version %s is experiencing a delay whilst it performs necessary pre-upgrade procedures. The upgrade will continue to retry. This is an informational notification and no action is required"
 	// UPGRADE_PREHEALTHCHECK_DELAY_DESC describes the upgrade pre health check delay
-	UPGRADE_PREHEALTHCHECK_DELAY_DESC = "Cluster upgrade to version %s is experiencing a delay as health alerts are firing in the cluster which could impact the upgrade's operation. The upgrade will continue to retry. This is an informational notification and no action is required by you."
+	UPGRADE_PREHEALTHCHECK_DELAY_DESC = "Cluster upgrade to version %s is experiencing a delay as health alerts are firing in the cluster which could impact the upgrade's operation. The upgrade will continue to retry. This is an informational notification and no action is required by you"
 	// UPGRADE_EXTDEPCHECK_DELAY_DESC describes the upgrade external dependency check delay
-	UPGRADE_EXTDEPCHECK_DELAY_DESC = "Cluster upgrade to version %s is experiencing a delay as an external dependency of the upgrade is currently unavailable. The upgrade will continue to retry. This is an informational notification and no action is required by you."
+	UPGRADE_EXTDEPCHECK_DELAY_DESC = "Cluster upgrade to version %s is experiencing a delay as an external dependency of the upgrade is currently unavailable. The upgrade will continue to retry. This is an informational notification and no action is required by you"
 	// UPGRADE_SCALE_DELAY_DESC describes the upgrade scaling delayed
-	UPGRADE_SCALE_DELAY_DESC = "Cluster upgrade to version %s is experiencing a delay attempting to scale up an additional worker node. The upgrade will continue to retry. This is an informational notification and no action is required by you."
+	UPGRADE_SCALE_DELAY_DESC = "Cluster upgrade to version %s is experiencing a delay attempting to scale up an additional worker node. The upgrade will continue to retry. This is an informational notification and no action is required by you"
 	// UPGRADE_SCALE_DELAY_SKIP_DESC describes the upgrade scaling skipped after delay
-	UPGRADE_SCALE_DELAY_SKIP_DESC = "Cluster upgrade to version %s has experienced an issue during capacity reservation efforts. This could be caused by cloud service provider quota limitations or temporary connectivity issues to/from the new worker node. The upgrade will continue without extra compute. This is an informational notification and no action is required by you."
+	UPGRADE_SCALE_DELAY_SKIP_DESC = "Cluster upgrade to version %s has experienced an issue during capacity reservation efforts. This could be caused by cloud service provider quota limitations or temporary connectivity issues to/from the new worker node. The upgrade will continue without extra compute. This is an informational notification and no action is required by you"
 )
 
 // EventManager enables implementation of an EventManager


### PR DESCRIPTION
Signed-off-by: Aniket Joshi <anjoshi@redhat.com>

### What type of PR is this?
Refactor.


### What this PR does / why we need it?
This change will remove the trialing period at the end of the MUO service logs template defined since those periods are already being added by MUO/OCM process.

### Which Jira/Github issue(s) this PR fixes?
[OSD-10202](https://issues.redhat.com/browse/OSD-10202)

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

