### PR TITLE
OSD-10033; OSD-10032 - Add metric to track paging alerts

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -7,10 +7,16 @@ The Managed Upgrade Operator reports the following metrics via direct instrument
 - `upgradeoperator_upgradeconfig_validation_failed`: If failed to validate the upgrade config `value > 0`
 - `upgradeoperator_cluster_check_failed`: If failed on the cluster check step `value > 0`
 - `upgradeoperator_scaling_failed`: If failed to scale up extra workers `value > 0`
-- `upgradeoperator_controlplane_timeout`: If ontrol plane upgrade timeout `value > 0`
+- `upgradeoperator_controlplane_timeout`: If control plane upgrade timeout `value > 0`
 - `upgradeoperator_worker_timeout`: If worker nodes upgrade timeout `value > 0`
 - `upgradeoperator_node_drain_timeout`: If node cannot be drained successfully in time `value > 0`
 - `upgradeoperator_upgradeconfig_synced`: If upgradeConfig has not been synced in time `value > 0`
+
+## Metrics for fleet-wide monitoring
+
+The following metrics are forwarded to Observatorium-MST for fleetwide monitoring via grafana
+
+- `upgradeoperator_upgrade_result`: Contains results from the previous upgrade. If upgrade fired a paging alert `value == 0` and the `alerts` field contains the name of alerts fired
 
 ## Metrics for upgrade conditions and state
 

--- a/pkg/metrics/mocks/metrics.go
+++ b/pkg/metrics/mocks/metrics.go
@@ -8,6 +8,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	metrics "github.com/openshift/managed-upgrade-operator/pkg/metrics"
 	reflect "reflect"
+	time "time"
 )
 
 // MockMetrics is a mock of Metrics interface
@@ -31,6 +32,21 @@ func NewMockMetrics(ctrl *gomock.Controller) *MockMetrics {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockMetrics) EXPECT() *MockMetricsMockRecorder {
 	return m.recorder
+}
+
+// AlertsFromUpgrade mocks base method
+func (m *MockMetrics) AlertsFromUpgrade(arg0, arg1 time.Time) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AlertsFromUpgrade", arg0, arg1)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AlertsFromUpgrade indicates an expected call of AlertsFromUpgrade
+func (mr *MockMetricsMockRecorder) AlertsFromUpgrade(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AlertsFromUpgrade", reflect.TypeOf((*MockMetrics)(nil).AlertsFromUpgrade), arg0, arg1)
 }
 
 // IsAlertFiring mocks base method
@@ -105,16 +121,16 @@ func (mr *MockMetricsMockRecorder) ResetAllMetricNodeDrainFailed() *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetAllMetricNodeDrainFailed", reflect.TypeOf((*MockMetrics)(nil).ResetAllMetricNodeDrainFailed))
 }
 
-// ResetAllMetrics mocks base method
-func (m *MockMetrics) ResetAllMetrics() {
+// ResetEphemeralMetrics mocks base method
+func (m *MockMetrics) ResetEphemeralMetrics() {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ResetAllMetrics")
+	m.ctrl.Call(m, "ResetEphemeralMetrics")
 }
 
-// ResetAllMetrics indicates an expected call of ResetAllMetrics
-func (mr *MockMetricsMockRecorder) ResetAllMetrics() *gomock.Call {
+// ResetEphemeralMetrics indicates an expected call of ResetEphemeralMetrics
+func (mr *MockMetricsMockRecorder) ResetEphemeralMetrics() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetAllMetrics", reflect.TypeOf((*MockMetrics)(nil).ResetAllMetrics))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetEphemeralMetrics", reflect.TypeOf((*MockMetrics)(nil).ResetEphemeralMetrics))
 }
 
 // ResetFailureMetrics mocks base method
@@ -271,6 +287,18 @@ func (m *MockMetrics) UpdateMetricUpgradeControlPlaneTimeout(arg0, arg1 string) 
 func (mr *MockMetricsMockRecorder) UpdateMetricUpgradeControlPlaneTimeout(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricUpgradeControlPlaneTimeout", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricUpgradeControlPlaneTimeout), arg0, arg1)
+}
+
+// UpdateMetricUpgradeResult mocks base method
+func (m *MockMetrics) UpdateMetricUpgradeResult(arg0, arg1 string, arg2 []string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateMetricUpgradeResult", arg0, arg1, arg2)
+}
+
+// UpdateMetricUpgradeResult indicates an expected call of UpdateMetricUpgradeResult
+func (mr *MockMetricsMockRecorder) UpdateMetricUpgradeResult(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricUpgradeResult", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricUpgradeResult), arg0, arg1, arg2)
 }
 
 // UpdateMetricUpgradeWindowBreached mocks base method


### PR DESCRIPTION
### What type of PR is this?
**Feature**

### Which Jira/Github issue(s) this PR fixes?
Fixes [OSD-10032](https://issues.redhat.com/browse/OSD-10032) and [OSD-10033](https://issues.redhat.com/browse/OSD-10033)

### What this PR does / why we need it?
This PR adds additional metrics for [OSD-10033](https://issues.redhat.com//browse/OSD-10033) and [OSD-10032](https://issues.redhat.com//browse/OSD-10032) to track alerts that paged SREP Primary during the latest upgrade. It does this by running additional logic during the `upgradeconfig` reconcile loop at the terminal stages of the upgrade (either when the upgrade is complete or has failed). This logic triggers a lookup via Prometheus query to determine which (if any) `pagingAlerts` fired during the upgrade, and adds them to the new `upgradeoperator_upgrade_alerted` metric. This new metric will be exported to Observatorium-MST ([relevant PR](https://github.com/openshift/managed-cluster-config/pull/1164)) for long-term storage and later analysis. 

### Special notes for your reviewer:
- The new metric `upgradeoperator_upgrade_alerted` added in this Pull Request should not be cleared on upgrade completion, whereas existing metrics should. Because of this, this PR divides the metrics into `ephemeral` and `persistent` metrics - those that should and should not be reset on upgrade completion, respectively. Additionally, the function `ResetAllMetrics` has been renamed to `ResetEphemeralMetrics` for clarity. 

- While the new metric shouldn't be cleared, only updated with each upgrade completion, the alert *is* cleared when the `managed-upgrade-operator` pod is restarted. I haven't found an elegant way to recover this metric between pod restarts; options I've considered include writing the results to a configmap, re-querying prometheus on operator start-up, or reconciling against another object (`clusterversion` objects have upgrade timestamps which do not appear to match the ones in `upgradeconfigs`, but maybe there's another object that I haven't considered?). Currently, I think accounting for this would make sense as a follow-up task, but I understand if this is something that we want to resolve from the get-go as well. 

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR

