### PR TITLE
OSD-12449 Pull prom token direct from secret

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -548,14 +548,6 @@ func (c *Counter) Query(query string) (*AlertResponse, error) {
 }
 
 func prometheusToken(c client.Client) (*string, error) {
-	token, err := prometheusTokenFromContainer()
-	if err == nil {
-		return token, nil
-	}
-	return prometheusTokenFromSecret(c)
-}
-
-func prometheusTokenFromSecret(c client.Client) (*string, error) {
 	sl := &corev1.SecretList{}
 	err := c.List(context.TODO(), sl, client.InNamespace(MonitoringNS))
 	if err != nil {
@@ -576,16 +568,6 @@ func prometheusTokenFromSecret(c client.Client) (*string, error) {
 	}
 
 	return &token, nil
-}
-
-func prometheusTokenFromContainer() (*string, error) {
-	token, err := ioutil.ReadFile("/run/secrets/kubernetes.io/serviceaccount/token")
-	if err != nil {
-		return nil, err
-	}
-
-	tokenstring := string(token)
-	return &tokenstring, nil
 }
 
 type AlertResponse struct {


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
PR #331 does not appear to be behaving well on some clusters when authenticating to Prometheus to check metrics, the mounted token is insufficient for this purpose. This PR adjusts the behaviour of MUO to pull the auth token direct from the `prometheus-k8s-token` secret.

### Which Jira/Github issue(s) this PR fixes?

[OSD-12449](https://issues.redhat.com//browse/OSD-12449)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

