### PR TITLE
Improve logging of function exit conditions

### DIFF
--- a/pkg/clusterversion/cv.go
+++ b/pkg/clusterversion/cv.go
@@ -173,6 +173,7 @@ func (c *clusterVersionClient) HasUpgradeCommenced(uc *upgradev1alpha1.UpgradeCo
 	// When using image to upgrade
 	case UpgradeWithImage:
 		if !isEqualImage(clusterVersion, uc) {
+			logger.Info(fmt.Sprintf("ClusterVersion is not yet set to Image %s", uc.Spec.Desired.Image))
 			return false, nil
 		} else {
 			logger.Info(fmt.Sprintf("ClusterVersion is already set to Image %s", uc.Spec.Desired.Image))
@@ -310,6 +311,7 @@ func (c *clusterVersionClient) runUpgradeWithChannelVersion(cv *configv1.Cluster
 		}
 	}
 	if !updateAvailable {
+		logger.Info(fmt.Sprintf("clusterversion does not have desired version %s in its AvailableUpdates, will not continue", desired.Version))
 		return false, nil
 	}
 

--- a/pkg/scaler/machineSetScaler.go
+++ b/pkg/scaler/machineSetScaler.go
@@ -61,6 +61,7 @@ func (s *machineSetScaler) EnsureScaleUpNodes(c client.Client, timeOut time.Dura
 	}
 	if created {
 		// New machineset created, machines must not ready at the moment, so skip following steps
+		logger.Info("created upgrade machinesets, will re-check their state on reconcile")
 		return false, nil
 	}
 
@@ -69,6 +70,7 @@ func (s *machineSetScaler) EnsureScaleUpNodes(c client.Client, timeOut time.Dura
 		return false, err
 	}
 	if !allNodeReady {
+		logger.Info("not all nodes in the upgrade machinesets are ready yet")
 		return false, nil
 	}
 

--- a/pkg/upgradeconfigmanager/upgradeconfigmanager.go
+++ b/pkg/upgradeconfigmanager/upgradeconfigmanager.go
@@ -234,6 +234,7 @@ func (s *upgradeConfigManager) Refresh() (bool, error) {
 			}
 			return true, nil
 		}
+		log.Info("no provider specs found and no UpgradeConfig on cluster, nothing to do")
 		return false, nil
 	}
 

--- a/pkg/upgraders/controlplanestep.go
+++ b/pkg/upgraders/controlplanestep.go
@@ -28,6 +28,7 @@ func (c *clusterUpgrader) CommenceUpgrade(ctx context.Context, logger logr.Logge
 
 	isComplete, err := c.cvClient.EnsureDesiredConfig(c.upgradeConfig)
 	if err != nil {
+		logger.Info("clusterversion has not been updated to desired version, will retry on next reconcile")
 		return false, err
 	}
 

--- a/pkg/upgraders/delaystep.go
+++ b/pkg/upgraders/delaystep.go
@@ -2,6 +2,7 @@ package upgraders
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -26,6 +27,7 @@ func (c *osdUpgrader) UpgradeDelayedCheck(ctx context.Context, logger logr.Logge
 	// Get the managed upgrade start time from the upgrade config history
 	h := c.upgradeConfig.Status.History.GetHistory(c.upgradeConfig.Spec.Desired.Version)
 	if h == nil {
+		logger.Info(fmt.Sprintf("no history found for version %s in UpgradeConfig yet, will retry", c.upgradeConfig.Spec.Desired.Version))
 		return false, nil
 	}
 	startTime := h.StartTime.Time

--- a/pkg/upgraders/notifierstep.go
+++ b/pkg/upgraders/notifierstep.go
@@ -2,6 +2,7 @@ package upgraders
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -52,6 +53,7 @@ func (c *clusterUpgrader) UpgradeDelayedCheck(ctx context.Context, logger logr.L
 	// Get the managed upgrade start time from the upgrade config history
 	h := c.upgradeConfig.Status.History.GetHistory(c.upgradeConfig.Spec.Desired.Version)
 	if h == nil {
+		logger.Info(fmt.Sprintf("no upgrade start time found for version %s in UpgradeConfig history yet", c.upgradeConfig.Spec.Desired.Version))
 		return false, nil
 	}
 	startTime := h.StartTime.Time
@@ -66,4 +68,3 @@ func (c *clusterUpgrader) UpgradeDelayedCheck(ctx context.Context, logger logr.L
 	}
 	return true, nil
 }
-


### PR DESCRIPTION
### What type of PR is this?
Refactor

### What this PR does / why we need it?
There are a few places in the MUO code where functions can exit due to certain non-error-related conditions but there is no logging to indicate that this was the reason for the function's exit.

This improves logging for those sort of `return false, nil` situations to improve insight into the operator's behaviour when encountering these edge cases.
