### PR TITLE
OSD-10568 select correct node taint for drain strategy

### DIFF
--- a/pkg/controller/nodekeeper/nodekeeper_controller.go
+++ b/pkg/controller/nodekeeper/nodekeeper_controller.go
@@ -156,7 +156,7 @@ func (r *ReconcileNodeKeeper) Reconcile(ctx context.Context, request reconcile.R
 		reqLogger.Error(err, "Error while executing drain.")
 		return reconcile.Result{}, err
 	}
-	res, err := drainStrategy.Execute(node)
+	res, err := drainStrategy.Execute(node, reqLogger)
 	for _, r := range res {
 		reqLogger.Info(r.Message)
 	}
@@ -164,7 +164,7 @@ func (r *ReconcileNodeKeeper) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, err
 	}
 
-	hasFailed, err := drainStrategy.HasFailed(node)
+	hasFailed, err := drainStrategy.HasFailed(node, reqLogger)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/nodekeeper/nodekeeper_controller_test.go
+++ b/pkg/controller/nodekeeper/nodekeeper_controller_test.go
@@ -134,8 +134,8 @@ var _ = Describe("NodeKeeperController", func() {
 					mockConfigManagerBuilder.EXPECT().New(gomock.Any(), gomock.Any()).Return(mockConfigManager),
 					mockConfigManager.EXPECT().Into(gomock.Any()).SetArg(0, config),
 					mockDrainStrategyBuilder.EXPECT().NewNodeDrainStrategy(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockDrainStrategy, nil),
-					mockDrainStrategy.EXPECT().Execute(gomock.Any()).Return([]*drain.DrainStrategyResult{}, nil),
-					mockDrainStrategy.EXPECT().HasFailed(gomock.Any()).Return(true, nil),
+					mockDrainStrategy.EXPECT().Execute(gomock.Any(), gomock.Any()).Return([]*drain.DrainStrategyResult{}, nil),
+					mockDrainStrategy.EXPECT().HasFailed(gomock.Any(), gomock.Any()).Return(true, nil),
 					mockMetricsClient.EXPECT().UpdateMetricNodeDrainFailed(gomock.Any()).Times(1),
 					mockMetricsClient.EXPECT().ResetMetricNodeDrainFailed(gomock.Any()).Times(0),
 				)

--- a/pkg/drain/drainStrategyMock.go
+++ b/pkg/drain/drainStrategyMock.go
@@ -5,6 +5,7 @@
 package drain
 
 import (
+	logr "github.com/go-logr/logr"
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 	reflect "reflect"
@@ -34,31 +35,31 @@ func (m *MockDrainStrategy) EXPECT() *MockDrainStrategyMockRecorder {
 }
 
 // Execute mocks base method
-func (m *MockDrainStrategy) Execute(arg0 *v1.Node) (*DrainStrategyResult, error) {
+func (m *MockDrainStrategy) Execute(arg0 *v1.Node, arg1 logr.Logger) (*DrainStrategyResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Execute", arg0)
+	ret := m.ctrl.Call(m, "Execute", arg0, arg1)
 	ret0, _ := ret[0].(*DrainStrategyResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Execute indicates an expected call of Execute
-func (mr *MockDrainStrategyMockRecorder) Execute(arg0 interface{}) *gomock.Call {
+func (mr *MockDrainStrategyMockRecorder) Execute(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockDrainStrategy)(nil).Execute), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockDrainStrategy)(nil).Execute), arg0, arg1)
 }
 
 // IsValid mocks base method
-func (m *MockDrainStrategy) IsValid(arg0 *v1.Node) (bool, error) {
+func (m *MockDrainStrategy) IsValid(arg0 *v1.Node, arg1 logr.Logger) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsValid", arg0)
+	ret := m.ctrl.Call(m, "IsValid", arg0, arg1)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // IsValid indicates an expected call of IsValid
-func (mr *MockDrainStrategyMockRecorder) IsValid(arg0 interface{}) *gomock.Call {
+func (mr *MockDrainStrategyMockRecorder) IsValid(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsValid", reflect.TypeOf((*MockDrainStrategy)(nil).IsValid), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsValid", reflect.TypeOf((*MockDrainStrategy)(nil).IsValid), arg0, arg1)
 }

--- a/pkg/drain/mocks/nodeDrainStrategy.go
+++ b/pkg/drain/mocks/nodeDrainStrategy.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	logr "github.com/go-logr/logr"
 	gomock "github.com/golang/mock/gomock"
 	drain "github.com/openshift/managed-upgrade-operator/pkg/drain"
 	v1 "k8s.io/api/core/v1"
@@ -35,31 +36,31 @@ func (m *MockNodeDrainStrategy) EXPECT() *MockNodeDrainStrategyMockRecorder {
 }
 
 // Execute mocks base method
-func (m *MockNodeDrainStrategy) Execute(arg0 *v1.Node) ([]*drain.DrainStrategyResult, error) {
+func (m *MockNodeDrainStrategy) Execute(arg0 *v1.Node, arg1 logr.Logger) ([]*drain.DrainStrategyResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Execute", arg0)
+	ret := m.ctrl.Call(m, "Execute", arg0, arg1)
 	ret0, _ := ret[0].([]*drain.DrainStrategyResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Execute indicates an expected call of Execute
-func (mr *MockNodeDrainStrategyMockRecorder) Execute(arg0 interface{}) *gomock.Call {
+func (mr *MockNodeDrainStrategyMockRecorder) Execute(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockNodeDrainStrategy)(nil).Execute), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockNodeDrainStrategy)(nil).Execute), arg0, arg1)
 }
 
 // HasFailed mocks base method
-func (m *MockNodeDrainStrategy) HasFailed(arg0 *v1.Node) (bool, error) {
+func (m *MockNodeDrainStrategy) HasFailed(arg0 *v1.Node, arg1 logr.Logger) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasFailed", arg0)
+	ret := m.ctrl.Call(m, "HasFailed", arg0, arg1)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // HasFailed indicates an expected call of HasFailed
-func (mr *MockNodeDrainStrategyMockRecorder) HasFailed(arg0 interface{}) *gomock.Call {
+func (mr *MockNodeDrainStrategyMockRecorder) HasFailed(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasFailed", reflect.TypeOf((*MockNodeDrainStrategy)(nil).HasFailed), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasFailed", reflect.TypeOf((*MockNodeDrainStrategy)(nil).HasFailed), arg0, arg1)
 }

--- a/pkg/drain/strategy.go
+++ b/pkg/drain/strategy.go
@@ -8,6 +8,8 @@ import (
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/go-logr/logr"
+
 	upgradev1alpha1 "github.com/openshift/managed-upgrade-operator/pkg/apis/upgrade/v1alpha1"
 	"github.com/openshift/managed-upgrade-operator/pkg/pod"
 )
@@ -21,15 +23,15 @@ type NodeDrainStrategyBuilder interface {
 // NodeDrainStrategy enables implementation for a NodeDrainStrategy
 //go:generate mockgen -destination=mocks/nodeDrainStrategy.go -package=mocks github.com/openshift/managed-upgrade-operator/pkg/drain NodeDrainStrategy
 type NodeDrainStrategy interface {
-	Execute(*corev1.Node) ([]*DrainStrategyResult, error)
-	HasFailed(*corev1.Node) (bool, error)
+	Execute(*corev1.Node, logr.Logger) ([]*DrainStrategyResult, error)
+	HasFailed(*corev1.Node, logr.Logger) (bool, error)
 }
 
 // DrainStrategy enables implementation for a DrainStrategy
 //go:generate mockgen -destination=./drainStrategyMock.go -package=drain -self_package=github.com/openshift/managed-upgrade-operator/pkg/drain github.com/openshift/managed-upgrade-operator/pkg/drain DrainStrategy
 type DrainStrategy interface {
-	Execute(*corev1.Node) (*DrainStrategyResult, error)
-	IsValid(*corev1.Node) (bool, error)
+	Execute(*corev1.Node, logr.Logger) (*DrainStrategyResult, error)
+	IsValid(*corev1.Node, logr.Logger) (bool, error)
 }
 
 // TimedDrainStrategy enables implementation for a TimedDrainStrategy

--- a/pkg/machinery/node.go
+++ b/pkg/machinery/node.go
@@ -17,7 +17,7 @@ func (m *machinery) IsNodeCordoned(node *corev1.Node) *IsCordonedResult {
 	isCordoned := false
 	if node.Spec.Unschedulable && len(node.Spec.Taints) > 0 {
 		for _, n := range node.Spec.Taints {
-			if n.Effect == corev1.TaintEffectNoSchedule {
+			if n.Effect == corev1.TaintEffectNoSchedule && n.Key == corev1.TaintNodeUnschedulable {
 				isCordoned = true
 				cordonAddedTime = n.TimeAdded
 			}

--- a/pkg/scaler/machineSetScaler.go
+++ b/pkg/scaler/machineSetScaler.go
@@ -280,7 +280,7 @@ func nodesAreReady(c client.Client, timeOut time.Duration, upgradeMachinesets ma
 
 func handleDrainStrategy(c client.Client, nds drain.NodeDrainStrategy, nodes corev1.NodeList, logger logr.Logger) (bool, error) {
 	for _, n := range nodes.Items {
-		res, err := nds.Execute(&n)
+		res, err := nds.Execute(&n, logger)
 		for _, r := range res {
 			logger.Info(r.Message)
 		}
@@ -289,7 +289,7 @@ func handleDrainStrategy(c client.Client, nds drain.NodeDrainStrategy, nodes cor
 		}
 	}
 	for _, n := range nodes.Items {
-		hasFailed, err := nds.HasFailed(&n)
+		hasFailed, err := nds.HasFailed(&n, logger)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/scaler/scaling_test.go
+++ b/pkg/scaler/scaling_test.go
@@ -524,8 +524,8 @@ var _ = Describe("Node scaling tests", func() {
 					}).Times(2),
 				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, *nodes),
 				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, *upgradeMachines),
-				mockDrainStrategy.EXPECT().Execute(gomock.Any()).Return([]*drain.DrainStrategyResult{}, nil),
-				mockDrainStrategy.EXPECT().HasFailed(gomock.Any()).Return(false, nil),
+				mockDrainStrategy.EXPECT().Execute(gomock.Any(), gomock.Any()).Return([]*drain.DrainStrategyResult{}, nil),
+				mockDrainStrategy.EXPECT().HasFailed(gomock.Any(), gomock.Any()).Return(false, nil),
 				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
 					client.InNamespace(MACHINE_API_NAMESPACE),
 					client.MatchingLabels{LABEL_UPGRADE: "true"},
@@ -585,8 +585,8 @@ var _ = Describe("Node scaling tests", func() {
 					}).Times(2),
 				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, *nodes),
 				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).SetArg(1, *upgradeMachines),
-				mockDrainStrategy.EXPECT().Execute(gomock.Any()).Return([]*drain.DrainStrategyResult{}, nil),
-				mockDrainStrategy.EXPECT().HasFailed(gomock.Any()).Return(false, nil),
+				mockDrainStrategy.EXPECT().Execute(gomock.Any(), gomock.Any()).Return([]*drain.DrainStrategyResult{}, nil),
+				mockDrainStrategy.EXPECT().HasFailed(gomock.Any(), gomock.Any()).Return(false, nil),
 				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
 					client.InNamespace(MACHINE_API_NAMESPACE),
 					client.MatchingLabels{LABEL_UPGRADE: "true"},


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
This PR primarily fixes one issue wherein the node controller was incorrectly selecting the wrong `Unschedulable` taint on the Node to determine the time it commenced draining. The cluster autoscaler adds its own `Unschedulable` taint with no `timeAdded` field, which became the taint that MUO would select. This in turn broke the logic when determining if a drain strategy could be executed, because it was using a `nil` time in that comparison.

MUO will now select the right taint and will additionally throw an error if a node is unschedulable and has no `timeAdded` field.

Test cases have been added to test to the drain and machine suites to cater for this situation.

Additionally, I took this as an opportunity to address a sore point with MUO which is that none of the drain strategy code produces any logs. MUO will now log:
- Every time it attempts a drain strategy.
- Every time it evaluates a drain strategy on a cordoned node but rejects it
- Every pod it attempts to perform a 'force delete' strategy on
- Every pod it attempts to perform a 'remove finalizer' strategy on

### Which Jira/Github issue(s) this PR fixes?

[OSD-10568](https://issues.redhat.com/browse/OSD-10568)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster


