### PR TITLE
OSD-11105 updated error message in case the cluster cannot be upgraded

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -52,6 +52,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  verbs:
+  - get
+  - list
+- apiGroups:
   - machine.openshift.io
   resources:
   - machines

--- a/pkg/upgraders/upgradeable.go
+++ b/pkg/upgraders/upgradeable.go
@@ -3,13 +3,40 @@ package upgraders
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/blang/semver"
 	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
 	upgradev1alpha1 "github.com/openshift/managed-upgrade-operator/pkg/apis/upgrade/v1alpha1"
 	cv "github.com/openshift/managed-upgrade-operator/pkg/clusterversion"
+
+	"k8s.io/apimachinery/pkg/types"
 )
+
+const (
+	upgradeCancelledArticleNumberForOSD = 6657541
+	upgradeCancelledArticleNumberForROSA = 6541901
+)
+
+func (c *clusterUpgrader) isRosaCluster(ctx context.Context) (bool, error) {
+	infraConfig := &configv1.Infrastructure{}
+	if err := c.client.Get(ctx, types.NamespacedName{Name: "cluster"}, infraConfig); err != nil {
+		return false, fmt.Errorf("failed fetching infrastructure config: %w", err)
+	}
+
+	platformStatus := infraConfig.Status.PlatformStatus
+
+	if platformStatus != nil && platformStatus.AWS != nil {
+		for _, resourceTag := range platformStatus.AWS.ResourceTags {
+			if resourceTag.Key == "red-hat-clustertype" {
+				return resourceTag.Value == "rosa", nil
+			}
+		}
+	}
+
+	return false, nil
+}
 
 func (c *clusterUpgrader) IsUpgradeable(ctx context.Context, logger logr.Logger) (bool, error) {
 	upgradeCommenced, err := c.cvClient.HasUpgradeCommenced(c.upgradeConfig)
@@ -41,9 +68,33 @@ func (c *clusterUpgrader) IsUpgradeable(ctx context.Context, logger logr.Logger)
 	}
 
 	// if the upgradeable is false then we need to check the current version with upgrade version for y-stream update
+	isRosaCluster, err := c.isRosaCluster(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	var articleNumber int
+
+	if isRosaCluster {
+		articleNumber = upgradeCancelledArticleNumberForROSA
+	} else {
+		articleNumber = upgradeCancelledArticleNumberForOSD
+	}
+
+	upgradeTime, err := time.Parse(time.RFC3339, c.upgradeConfig.Spec.UpgradeAt)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse spec.upgradeAt: %w", err)
+	}
+	upgradeTimeText := upgradeTime.UTC().Format(time.UnixDate)
+
 	for _, condition := range clusterVersion.Status.Conditions {
 		if condition.Type == configv1.OperatorUpgradeable && condition.Status == configv1.ConditionFalse && parsedDesiredVersion.Major >= parsedCurrentVersion.Major && parsedDesiredVersion.Minor > parsedCurrentVersion.Minor {
-			return false, fmt.Errorf("Cluster upgrade to version %s is canceled with the reason of %s containing message that %s Automated upgrades will be retried on their next scheduling cycle. If you have manually scheduled an upgrade instead, it must be rescheduled.", desiredVersion, condition.Reason, condition.Message)
+			return false, fmt.Errorf(
+				"Cluster upgrade maintenance to version %s on %s has been cancelled due to unacknowledged user actions. See https://access.redhat.com/solutions/%d for more details.",
+				desiredVersion,
+				upgradeTimeText,
+				articleNumber,
+			)
 		}
 	}
 


### PR DESCRIPTION
Distinguishing ROSA cluster from OSD cluster using infrastructure resource

### What type of PR is this?
_bug fix_


### What this PR does / why we need it?
This PR align the code with the following spec:
https://docs.google.com/spreadsheets/d/1Ghx1J_hjqPIzEPmVuIkmTDW_HMFF2-tw0BO6bQ-6ecI/edit#gid=0&range=14:15
Remark that the error message is no longer the same regarding the cluster is a ROSA cluster or a normal OSD cluster.

### Which Jira/Github issue(s) this PR fixes?
[OSD-11105](https://issues.redhat.com//browse/OSD-11105)

### Special notes for your reviewer:
`ROSA` vs `OSD` cluster type is retrieved through the `infrastructure` object. On an openshift cluster you can view it running `oc get infrastructure -oyaml`.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR