### PR TITLE
Osd 11612

### DIFF
--- a/pkg/upgraders/controlplanestep.go
+++ b/pkg/upgraders/controlplanestep.go
@@ -48,7 +48,7 @@ func (c *clusterUpgrader) ControlPlaneUpgraded(ctx context.Context, logger logr.
 	if history == nil {
 		upgradeStartTime, err = time.Parse(time.RFC3339, c.upgradeConfig.Spec.UpgradeAt)
 		if err != nil {
-			return false, err //handle error later
+			return false, err //error parsing time string
 		}
 	} else {
 		upgradeStartTime = history.StartedTime.Time

--- a/pkg/upgraders/controlplanestep.go
+++ b/pkg/upgraders/controlplanestep.go
@@ -43,14 +43,22 @@ func (c *clusterUpgrader) ControlPlaneUpgraded(ctx context.Context, logger logr.
 
 	isCompleted := c.cvClient.HasUpgradeCompleted(clusterVersion, c.upgradeConfig)
 	history := cv.GetHistory(clusterVersion, c.upgradeConfig.Spec.Desired.Version)
+	var upgradeStartTime time.Time
+	var controlPlaneCompleteTime time.Time
 	if history == nil {
-		return false, err
+		upgradeStartTime, err = time.Parse(time.RFC3339, c.upgradeConfig.Spec.UpgradeAt)
+		if err != nil {
+			return false, err //handle error later
+		}
+	} else {
+		upgradeStartTime = history.StartedTime.Time
+		if !history.CompletionTime.IsZero() {
+			controlPlaneCompleteTime = history.CompletionTime.Time
+		}
 	}
 
-	upgradeStartTime := history.StartedTime
-	controlPlaneCompleteTime := history.CompletionTime
 	upgradeTimeout := c.config.Maintenance.GetControlPlaneDuration()
-	if !upgradeStartTime.IsZero() && controlPlaneCompleteTime == nil && time.Now().After(upgradeStartTime.Add(upgradeTimeout)) {
+	if !upgradeStartTime.IsZero() && controlPlaneCompleteTime.IsZero() && time.Now().After(upgradeStartTime.Add(upgradeTimeout)) {
 		logger.Info("Control plane upgrade timeout")
 		c.metrics.UpdateMetricUpgradeControlPlaneTimeout(c.upgradeConfig.Name, c.upgradeConfig.Spec.Desired.Version)
 	}


### PR DESCRIPTION
```
Updated ControlPlaneUpgraded and tests to fallback to upgrade start time if history is not found

### What type of PR is this?
Bug

### What this PR does / why we need it?
If the ControlPlaneUpgraded function cannot find the current in-progress update in the clusterVersion history to determine the start time of the upgrade, it will instead use the time that the upgrade was initiated in order to set the UpgradeControlPlaneTimeout metric

### Which Jira/Github issue(s) this PR fixes?
Fixes OSD-11612 https://issues.redhat.com/browse/OSD-11612

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR


```