### PR TITLE
adds logic to reinit FIO in fedramp

### DIFF
--- a/api/v1alpha1/upgradeconfig_types.go
+++ b/api/v1alpha1/upgradeconfig_types.go
@@ -125,6 +125,8 @@ const (
 	RemoveMaintWindow UpgradeConditionType = "WorkersMaintenanceWindowRemoved"
 	// PostClusterHealthCheck is an UpgradeConditionType
 	PostClusterHealthCheck UpgradeConditionType = "ClusterHealthyAfterUpgrade"
+	// PostUpgradeProcedures is an UpgradeConditionType
+	PostUpgradeProcedures UpgradeConditionType = "PostUpgradeTasksCompleted"
 	// SendCompletedNotification is an UpgradeConditionType
 	SendCompletedNotification UpgradeConditionType = "CompletedNotificationSent"
 	// IsClusterUpgradable is an UpgradeConditionType

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -100,3 +100,10 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - "fileintegrity.openshift.io"
+  resources:
+  - fileintegrities
+  verbs:
+  - get
+  - update

--- a/pkg/upgraders/config.go
+++ b/pkg/upgraders/config.go
@@ -15,6 +15,7 @@ type upgraderConfig struct {
 	HealthCheck                    healthCheck                       `yaml:"healthCheck"`
 	ExtDependencyAvailabilityCheck ac.ExtDependencyAvailabilityCheck `yaml:"extDependencyAvailabilityChecks"`
 	UpgradeWindow                  upgradeWindow                     `yaml:"upgradeWindow"`
+	Environment                    environment                       `yaml:"environment"`
 }
 
 type maintenanceConfig struct {
@@ -95,4 +96,12 @@ func (cfg *upgraderConfig) IsValid() error {
 
 func (cfg *upgraderConfig) GetScaleDuration() time.Duration {
 	return time.Duration(cfg.Scale.TimeOut) * time.Minute
+}
+
+type environment struct {
+	Fedramp bool `yaml:"fedramp"`
+}
+
+func (cfg *environment) IsFedramp() bool {
+	return cfg.Fedramp
 }

--- a/pkg/upgraders/osdupgrader.go
+++ b/pkg/upgraders/osdupgrader.go
@@ -77,6 +77,7 @@ func NewOSDUpgrader(c client.Client, cfm configmanager.ConfigManager, mc metrics
 		upgradesteps.Action(string(upgradev1alpha1.RemoveExtraScaledNodes), ou.RemoveExtraScaledNodes),
 		upgradesteps.Action(string(upgradev1alpha1.RemoveMaintWindow), ou.RemoveMaintWindow),
 		upgradesteps.Action(string(upgradev1alpha1.PostClusterHealthCheck), ou.PostUpgradeHealthCheck),
+		upgradesteps.Action(string(upgradev1alpha1.PostUpgradeProcedures), ou.PostUpgradeProcedures),
 		upgradesteps.Action(string(upgradev1alpha1.SendCompletedNotification), ou.SendCompletedNotification),
 	}
 	ou.steps = steps

--- a/pkg/upgraders/postupgradestep.go
+++ b/pkg/upgraders/postupgradestep.go
@@ -11,9 +11,8 @@ import (
 )
 
 const (
-	fioNamespace    string = "openshift-file-integrity"
-	fioObject       string = "osd-fileintegrity"
-	frOCMBaseDomain string = "openshiftusgov.com"
+	fioNamespace string = "openshift-file-integrity"
+	fioObject    string = "osd-fileintegrity"
 )
 
 var reinitAnnotation = map[string]string{"file-integrity.openshift.io/re-init": ""}

--- a/pkg/upgraders/postupgradestep.go
+++ b/pkg/upgraders/postupgradestep.go
@@ -1,0 +1,111 @@
+package upgraders
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/openshift/managed-upgrade-operator/config"
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	fioNamespace    string = "openshift-file-integrity"
+	fioObject       string = "osd-fileintegrity"
+	frOCMBaseDomain string = "openshiftusgov.com"
+)
+
+var reinitAnnotation = map[string]string{"file-integrity.openshift.io/re-init": ""}
+
+// ugConfigManager stores the configManager section of the upgradeconfig manager configmap
+type ugConfigManager struct {
+	Source     string `yaml:"source"`
+	OcmBaseURL string `yaml:"ocmBaseUrl"`
+}
+
+// ugConfigManagerSpec stores the config.yaml section of the upgradeconfig manager configmap
+type ugConfigManagerSpec struct {
+	Config ugConfigManager `yaml:"configManager"`
+}
+
+// PostUpgradeProcedures are any misc tasks that are needed to be completed after an upgrade has finished to ensure healthy state
+// Currently the only task is to reinit file integrity operator due to changes that come from upgrades
+func (c *clusterUpgrader) PostUpgradeProcedures(ctx context.Context, logger logr.Logger) (bool, error) {
+
+	frCluster, err := c.frClusterCheck(ctx)
+	if err != nil {
+		return false, err
+	}
+	if !frCluster {
+		logger.Info("Non-FedRAMP environment...skipping PostUpgradeFIOReInit ")
+		return true, nil
+	}
+	err = c.postUpgradeFIOReInit(ctx, logger)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// frClusterCheck checks to see if the upgrading cluster is a FedRAMP cluster to determine if we need to re-init the File Integrity Operator
+func (c *clusterUpgrader) frClusterCheck(ctx context.Context) (bool, error) {
+	ocmConfig := &corev1.ConfigMap{}
+	err := c.client.Get(context.TODO(), client.ObjectKey{Namespace: config.OperatorNamespace, Name: config.ConfigMapName}, ocmConfig)
+
+	if err != nil {
+		return false, fmt.Errorf("failed to fetch %s config map to parse: %v", config.ConfigMapName, err)
+	}
+
+	var cm ugConfigManagerSpec
+	data := fmt.Sprint(ocmConfig.Data["config.yaml"])
+	err = yaml.Unmarshal([]byte(data), &cm)
+
+	if err != nil {
+		return false, fmt.Errorf("failed to parse %s config map for OCM URL: %v", config.ConfigMapName, err)
+	}
+
+	if cm.Config.Source == "OCM" {
+		ocmBaseUrl, err := url.Parse(cm.Config.OcmBaseURL)
+		if err != nil {
+			return false, fmt.Errorf("failed to parse %s config map for OCM URL: %v", config.ConfigMapName, err)
+		}
+		if !strings.Contains(ocmBaseUrl.Host, frOCMBaseDomain) {
+			return false, nil
+		}
+	} else {
+		return false, nil
+	}
+	return true, nil
+}
+
+// postUpgradeFIOReInit reinitializes the AIDE DB in file integrity operator to track file changes due to upgrades
+func (c *clusterUpgrader) postUpgradeFIOReInit(ctx context.Context, logger logr.Logger) error {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "fileintegrity.openshift.io",
+		Kind:    "FileIntegrity",
+		Version: "v1alpha1",
+	})
+
+	logger.Info("FedRAMP Environment...Fetching File Integrity for re-initialization")
+	err := c.client.Get(context.TODO(), client.ObjectKey{Namespace: fioNamespace, Name: fioObject}, u)
+	if err != nil {
+		return fmt.Errorf("failed to fetch file integrity %s in %s namespace: %v", fioObject, fioNamespace, err)
+	}
+
+	logger.Info("Setting re-init annotation")
+	u.SetAnnotations(reinitAnnotation)
+	err = c.client.Update(context.TODO(), u)
+	if err != nil {
+		logger.Error(err, "Failed to annotate File Integrity object")
+		return err
+	}
+	logger.Info("File Integrity Operator AIDE Datbase reinitialized")
+	return nil
+}

--- a/pkg/upgraders/postupgradestep_test.go
+++ b/pkg/upgraders/postupgradestep_test.go
@@ -91,7 +91,7 @@ var _ = Describe("PostUpgradeStep", func() {
 			BeforeEach(func() {
 				testConfig.Config.OcmBaseURL = "https://api.openshift.com"
 				testOperatorConfig.Data["config.yaml"] = `
-                  configManager: 
+                  configManager:
                     source: ` + testConfig.Config.Source + `
                     ocmBaseUrl: ` + testConfig.Config.OcmBaseURL
 			})
@@ -111,7 +111,7 @@ var _ = Describe("PostUpgradeStep", func() {
 		BeforeEach(func() {
 			testConfig.Config.Source = "TEST"
 			testOperatorConfig.Data["config.yaml"] = `
-              configManager: 
+              configManager:
                 source: ` + testConfig.Config.Source + `
                 ocmBaseUrl: ` + testConfig.Config.OcmBaseURL
 		})

--- a/pkg/upgraders/postupgradestep_test.go
+++ b/pkg/upgraders/postupgradestep_test.go
@@ -1,0 +1,127 @@
+package upgraders
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/managed-upgrade-operator/config"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var _ = Describe("PostUpgradeStep", func() {
+
+	var (
+		testConfig         *ugConfigManagerSpec
+		testOperatorConfig *corev1.ConfigMap
+		testUpgrader       *clusterUpgrader
+		log                logr.Logger
+		testFileIntegrity  *unstructured.Unstructured
+		configClient       *fake.ClientBuilder
+		fioClient          *fake.ClientBuilder
+	)
+
+	BeforeEach(func() {
+		log = logf.Log.WithName("upgrader-test-logger")
+
+		testConfig = &ugConfigManagerSpec{
+			Config: ugConfigManager{
+				Source:     "OCM",
+				OcmBaseURL: "https://api.openshiftusgov.com",
+			},
+		}
+
+		testOperatorConfig = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      config.ConfigMapName,
+				Namespace: config.OperatorNamespace,
+			},
+			Data: map[string]string{
+				"config.yaml": `
+                  configManager:
+                    source: ` + testConfig.Config.Source + `
+                    ocmBaseUrl: ` + testConfig.Config.OcmBaseURL,
+			},
+		}
+		testFileIntegrity = &unstructured.Unstructured{}
+		testFileIntegrity.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "fileintegrity.openshift.io",
+			Kind:    "FileIntegrity",
+			Version: "v1alpha1",
+		})
+		testFileIntegrity.Object = map[string]interface{}{
+			"apiVersion": "fileintegrity.openshift.io/v1alpha1",
+			"kind":       "FileIntegrity",
+			"metadata": map[string]interface{}{
+				"name":      fioObject,
+				"namespace": fioNamespace,
+			},
+		}
+
+		configClient = fake.NewClientBuilder().WithRuntimeObjects(testOperatorConfig)
+		fioClient = fake.NewClientBuilder().WithRuntimeObjects(testFileIntegrity)
+
+	})
+
+	Context("When the managed-upgrade-operator-config Source is OCM", func() {
+		Context("When the OCM Base URL belongs to FedRAMP", func() {
+			It("FIO should be re-initialized", func() {
+				Expect(testConfig.Config.Source).To(Equal("OCM"))
+				Expect(testConfig.Config.OcmBaseURL).To(Equal("https://api.openshiftusgov.com"))
+
+				testUpgrader = &clusterUpgrader{client: configClient.Build()}
+
+				isFr, err := testUpgrader.frClusterCheck(context.TODO())
+				Expect(isFr).To(BeTrue())
+				Expect(err).NotTo(HaveOccurred())
+
+				testUpgrader.client = fioClient.Build()
+				err = testUpgrader.postUpgradeFIOReInit(context.TODO(), log)
+				Expect(err).NotTo(HaveOccurred())
+
+			})
+		})
+		Context("When the OCM Base URL does not belong to FedRAMP", func() {
+			BeforeEach(func() {
+				testConfig.Config.OcmBaseURL = "https://api.openshift.com"
+				testOperatorConfig.Data["config.yaml"] = `
+                  configManager: 
+                    source: ` + testConfig.Config.Source + `
+                    ocmBaseUrl: ` + testConfig.Config.OcmBaseURL
+			})
+			It("FIO re-init step should be skipped", func() {
+				Expect(testConfig.Config.Source).To(Equal("OCM"))
+				Expect(testConfig.Config.OcmBaseURL).NotTo(Equal("https://api.openshiftusgov.com"))
+
+				testUpgrader = &clusterUpgrader{client: configClient.Build()}
+				isFr, err := testUpgrader.frClusterCheck(context.TODO())
+				Expect(isFr).To(BeFalse())
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
+	Context("When the managed-upgrade-operator-config Source is not OCM", func() {
+		BeforeEach(func() {
+			testConfig.Config.Source = "TEST"
+			testOperatorConfig.Data["config.yaml"] = `
+              configManager: 
+                source: ` + testConfig.Config.Source + `
+                ocmBaseUrl: ` + testConfig.Config.OcmBaseURL
+		})
+		It("FIO re-init step should be skipped", func() {
+			Expect(testConfig.Config.Source).NotTo(Equal("OCM"))
+
+			testUpgrader = &clusterUpgrader{client: configClient.Build()}
+			isFr, err := testUpgrader.frClusterCheck(context.TODO())
+			Expect(isFr).To(BeFalse())
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/test/deploy/managed-upgrade-operator-config.yaml
+++ b/test/deploy/managed-upgrade-operator-config.yaml
@@ -37,3 +37,5 @@ data:
       - openshift-customer-monitoring
       - openshift-operators
       - openshift-redhat-marketplace
+    environment:
+      fedramp: false


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation/test/refactor)_
feature

### What this PR does / why we need it?
The FedRAMP environment utilizes the [File Integrity Operator](https://github.com/openshift/file-integrity-operator) which monitors for changes to files and alerts if monitored files are changed (potential security threat/attack).
Since upgrades can make lots of changes, this PR adds a post-upgrade step to re-initialize FIO in FedRAMP clusters to ensure file changes are updated in its tracking DB.

### Which Jira/Github issue(s) this PR fixes?
[OSD-9594](https://issues.redhat.com/browse/OSD-9594)

### Special notes for your reviewer:

Currently MUO does not work in FedRAMP (pending other changes to make that possible), so to test that this is working, I did both tests in commercial and changed the logic that the post-upgrade step is checking to see if the cluster is in FedRAMP or not. Since commercial is not impacted by this logic, I figured submit the changes now so if there are changes you'd like to be made, we aren't trying to make them when there is inevitably some crunch time to get this done. Info on the manual tests are available in the Jira story,

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster (test results can be find in Jira Card)
- [ ] Included documentation changes with PR

