### PR TITLE
OSD-11002 patch clusterversion instead of update

### DIFF
--- a/pkg/clusterversion/clusterversion_test.go
+++ b/pkg/clusterversion/clusterversion_test.go
@@ -108,8 +108,8 @@ var _ = Describe("ClusterVersion client and utils", func() {
 							},
 						},
 					}
-					channelPatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"Channel": "%s" }}`, upgradeConfig.Spec.Desired.Channel)))
-					versionPatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"DesiredUpdate":{"Version": "%s" }}}`, upgradeConfig.Spec.Desired.Version)))
+					channelPatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"channel":"%s"}}`, upgradeConfig.Spec.Desired.Channel)))
+					versionPatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"version":"%s"}}}`, upgradeConfig.Spec.Desired.Version)))
 					gomock.InOrder(
 						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, clusterVersion).Return(nil),
 						mockKubeClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -146,7 +146,7 @@ var _ = Describe("ClusterVersion client and utils", func() {
 							},
 						},
 					}
-					versionPatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"DesiredUpdate":{"Version": "%s" }}}`, upgradeConfig.Spec.Desired.Version)))
+					versionPatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"version":"%s"}}}`, upgradeConfig.Spec.Desired.Version)))
 					gomock.InOrder(
 						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, clusterVersion).Return(nil),
 						mockKubeClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -179,7 +179,7 @@ var _ = Describe("ClusterVersion client and utils", func() {
 							},
 						},
 					}
-					versionPatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"DesiredUpdate":{"Version": "%s" }}}`, upgradeConfig.Spec.Desired.Version)))
+					versionPatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"version":"%s"}}}`, upgradeConfig.Spec.Desired.Version)))
 					gomock.InOrder(
 						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, clusterVersion).Return(nil),
 						mockKubeClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -287,7 +287,7 @@ var _ = Describe("ClusterVersion client and utils", func() {
 						},
 					}
 					upgradeConfig.Spec.Desired.Image = "quay.io/test/test-image"
-					updatePatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"image": "%s", "version": "" }}}`, upgradeConfig.Spec.Desired.Image)))
+					updatePatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"image":"%s","version":""}}}`, upgradeConfig.Spec.Desired.Image)))
 					gomock.InOrder(
 						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, clusterVersion).Return(nil),
 						mockKubeClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -312,7 +312,7 @@ var _ = Describe("ClusterVersion client and utils", func() {
 						},
 					}
 					upgradeConfig.Spec.Desired.Image = "quay.io/test/test-image"
-					updatePatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"image": "%s", "version": "" }}}`, upgradeConfig.Spec.Desired.Image)))
+					updatePatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"image":"%s","version":""}}}`, upgradeConfig.Spec.Desired.Image)))
 					gomock.InOrder(
 						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, clusterVersion).Return(nil),
 						mockKubeClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(

--- a/pkg/clusterversion/clusterversion_test.go
+++ b/pkg/clusterversion/clusterversion_test.go
@@ -109,7 +109,7 @@ var _ = Describe("ClusterVersion client and utils", func() {
 						},
 					}
 					channelPatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"channel":"%s"}}`, upgradeConfig.Spec.Desired.Channel)))
-					versionPatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"version":"%s"}}}`, upgradeConfig.Spec.Desired.Version)))
+					versionPatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"version":"%s","image":""}}}`, upgradeConfig.Spec.Desired.Version)))
 					gomock.InOrder(
 						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, clusterVersion).Return(nil),
 						mockKubeClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -146,7 +146,7 @@ var _ = Describe("ClusterVersion client and utils", func() {
 							},
 						},
 					}
-					versionPatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"version":"%s"}}}`, upgradeConfig.Spec.Desired.Version)))
+					versionPatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"version":"%s","image":""}}}`, upgradeConfig.Spec.Desired.Version)))
 					gomock.InOrder(
 						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, clusterVersion).Return(nil),
 						mockKubeClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -179,7 +179,7 @@ var _ = Describe("ClusterVersion client and utils", func() {
 							},
 						},
 					}
-					versionPatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"version":"%s"}}}`, upgradeConfig.Spec.Desired.Version)))
+					versionPatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"version":"%s","image":""}}}`, upgradeConfig.Spec.Desired.Version)))
 					gomock.InOrder(
 						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, clusterVersion).Return(nil),
 						mockKubeClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(

--- a/pkg/clusterversion/clusterversion_test.go
+++ b/pkg/clusterversion/clusterversion_test.go
@@ -2,6 +2,8 @@ package clusterversion
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -12,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	upgradev1alpha1 "github.com/openshift/managed-upgrade-operator/pkg/apis/upgrade/v1alpha1"
 	testStructs "github.com/openshift/managed-upgrade-operator/util/mocks/structs"
@@ -105,13 +108,19 @@ var _ = Describe("ClusterVersion client and utils", func() {
 							},
 						},
 					}
+					channelPatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"Channel": "%s" }}`, upgradeConfig.Spec.Desired.Channel)))
+					versionPatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"DesiredUpdate":{"Version": "%s" }}}`, upgradeConfig.Spec.Desired.Version)))
 					gomock.InOrder(
 						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, clusterVersion).Return(nil),
-						mockKubeClient.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil),
+						mockKubeClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+							func(ctx context.Context, cv *configv1.ClusterVersion, p client.Patch) error {
+								Expect(reflect.DeepEqual(p, channelPatch)).To(BeTrue())
+								return nil
+							}),
 						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, updatedClusterVersion).Return(nil),
-						mockKubeClient.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(
-							func(ctx context.Context, cv *configv1.ClusterVersion) error {
-								Expect(cv.Spec.Channel).To(Equal(upgradeConfig.Spec.Desired.Channel))
+						mockKubeClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+							func(ctx context.Context, cv *configv1.ClusterVersion, p client.Patch) error {
+								Expect(reflect.DeepEqual(p, versionPatch)).To(BeTrue())
 								return nil
 							}),
 					)
@@ -137,12 +146,12 @@ var _ = Describe("ClusterVersion client and utils", func() {
 							},
 						},
 					}
+					versionPatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"DesiredUpdate":{"Version": "%s" }}}`, upgradeConfig.Spec.Desired.Version)))
 					gomock.InOrder(
 						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, clusterVersion).Return(nil),
-						mockKubeClient.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(
-							func(ctx context.Context, cv *configv1.ClusterVersion) error {
-								Expect(cv.Spec.DesiredUpdate.Version).To(Equal(upgradeConfig.Spec.Desired.Version))
-								Expect(cv.Spec.Channel).To(Equal(upgradeConfig.Spec.Desired.Channel))
+						mockKubeClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+							func(ctx context.Context, cv *configv1.ClusterVersion, p client.Patch) error {
+								Expect(reflect.DeepEqual(p, versionPatch)).To(BeTrue())
 								return nil
 							}),
 					)
@@ -170,12 +179,12 @@ var _ = Describe("ClusterVersion client and utils", func() {
 							},
 						},
 					}
+					versionPatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"DesiredUpdate":{"Version": "%s" }}}`, upgradeConfig.Spec.Desired.Version)))
 					gomock.InOrder(
 						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, clusterVersion).Return(nil),
-						mockKubeClient.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(
-							func(ctx context.Context, cv *configv1.ClusterVersion) error {
-								Expect(cv.Spec.DesiredUpdate.Version).To(Equal(upgradeConfig.Spec.Desired.Version))
-								Expect(cv.Spec.Channel).To(Equal(upgradeConfig.Spec.Desired.Channel))
+						mockKubeClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+							func(ctx context.Context, cv *configv1.ClusterVersion, p client.Patch) error {
+								Expect(reflect.DeepEqual(p, versionPatch)).To(BeTrue())
 								return nil
 							}),
 					)
@@ -278,12 +287,12 @@ var _ = Describe("ClusterVersion client and utils", func() {
 						},
 					}
 					upgradeConfig.Spec.Desired.Image = "quay.io/test/test-image"
+					updatePatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"image": "%s", "version": "" }}}`, upgradeConfig.Spec.Desired.Image)))
 					gomock.InOrder(
 						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, clusterVersion).Return(nil),
-						mockKubeClient.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(
-							func(ctx context.Context, cv *configv1.ClusterVersion) error {
-								Expect(cv.Spec.DesiredUpdate.Image).To(Equal(upgradeConfig.Spec.Desired.Image))
-								Expect(cv.Spec.DesiredUpdate.Version).To(Equal(""))
+						mockKubeClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+							func(ctx context.Context, cv *configv1.ClusterVersion, p client.Patch) error {
+								Expect(reflect.DeepEqual(p, updatePatch)).To(BeTrue())
 								return nil
 							}),
 					)
@@ -303,12 +312,12 @@ var _ = Describe("ClusterVersion client and utils", func() {
 						},
 					}
 					upgradeConfig.Spec.Desired.Image = "quay.io/test/test-image"
+					updatePatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"image": "%s", "version": "" }}}`, upgradeConfig.Spec.Desired.Image)))
 					gomock.InOrder(
 						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, clusterVersion).Return(nil),
-						mockKubeClient.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(
-							func(ctx context.Context, cv *configv1.ClusterVersion) error {
-								Expect(cv.Spec.DesiredUpdate.Image).To(Equal(upgradeConfig.Spec.Desired.Image))
-								Expect(cv.Spec.DesiredUpdate.Version).To(Equal(""))
+						mockKubeClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+							func(ctx context.Context, cv *configv1.ClusterVersion, p client.Patch) error {
+								Expect(reflect.DeepEqual(p, updatePatch)).To(BeTrue())
 								return nil
 							}),
 					)

--- a/pkg/clusterversion/clusterversion_test.go
+++ b/pkg/clusterversion/clusterversion_test.go
@@ -108,8 +108,8 @@ var _ = Describe("ClusterVersion client and utils", func() {
 							},
 						},
 					}
-					channelPatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"channel":"%s"}}`, upgradeConfig.Spec.Desired.Channel)))
-					versionPatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"version":"%s","image":""}}}`, upgradeConfig.Spec.Desired.Version)))
+					channelPatch := client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf(`{"spec":{"channel":"%s"}}`, upgradeConfig.Spec.Desired.Channel)))
+					versionPatch := client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"version":"%s","image":null}}}`, upgradeConfig.Spec.Desired.Version)))
 					gomock.InOrder(
 						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, clusterVersion).Return(nil),
 						mockKubeClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -146,7 +146,7 @@ var _ = Describe("ClusterVersion client and utils", func() {
 							},
 						},
 					}
-					versionPatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"version":"%s","image":""}}}`, upgradeConfig.Spec.Desired.Version)))
+					versionPatch := client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"version":"%s","image":null}}}`, upgradeConfig.Spec.Desired.Version)))
 					gomock.InOrder(
 						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, clusterVersion).Return(nil),
 						mockKubeClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -179,7 +179,7 @@ var _ = Describe("ClusterVersion client and utils", func() {
 							},
 						},
 					}
-					versionPatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"version":"%s","image":""}}}`, upgradeConfig.Spec.Desired.Version)))
+					versionPatch := client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"version":"%s","image":null}}}`, upgradeConfig.Spec.Desired.Version)))
 					gomock.InOrder(
 						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, clusterVersion).Return(nil),
 						mockKubeClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -287,7 +287,7 @@ var _ = Describe("ClusterVersion client and utils", func() {
 						},
 					}
 					upgradeConfig.Spec.Desired.Image = "quay.io/test/test-image"
-					updatePatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"image":"%s","version":""}}}`, upgradeConfig.Spec.Desired.Image)))
+					updatePatch := client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"image":"%s","version":null}}}`, upgradeConfig.Spec.Desired.Image)))
 					gomock.InOrder(
 						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, clusterVersion).Return(nil),
 						mockKubeClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -312,7 +312,7 @@ var _ = Describe("ClusterVersion client and utils", func() {
 						},
 					}
 					upgradeConfig.Spec.Desired.Image = "quay.io/test/test-image"
-					updatePatch := client.RawPatch(types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"image":"%s","version":""}}}`, upgradeConfig.Spec.Desired.Image)))
+					updatePatch := client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"image":"%s","version":null}}}`, upgradeConfig.Spec.Desired.Image)))
 					gomock.InOrder(
 						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, clusterVersion).Return(nil),
 						mockKubeClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(

--- a/pkg/clusterversion/cv.go
+++ b/pkg/clusterversion/cv.go
@@ -275,8 +275,8 @@ func (c *clusterVersionClient) runUpgradeWithImage(cv *configv1.ClusterVersion, 
 
 	if cv.Spec.DesiredUpdate == nil || cv.Spec.DesiredUpdate.Image != desired.Image {
 		logger.Info(fmt.Sprintf("Setting ClusterVersion to Image %s", desired.Image))
-		cv.Spec.DesiredUpdate = &configv1.Update{Image: desired.Image, Version: ""}
-		err := c.client.Update(context.TODO(), cv)
+		patch := []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"image": "%s", "version": "" }}}`, desired.Image))
+		err := c.client.Patch(context.TODO(), cv, client.RawPatch(types.StrategicMergePatchType, patch))
 		if err != nil {
 			return false, err
 		}
@@ -289,8 +289,8 @@ func (c *clusterVersionClient) runUpgradeWithChannelVersion(cv *configv1.Cluster
 
 	if cv.Spec.Channel != desired.Channel {
 		logger.Info(fmt.Sprintf("Setting ClusterVersion to Channel %s Version %s", desired.Channel, desired.Version))
-		cv.Spec.Channel = desired.Channel
-		err := c.client.Update(context.TODO(), cv)
+		patch := []byte(fmt.Sprintf(`{"spec":{"Channel": "%s" }}`, desired.Channel))
+		err := c.client.Patch(context.TODO(), cv, client.RawPatch(types.StrategicMergePatchType, patch))
 		if err != nil {
 			return false, err
 		}
@@ -314,8 +314,8 @@ func (c *clusterVersionClient) runUpgradeWithChannelVersion(cv *configv1.Cluster
 	}
 
 	cv.Spec.Overrides = []configv1.ComponentOverride{}
-	cv.Spec.DesiredUpdate = &configv1.Update{Version: uc.Spec.Desired.Version}
-	err := c.client.Update(context.TODO(), cv)
+	patch := []byte(fmt.Sprintf(`{"spec":{"DesiredUpdate":{"Version": "%s" }}}`, desired.Version))
+	err := c.client.Patch(context.TODO(), cv, client.RawPatch(types.StrategicMergePatchType, patch))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/clusterversion/cv.go
+++ b/pkg/clusterversion/cv.go
@@ -275,8 +275,8 @@ func (c *clusterVersionClient) runUpgradeWithImage(cv *configv1.ClusterVersion, 
 
 	if cv.Spec.DesiredUpdate == nil || cv.Spec.DesiredUpdate.Image != desired.Image {
 		logger.Info(fmt.Sprintf("Setting ClusterVersion to Image %s", desired.Image))
-		patch := []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"image":"%s","version":""}}}`, desired.Image))
-		err := c.client.Patch(context.TODO(), cv, client.RawPatch(types.StrategicMergePatchType, patch))
+		patch := []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"image":"%s","version":null}}}`, desired.Image))
+		err := c.client.Patch(context.TODO(), cv, client.RawPatch(types.MergePatchType, patch))
 		if err != nil {
 			return false, err
 		}
@@ -290,7 +290,7 @@ func (c *clusterVersionClient) runUpgradeWithChannelVersion(cv *configv1.Cluster
 	if cv.Spec.Channel != desired.Channel {
 		logger.Info(fmt.Sprintf("Setting ClusterVersion to Channel %s Version %s", desired.Channel, desired.Version))
 		patch := []byte(fmt.Sprintf(`{"spec":{"channel":"%s"}}`, desired.Channel))
-		err := c.client.Patch(context.TODO(), cv, client.RawPatch(types.StrategicMergePatchType, patch))
+		err := c.client.Patch(context.TODO(), cv, client.RawPatch(types.MergePatchType, patch))
 		if err != nil {
 			return false, err
 		}
@@ -314,8 +314,8 @@ func (c *clusterVersionClient) runUpgradeWithChannelVersion(cv *configv1.Cluster
 	}
 
 	cv.Spec.Overrides = []configv1.ComponentOverride{}
-	patch := []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"version":"%s","image":""}}}`, desired.Version))
-	err := c.client.Patch(context.TODO(), cv, client.RawPatch(types.StrategicMergePatchType, patch))
+	patch := []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"version":"%s","image":null}}}`, desired.Version))
+	err := c.client.Patch(context.TODO(), cv, client.RawPatch(types.MergePatchType, patch))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/clusterversion/cv.go
+++ b/pkg/clusterversion/cv.go
@@ -275,8 +275,8 @@ func (c *clusterVersionClient) runUpgradeWithImage(cv *configv1.ClusterVersion, 
 
 	if cv.Spec.DesiredUpdate == nil || cv.Spec.DesiredUpdate.Image != desired.Image {
 		logger.Info(fmt.Sprintf("Setting ClusterVersion to Image %s", desired.Image))
-		patch := []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"image":"%s","version":null}}}`, desired.Image))
-		err := c.client.Patch(context.TODO(), cv, client.RawPatch(types.MergePatchType, patch))
+		desiredImage := []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"image":"%s","version":null}}}`, desired.Image))
+		err := c.client.Patch(context.TODO(), cv, client.RawPatch(types.MergePatchType, desiredImage))
 		if err != nil {
 			return false, err
 		}
@@ -289,8 +289,8 @@ func (c *clusterVersionClient) runUpgradeWithChannelVersion(cv *configv1.Cluster
 
 	if cv.Spec.Channel != desired.Channel {
 		logger.Info(fmt.Sprintf("Setting ClusterVersion to Channel %s Version %s", desired.Channel, desired.Version))
-		patch := []byte(fmt.Sprintf(`{"spec":{"channel":"%s"}}`, desired.Channel))
-		err := c.client.Patch(context.TODO(), cv, client.RawPatch(types.MergePatchType, patch))
+		desiredChannel := []byte(fmt.Sprintf(`{"spec":{"channel":"%s"}}`, desired.Channel))
+		err := c.client.Patch(context.TODO(), cv, client.RawPatch(types.MergePatchType, desiredChannel))
 		if err != nil {
 			return false, err
 		}
@@ -314,8 +314,8 @@ func (c *clusterVersionClient) runUpgradeWithChannelVersion(cv *configv1.Cluster
 	}
 
 	cv.Spec.Overrides = []configv1.ComponentOverride{}
-	patch := []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"version":"%s","image":null}}}`, desired.Version))
-	err := c.client.Patch(context.TODO(), cv, client.RawPatch(types.MergePatchType, patch))
+	desiredVersion := []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"version":"%s","image":null}}}`, desired.Version))
+	err := c.client.Patch(context.TODO(), cv, client.RawPatch(types.MergePatchType, desiredVersion))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/clusterversion/cv.go
+++ b/pkg/clusterversion/cv.go
@@ -275,7 +275,7 @@ func (c *clusterVersionClient) runUpgradeWithImage(cv *configv1.ClusterVersion, 
 
 	if cv.Spec.DesiredUpdate == nil || cv.Spec.DesiredUpdate.Image != desired.Image {
 		logger.Info(fmt.Sprintf("Setting ClusterVersion to Image %s", desired.Image))
-		patch := []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"image": "%s", "version": "" }}}`, desired.Image))
+		patch := []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"image":"%s","version":""}}}`, desired.Image))
 		err := c.client.Patch(context.TODO(), cv, client.RawPatch(types.StrategicMergePatchType, patch))
 		if err != nil {
 			return false, err
@@ -289,7 +289,7 @@ func (c *clusterVersionClient) runUpgradeWithChannelVersion(cv *configv1.Cluster
 
 	if cv.Spec.Channel != desired.Channel {
 		logger.Info(fmt.Sprintf("Setting ClusterVersion to Channel %s Version %s", desired.Channel, desired.Version))
-		patch := []byte(fmt.Sprintf(`{"spec":{"Channel": "%s" }}`, desired.Channel))
+		patch := []byte(fmt.Sprintf(`{"spec":{"channel":"%s"}}`, desired.Channel))
 		err := c.client.Patch(context.TODO(), cv, client.RawPatch(types.StrategicMergePatchType, patch))
 		if err != nil {
 			return false, err
@@ -314,7 +314,7 @@ func (c *clusterVersionClient) runUpgradeWithChannelVersion(cv *configv1.Cluster
 	}
 
 	cv.Spec.Overrides = []configv1.ComponentOverride{}
-	patch := []byte(fmt.Sprintf(`{"spec":{"DesiredUpdate":{"Version": "%s" }}}`, desired.Version))
+	patch := []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"version":"%s"}}}`, desired.Version))
 	err := c.client.Patch(context.TODO(), cv, client.RawPatch(types.StrategicMergePatchType, patch))
 	if err != nil {
 		return false, err

--- a/pkg/clusterversion/cv.go
+++ b/pkg/clusterversion/cv.go
@@ -314,7 +314,7 @@ func (c *clusterVersionClient) runUpgradeWithChannelVersion(cv *configv1.Cluster
 	}
 
 	cv.Spec.Overrides = []configv1.ComponentOverride{}
-	patch := []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"version":"%s"}}}`, desired.Version))
+	patch := []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"version":"%s","image":""}}}`, desired.Version))
 	err := c.client.Patch(context.TODO(), cv, client.RawPatch(types.StrategicMergePatchType, patch))
 	if err != nil {
 		return false, err


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?

An Update() to clusterversion can result in potentially cause fields to be nullified or emptied in it,
if the client performing the update isn't aware of those fields.
This will impact MUO as it performs an Update to clusterversion when it initiates an upgrade.
Instead of an Update it should perform a Patch.

### Which Jira/Github issue(s) this PR fixes?

[OSD-11002](https://issues.redhat.com//browse/OSD-11002)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

