### PR TITLE
OSD-11753 default to stable channel

### DIFF
--- a/pkg/ocmprovider/ocmprovider_test.go
+++ b/pkg/ocmprovider/ocmprovider_test.go
@@ -94,6 +94,13 @@ var _ = Describe("OCM Provider", func() {
 			_, err := inferUpgradeChannelFromChannelGroup(channelGroup, version)
 			Expect(err).NotTo(BeNil())
 		})
+		It("Sets the channel to stable if the channel group is empty", func() {
+			version := "4.9.1"
+			channelGroup := ""
+			channel, err := inferUpgradeChannelFromChannelGroup(channelGroup, version)
+			Expect(*channel).To(Equal("stable-4.9"))
+			Expect(err).To(BeNil())
+		})
 
 	})
 


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Set our channelGroup to "stable" if it's empty or we can't find one.
This is required for MUO support on ARO as OCM does not inform ARO clusters of a channel group.

### Which Jira/Github issue(s) this PR fixes?

Fixes [OSD-11753](https://issues.redhat.com//browse/OSD-11753)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

