### PR TITLE
Restrict all TLS configuration to FIPS-approved settings

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /workdir
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN make go-build
+RUN GOFLAGS_MOD="-tags=mandate_fips" make go-build
 
 ####
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest


### PR DESCRIPTION
### What this PR does / why we need it?

Boilerplate now uses the FIPS enabled go-toolset.
This sets the build flag that MUO uses to enable fips

https://github.com/openshift/managed-upgrade-operator/blob/master/cmd/manager/fips.go#L1



