### PR TITLE
OSD-11342 Remove OCM upgrade_type dependency

### DIFF
--- a/docs/configmap.md
+++ b/docs/configmap.md
@@ -28,6 +28,17 @@ TBD
 
 
 ## Configurable knobs
+
+#### upgradeType
+
+This defines which upgrader MUO should use to upgrade the cluster.
+
+Valid options are:
+- [ARO](https://github.com/openshift/managed-upgrade-operator/blob/master/pkg/upgraders/aroupgrader.go)
+- [OSD](https://github.com/openshift/managed-upgrade-operator/blob/master/pkg/upgraders/osdupgrader.go)
+
+If this field is not present or is an empty value, the ARO upgrader is used by default.
+
 #### configManager
 
 Please refer to the doc [`configmanager`](./configmanager.md)

--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -26,8 +26,6 @@ const (
 	UPGRADEPOLICIES_V1_PATH = "upgrade_policies"
 	// STATE_V1_PATH sub-path to the policy state service
 	STATE_V1_PATH = "state"
-	// UPGRADE_TYPE_OSD is the only supported type.
-	UPGRADE_TYPE_OSD = "OSD"
 )
 
 var log = logf.Log.WithName("ocm-client")
@@ -131,8 +129,6 @@ func (s *ocmClient) GetClusterUpgradePolicies(clusterId string) (*UpgradePolicyL
 		SetQueryParams(map[string]string{
 			"page": "1",
 			"size": "1",
-			// OCM also provides types [ADDON, CVE] which are currently unsupported.
-			"search": fmt.Sprintf("upgrade_type = '%s'", UPGRADE_TYPE_OSD),
 		}).
 		SetResult(&UpgradePolicyList{}).
 		ExpectContentType("application/json").

--- a/pkg/ocmprovider/ocmprovider_test.go
+++ b/pkg/ocmprovider/ocmprovider_test.go
@@ -22,7 +22,7 @@ const (
 
 	// Upgrade policy constants
 	TEST_OPERATOR_NAMESPACE                 = "test-managed-upgrade-operator"
-	TEST_UPGRADEPOLICY_UPGRADETYPE          = "OSD"
+	TEST_UPGRADEPOLICY_UPGRADETYPE          = "TEST_UPGRADE_TYPE"
 	TEST_UPGRADEPOLICY_TIME                 = "2020-06-20T00:00:00Z"
 	TEST_UPGRADEPOLICY_TIME_NEXT_OCCURRING  = "2020-05-20T00:00:00Z"
 	TEST_UPGRADEPOLICY_VERSION              = "4.4.5"
@@ -46,8 +46,9 @@ var _ = Describe("OCM Provider", func() {
 		mockKubeClient = mocks.NewMockClient(mockCtrl)
 		mockOcmClient = mockOcm.NewMockOcmClient(mockCtrl)
 		provider = &ocmProvider{
-			client:    mockKubeClient,
-			ocmClient: mockOcmClient,
+			client:      mockKubeClient,
+			ocmClient:   mockOcmClient,
+			upgradeType: TEST_UPGRADEPOLICY_UPGRADETYPE,
 		}
 		upgradePolicyListResponse = ocm.UpgradePolicyList{
 			Kind:  "UpgradePolicyList",
@@ -61,7 +62,6 @@ var _ = Describe("OCM Provider", func() {
 					Href:         "test",
 					Schedule:     "test",
 					ScheduleType: "manual",
-					UpgradeType:  TEST_UPGRADEPOLICY_UPGRADETYPE,
 					Version:      TEST_UPGRADEPOLICY_VERSION,
 					NextRun:      TEST_UPGRADEPOLICY_TIME,
 					ClusterId:    TEST_CLUSTER_ID,
@@ -129,7 +129,6 @@ var _ = Describe("OCM Provider", func() {
 						Href:         "test",
 						Schedule:     "test",
 						ScheduleType: "manual",
-						UpgradeType:  TEST_UPGRADEPOLICY_UPGRADETYPE,
 						Version:      TEST_UPGRADEPOLICY_VERSION,
 						NextRun:      TEST_UPGRADEPOLICY_TIME,
 						ClusterId:    TEST_CLUSTER_ID,
@@ -185,7 +184,6 @@ var _ = Describe("OCM Provider", func() {
 						Href:         "test",
 						Schedule:     "test",
 						ScheduleType: "manual",
-						UpgradeType:  TEST_UPGRADEPOLICY_UPGRADETYPE,
 						Version:      TEST_UPGRADEPOLICY_VERSION,
 						NextRun:      TEST_UPGRADEPOLICY_TIME,
 						ClusterId:    TEST_CLUSTER_ID_MULTI_POLICIES,
@@ -196,7 +194,6 @@ var _ = Describe("OCM Provider", func() {
 						Href:         "test",
 						Schedule:     "3 5 5 * *",
 						ScheduleType: "automatic",
-						UpgradeType:  TEST_UPGRADEPOLICY_UPGRADETYPE,
 						Version:      TEST_UPGRADEPOLICY_VERSION,
 						NextRun:      TEST_UPGRADEPOLICY_TIME_NEXT_OCCURRING,
 						ClusterId:    TEST_CLUSTER_ID_MULTI_POLICIES,

--- a/pkg/specprovider/config.go
+++ b/pkg/specprovider/config.go
@@ -3,6 +3,8 @@ package specprovider
 import (
 	"fmt"
 	"strings"
+
+	upgradev1alpha1 "github.com/openshift/managed-upgrade-operator/pkg/apis/upgrade/v1alpha1"
 )
 
 const (
@@ -17,6 +19,9 @@ type ConfigManagerSource string
 
 // SpecProviderConfig holds fields that describe a spec providers config
 type SpecProviderConfig struct {
+	// UpgradeType is used to select which upgrader to use when upgrading
+	UpgradeType   string        `yaml:"upgradeType"`
+	// ConfigManager configures the source that the operator uses to read UpgradeConfig specs
 	ConfigManager ConfigManager `yaml:"configManager"`
 }
 
@@ -41,10 +46,28 @@ func (cfg *SpecProviderConfig) IsValid() error {
 
 	switch strings.ToUpper(cfg.ConfigManager.Source) {
 	case string(OCM):
-		return nil
+		break
 	case string(LOCAL):
-		return nil
+		break
 	default:
 		return ErrInvalidSpecProvider
 	}
+
+	switch upgradev1alpha1.UpgradeType(cfg.UpgradeType) {
+	case upgradev1alpha1.ARO, upgradev1alpha1.OSD, "":
+		// An empty upgrade type is fine
+		break
+	default:
+		return ErrInvalidSpecProvider
+	}
+	return nil
+}
+
+// GetUpgradeType returns the upgrader type to populate in the upgrade config spec
+func (cfg *SpecProviderConfig) GetUpgradeType() upgradev1alpha1.UpgradeType {
+	// If an upgrade type is not specified, default to ARO
+	if len(cfg.UpgradeType) == 0 {
+		return upgradev1alpha1.ARO
+	}
+	return upgradev1alpha1.UpgradeType(cfg.UpgradeType)
 }

--- a/pkg/specprovider/specprovider.go
+++ b/pkg/specprovider/specprovider.go
@@ -44,22 +44,22 @@ func (ppb *specProviderBuilder) New(client client.Client, builder configmanager.
 	switch strings.ToUpper(cfg.ConfigManager.Source) {
 	case "OCM":
 		logf.Log.Info("Using OCM as the upgrade config provider")
-		cfg, err := readOcmProviderConfig(client, builder)
+		providerCfg, err := readOcmProviderConfig(client, builder)
 		if err != nil {
 			return nil, err
 		}
-		mgr, err := ocmprovider.New(client, cfg.GetOCMBaseURL())
+		mgr, err := ocmprovider.New(client, cfg.GetUpgradeType(), providerCfg.GetOCMBaseURL())
 		if err != nil {
 			return nil, err
 		}
 		return mgr, nil
 	case "LOCAL":
 		logf.Log.Info("Using local CR as the upgrade config provider")
-		cfg, err := readLocalProviderConfig(client, builder)
+		providerCfg, err := readLocalProviderConfig(client, builder)
 		if err != nil {
 			return nil, err
 		}
-		provider, err := localprovider.New(client, cfg.ConfigManager.LocalConfigName)
+		provider, err := localprovider.New(client, providerCfg.ConfigManager.LocalConfigName)
 		if err != nil {
 			return nil, err
 		}

--- a/test/deploy/managed-upgrade-operator-config.yaml
+++ b/test/deploy/managed-upgrade-operator-config.yaml
@@ -4,6 +4,7 @@ metadata:
   name: managed-upgrade-operator-config
 data:
   config.yaml: |
+    upgradeType: OSD
     configManager:
       source: LOCAL
       localConfigName: managed-upgrade-config


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
This removes filtering on `upgrade_type` when the OCM Upgrade Spec provider pulls upgrade policies from OCM.

In doing so, it also removes a hard-coded `OSD` upgrade type dependency on the OCM Provider, which was essentially preventing ARO clusters from making use of the OCM provider.

As this field was also used by MUO to determine which upgrader it should use, that behaviour is now replaced by the introduction of a `upgradeType` configuration field in MUO's ConfigMap. This value maps directly into the UpgradeConfig's upgradeType.

Valid values for `upgradeType` are:
- ARO
- OSD

If empty, ARO is used by default.

### Which Jira/Github issue(s) this PR fixes?
[OSD-11342](https://issues.redhat.com//browse/OSD-11342)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [X] Included documentation changes with PR

