### PR TITLE
[OSD-12087] introduce new metric for upgrdeconfig sync timestamp

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -10,7 +10,7 @@ The Managed Upgrade Operator reports the following metrics via direct instrument
 - `upgradeoperator_controlplane_timeout`: If control plane upgrade timeout `value > 0`
 - `upgradeoperator_worker_timeout`: If worker nodes upgrade timeout `value > 0`
 - `upgradeoperator_node_drain_timeout`: If node cannot be drained successfully in time `value > 0`
-- `upgradeoperator_upgradeconfig_synced`: If upgradeConfig has not been synced in time `value > 0`
+- `upgradeoperator_upgradeconfig_sync_timestamp`: Set a timestamp as the value of the metric if the upgradeconfig sync succeeded
 
 ## Metrics for fleet-wide monitoring
 

--- a/pkg/metrics/mocks/metrics.go
+++ b/pkg/metrics/mocks/metrics.go
@@ -265,6 +265,18 @@ func (mr *MockMetricsMockRecorder) UpdateMetricScalingSucceeded(arg0 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricScalingSucceeded", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricScalingSucceeded), arg0)
 }
 
+// UpdateMetricUpgradeConfigSyncTimestamp mocks base method
+func (m *MockMetrics) UpdateMetricUpgradeConfigSyncTimestamp(arg0 string, arg1 time.Time) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateMetricUpgradeConfigSyncTimestamp", arg0, arg1)
+}
+
+// UpdateMetricUpgradeConfigSyncTimestamp indicates an expected call of UpdateMetricUpgradeConfigSyncTimestamp
+func (mr *MockMetricsMockRecorder) UpdateMetricUpgradeConfigSyncTimestamp(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricUpgradeConfigSyncTimestamp", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricUpgradeConfigSyncTimestamp), arg0, arg1)
+}
+
 // UpdateMetricUpgradeConfigSynced mocks base method
 func (m *MockMetrics) UpdateMetricUpgradeConfigSynced(arg0 string) {
 	m.ctrl.T.Helper()

--- a/pkg/upgradeconfigmanager/upgradeconfigmanager.go
+++ b/pkg/upgradeconfigmanager/upgradeconfigmanager.go
@@ -160,11 +160,14 @@ func (s *upgradeConfigManager) StartSync(stopCh context.Context) {
 			if err != nil {
 				waitDuration := s.backoffCounter.Duration()
 				log.Error(err, fmt.Sprintf("unable to refresh upgrade config, retrying in %v", waitDuration))
+				// Remove after UpdateMetricUpgradeConfigSyncTimestamp in use
 				metricsClient.UpdateMetricUpgradeConfigSynced(UPGRADECONFIG_CR_NAME)
 				duration = durationWithJitter(waitDuration, JITTER_FACTOR)
 			} else {
 				s.backoffCounter.Reset()
+				// Remove after UpdateMetricUpgradeConfigSyncTimestamp in use
 				metricsClient.ResetMetricUpgradeConfigSynced(UPGRADECONFIG_CR_NAME)
+				metricsClient.UpdateMetricUpgradeConfigSyncTimestamp(UPGRADECONFIG_CR_NAME, time.Now())
 				duration = durationWithJitter(cfg.GetWatchInterval(), JITTER_FACTOR)
 			}
 		case <-stopCh.Done():


### PR DESCRIPTION
### What type of PR is this?
_bug/refactor_

### What this PR does / why we need it?
Change the logic for the metric which used by UpgradeConfigSyncFailure to avoid some false alerts.


### Which Jira/Github issue(s) this PR fixes?

_Fixes #OSD-12087_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

