### PR TITLE
OSD-12071 Add annotation to disable global namespace resolution

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -60,6 +60,8 @@ objects:
           metadata:
             name: managed-upgrade-operator-og
             namespace: openshift-managed-upgrade-operator
+            annotations:
+              olm.operatorframework.io/exclude-global-namespace-resolution: 'true'
           spec:
             targetNamespaces:
               - openshift-managed-upgrade-operator
@@ -82,7 +84,7 @@ objects:
           - apiGroups:
             - ""
             resources:
-            - configmaps  
+            - configmaps
             - serviceaccounts
             - secrets
             - services


### PR DESCRIPTION
This adds an annotation to the OperatorGroup to allow OLM to be more resilient if a catalog source becomes in a bad state.

**References**
https://bugzilla.redhat.com/show_bug.cgi?id=2076323
https://issues.redhat.com/browse/OSD-12071