### PR TITLE
[OSD-10140] latest tag is being removed from the quay repo, use specific version for managed-upgrade-operator image

### DIFF
--- a/config/templates/csv-template.yaml
+++ b/config/templates/csv-template.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: A list of comma separated categories that your operator falls under.
     certified: "false"
     description: Operator providing managed upgrades for OpenShift 4
-    containerImage: quay.io/app-sre/managed-upgrade-operator:latest
+    containerImage: quay.io/app-sre/managed-upgrade-operator:v0.1.809-46d986a
     support: Red Hat OpenShift SRE
 spec:
   displayName: managed-upgrade-operator

--- a/config/templates/csv-template.yaml
+++ b/config/templates/csv-template.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: A list of comma separated categories that your operator falls under.
     certified: "false"
     description: Operator providing managed upgrades for OpenShift 4
-    containerImage: quay.io/app-sre/managed-upgrade-operator:v0.1.809-46d986a
+    containerImage: quay.io/app-sre/managed-upgrade-operator:GENERATED
     support: Red Hat OpenShift SRE
 spec:
   displayName: managed-upgrade-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -40,7 +40,7 @@ spec:
         - name: managed-upgrade-operator
           # Replace this with the built image name
           # This will get replaced on deploy by /hack/generate-operator-bundle.py
-          image: quay.io/app-sre/managed-upgrade-operator:v0.1.809-46d986a
+          image: quay.io/app-sre/managed-upgrade-operator:GENERATED
           command:
           - managed-upgrade-operator
           imagePullPolicy: Always

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -40,7 +40,7 @@ spec:
         - name: managed-upgrade-operator
           # Replace this with the built image name
           # This will get replaced on deploy by /hack/generate-operator-bundle.py
-          image: quay.io/app-sre/managed-upgrade-operator:latest
+          image: quay.io/app-sre/managed-upgrade-operator:v0.1.809-46d986a
           command:
           - managed-upgrade-operator
           imagePullPolicy: Always

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,6 +4,7 @@
   - [Development Environment Setup](#development-environment-setup)
     - [golang](#golang)
     - [operator-sdk](#operator-sdk)
+  - [Makefile](#makefile)
   - [Dependencies](#dependencies)
   - [Linting](#linting)
   - [Testing](#testing)
@@ -253,7 +254,16 @@ oc create -f test/deploy/service_account.yaml
 oc create -f test/deploy/managed-upgrade-operator-config.yaml
 ```
 
-- Set `test/deploy/operator.yaml` to use `quay.io/<QUAY_USERNAME>/managed-upgrade-operator:latest` container image and create deployment configuration
+- Set `test/deploy/operator.yaml` to use `quay.io/<QUAY_USERNAME>/managed-upgrade-operator:latest` container image and create deployment configuration by updating the `image` field:
+
+```bash
+      containers:
+        - name: managed-upgrade-operator
+          # Update the line below
+          image: quay.io/<QUAY_USERNAME>/managed-upgrade-operator:latest
+```
+
+- Then create the `Deployment` resource:
 
 ```shell
 oc create -f test/deploy/operator.yaml

--- a/test/deploy/operator.yaml
+++ b/test/deploy/operator.yaml
@@ -18,7 +18,7 @@ spec:
         - name: managed-upgrade-operator
           # Replace this with the built image name
           # This will get replaced on deploy by /hack/generate-operator-bundle.py
-          image: quay.io/app-sre/managed-upgrade-operator:v0.1.809-46d986a
+          image: quay.io/app-sre/managed-upgrade-operator:REPLACE_TAG
           command:
           - managed-upgrade-operator
           imagePullPolicy: Always

--- a/test/deploy/operator.yaml
+++ b/test/deploy/operator.yaml
@@ -18,7 +18,7 @@ spec:
         - name: managed-upgrade-operator
           # Replace this with the built image name
           # This will get replaced on deploy by /hack/generate-operator-bundle.py
-          image: quay.io/app-sre/managed-upgrade-operator:latest
+          image: quay.io/app-sre/managed-upgrade-operator:v0.1.809-46d986a
           command:
           - managed-upgrade-operator
           imagePullPolicy: Always


### PR DESCRIPTION
latest tag is being removed from the quay repo, use specific version for managed-upgrade-operator image

### What type of PR is this?
_(refactor)_

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [OSD-10140](https://issues.redhat.com//browse/OSD-10140)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Ran make test
