### PR TITLE
[OSD-12966] Handle error for node drain strategy

### DIFF
--- a/controllers/nodekeeper/nodekeeper_controller.go
+++ b/controllers/nodekeeper/nodekeeper_controller.go
@@ -105,12 +105,13 @@ func (r *ReconcileNodeKeeper) Reconcile(ctx context.Context, request reconcile.R
 		reqLogger.Error(err, "Error while executing drain.")
 		return reconcile.Result{}, err
 	}
+
 	res, err := drainStrategy.Execute(node, reqLogger)
-	for _, r := range res {
-		reqLogger.Info(r.Message)
-	}
 	if err != nil {
 		return reconcile.Result{}, err
+	}
+	for _, r := range res {
+		reqLogger.Info(r.Message)
 	}
 
 	hasFailed, err := drainStrategy.HasFailed(node, reqLogger)

--- a/pkg/drain/nodeDrainStrategy.go
+++ b/pkg/drain/nodeDrainStrategy.go
@@ -56,6 +56,9 @@ func (ds *osdDrainStrategy) Execute(node *corev1.Node, logger logr.Logger) ([]*D
 			if isAfter(result.AddedAt, ds.GetWaitDuration()) {
 				logger.Info(fmt.Sprintf("Executing %s", drainStrategyMsg))
 				r, err := ds.GetStrategy().Execute(node, logger)
+				if err != nil {
+					return nil, err
+				}
 				me = multierror.Append(err, me)
 				if r.HasExecuted {
 					res = append(res, &DrainStrategyResult{Message: fmt.Sprintf("Executed %s . Result: %s", drainStrategyMsg, r.Message)})

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -50,6 +50,7 @@ func DeletePods(c client.Client, logger logr.Logger, pl *corev1.PodList, ignoreA
 			logger.Info(fmt.Sprintf("Applying pod deletion drain strategy to pod %v/%v", p.Namespace, p.Name))
 			err := c.Delete(context.TODO(), &p, options...)
 			if err != nil {
+				logger.Error(err, fmt.Sprintf("failed to delete the pod %v/%v", p.Namespace, p.Name))
 				me = multierror.Append(err, me)
 			} else {
 				podsMarkedForDeletion = append(podsMarkedForDeletion, p.Name)
@@ -84,6 +85,7 @@ func RemoveFinalizersFromPod(c client.Client, logger logr.Logger, pl *corev1.Pod
 
 			err := c.Update(context.TODO(), &p)
 			if err != nil {
+				logger.Error(err, fmt.Sprintf("failed to remove finalizer from the pod %v/%v", p.Namespace, p.Name))
 				me = multierror.Append(err, me)
 			} else {
 				podsWithFinalizersRemoved = append(podsWithFinalizersRemoved, p.Name)


### PR DESCRIPTION
### What type of PR is this?
_(bug)_


### What this PR does / why we need it?
Handle error to prevent panic during applying remove finalizer drain strategy.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x141984b]

goroutine 1654 [running]:
github.com/openshift/managed-upgrade-operator/pkg/drain.(*osdDrainStrategy).Execute(0xc000bbe200, 0xc000886c00, {{0x1b78c48, 0xc000a38630}, 0xc000790e90})
        /workdir/pkg/drain/nodeDrainStrategy.go:60 +0x4eb
github.com/openshift/managed-upgrade-operator/controllers/nodekeeper.(*ReconcileNodeKeeper).Reconcile(0xc0000f0930, {0xc000a38540, 0x16e2680}, {{{0x0, 0x18124e0}, {0xc000a1b920, 0x30}}})
```

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_[OSD-12966](https://issues.redhat.com/browse/OSD-12966)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

