### PR TITLE
Add a mandate-fips Go build tag to ensure that the built MUO is using FIPS compliant crypto

### DIFF
--- a/cmd/manager/fips.go
+++ b/cmd/manager/fips.go
@@ -1,0 +1,11 @@
+// +build mandate_fips
+
+package main
+
+import (
+	_ "crypto/tls/fipsonly"
+)
+
+func init() {
+	fipsMode = true
+}

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -52,6 +52,7 @@ var (
 	metricsHost             = "0.0.0.0"
 	metricsPort       int32 = 8383
 	customMetricsPath       = "/metrics"
+	fipsMode                = false
 )
 var log = logf.Log.WithName("cmd")
 
@@ -60,6 +61,7 @@ func printVersion() {
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
+	log.Info(fmt.Sprintf("FIPS crypto mandated: %t", fipsMode))
 }
 
 func main() {


### PR DESCRIPTION

### What type of PR is this?
feature

### What this PR does / why we need it?

If the mandate-fips build tag is given then MUO will mandate its use when building/running. It will also log if FIPS mandated crypto is being used.

### Which Jira/Github issue(s) this PR fixes?

part of https://issues.redhat.com/browse/OSD-9944

### Special notes for your reviewer:

already deployed to production in ARO

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

