### PR TITLE
[OSD-12087] remove the outdated metrics function

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -69,8 +69,6 @@ type Metrics interface {
 	UpdateMetricScalingFailed(string)
 	UpdateMetricScalingSucceeded(string)
 	UpdateMetricUpgradeWindowNotBreached(string)
-	UpdateMetricUpgradeConfigSynced(string)
-	ResetMetricUpgradeConfigSynced(string)
 	UpdateMetricUpgradeConfigSyncTimestamp(string, time.Time)
 	UpdateMetricUpgradeWindowBreached(string)
 	UpdateMetricUpgradeControlPlaneTimeout(string, string)
@@ -205,11 +203,6 @@ var (
 		Name:      "upgrade_window_breached",
 		Help:      "Failed to commence upgrade during the upgrade window",
 	}, []string{nameLabel})
-	metricUpgradeConfigSynced = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Subsystem: metricsTag,
-		Name:      "upgradeconfig_synced",
-		Help:      "UpgradeConfig has not been synced in time",
-	}, []string{nameLabel})
 	metricUpgradeControlPlaneTimeout = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: metricsTag,
 		Name:      "controlplane_timeout",
@@ -247,7 +240,6 @@ var (
 		metricClusterCheckFailed,
 		metricScalingFailed,
 		metricUpgradeWindowBreached,
-		metricUpgradeConfigSynced,
 		metricUpgradeControlPlaneTimeout,
 		metricUpgradeWorkerTimeout,
 		metricNodeDrainFailed,
@@ -302,16 +294,6 @@ func (c *Counter) UpdateMetricScalingSucceeded(upgradeConfigName string) {
 	metricScalingFailed.With(prometheus.Labels{
 		nameLabel: upgradeConfigName}).Set(
 		float64(0))
-}
-
-//Remove after UpdateMetricUpgradeConfigSyncTimestamp in use
-func (c *Counter) UpdateMetricUpgradeConfigSynced(name string) {
-	metricUpgradeConfigSynced.With(prometheus.Labels{nameLabel: name}).Set(float64(1))
-}
-
-//Remove after UpdateMetricUpgradeConfigSyncTimestamp in use
-func (c *Counter) ResetMetricUpgradeConfigSynced(name string) {
-	metricUpgradeConfigSynced.With(prometheus.Labels{nameLabel: name}).Set(float64(0))
 }
 
 func (c *Counter) UpdateMetricUpgradeConfigSyncTimestamp(name string, time time.Time) {

--- a/pkg/metrics/mocks/metrics.go
+++ b/pkg/metrics/mocks/metrics.go
@@ -157,18 +157,6 @@ func (mr *MockMetricsMockRecorder) ResetMetricNodeDrainFailed(arg0 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetMetricNodeDrainFailed", reflect.TypeOf((*MockMetrics)(nil).ResetMetricNodeDrainFailed), arg0)
 }
 
-// ResetMetricUpgradeConfigSynced mocks base method
-func (m *MockMetrics) ResetMetricUpgradeConfigSynced(arg0 string) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ResetMetricUpgradeConfigSynced", arg0)
-}
-
-// ResetMetricUpgradeConfigSynced indicates an expected call of ResetMetricUpgradeConfigSynced
-func (mr *MockMetricsMockRecorder) ResetMetricUpgradeConfigSynced(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetMetricUpgradeConfigSynced", reflect.TypeOf((*MockMetrics)(nil).ResetMetricUpgradeConfigSynced), arg0)
-}
-
 // ResetMetricUpgradeControlPlaneTimeout mocks base method
 func (m *MockMetrics) ResetMetricUpgradeControlPlaneTimeout(arg0, arg1 string) {
 	m.ctrl.T.Helper()
@@ -275,18 +263,6 @@ func (m *MockMetrics) UpdateMetricUpgradeConfigSyncTimestamp(arg0 string, arg1 t
 func (mr *MockMetricsMockRecorder) UpdateMetricUpgradeConfigSyncTimestamp(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricUpgradeConfigSyncTimestamp", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricUpgradeConfigSyncTimestamp), arg0, arg1)
-}
-
-// UpdateMetricUpgradeConfigSynced mocks base method
-func (m *MockMetrics) UpdateMetricUpgradeConfigSynced(arg0 string) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdateMetricUpgradeConfigSynced", arg0)
-}
-
-// UpdateMetricUpgradeConfigSynced indicates an expected call of UpdateMetricUpgradeConfigSynced
-func (mr *MockMetricsMockRecorder) UpdateMetricUpgradeConfigSynced(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricUpgradeConfigSynced", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricUpgradeConfigSynced), arg0)
 }
 
 // UpdateMetricUpgradeControlPlaneTimeout mocks base method

--- a/pkg/upgradeconfigmanager/upgradeconfigmanager.go
+++ b/pkg/upgradeconfigmanager/upgradeconfigmanager.go
@@ -160,13 +160,9 @@ func (s *upgradeConfigManager) StartSync(stopCh context.Context) {
 			if err != nil {
 				waitDuration := s.backoffCounter.Duration()
 				log.Error(err, fmt.Sprintf("unable to refresh upgrade config, retrying in %v", waitDuration))
-				// Remove after UpdateMetricUpgradeConfigSyncTimestamp in use
-				metricsClient.UpdateMetricUpgradeConfigSynced(UPGRADECONFIG_CR_NAME)
 				duration = durationWithJitter(waitDuration, JITTER_FACTOR)
 			} else {
 				s.backoffCounter.Reset()
-				// Remove after UpdateMetricUpgradeConfigSyncTimestamp in use
-				metricsClient.ResetMetricUpgradeConfigSynced(UPGRADECONFIG_CR_NAME)
 				metricsClient.UpdateMetricUpgradeConfigSyncTimestamp(UPGRADECONFIG_CR_NAME, time.Now())
 				duration = durationWithJitter(cfg.GetWatchInterval(), JITTER_FACTOR)
 			}


### PR DESCRIPTION
### What type of PR is this?
_bug/refactor_

### What this PR does / why we need it?
The second part of changing the metrics for alert UpgradeConfigSync
Should not be merged till https://github.com/openshift/managed-cluster-config/pull/1203 in PROD

### Which Jira/Github issue(s) this PR fixes?

_Fixes #OSD-12087_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

