### PR TITLE
OSD-10466 Do not attempt to use HTTP_PROXY for OCM comms

### DIFF
--- a/pkg/ocm/builder.go
+++ b/pkg/ocm/builder.go
@@ -53,15 +53,10 @@ func (ocb *ocmClientBuilder) New(c client.Client, ocmBaseUrl *url.URL) (OcmClien
 }
 
 func getProxy() string {
-	httpProxy := os.Getenv("HTTP_PROXY")
-	httpsProxy := os.Getenv("HTTPS_PROXY")
-
 	// Default to HTTPS_PROXY if available
+	httpsProxy := os.Getenv("HTTPS_PROXY")
 	if len(httpsProxy) > 0  {
 		return httpsProxy
-	}
-	if len(httpProxy) > 0 {
-		return httpProxy
 	}
 	return ""
 }


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
Given OCM communications are HTTPS-based, MUO shouldn't attempt to use the `HTTP_PROXY` environment variable as a proxy for communicating to OCM, only `HTTPS_PROXY`.

### Which Jira/Github issue(s) this PR fixes?
[OSD-10466](https://issues.redhat.com/browse/OSD-10466)
