### PR TITLE
OSD-13087 only check cvo during z-stream upgrades

### DIFF
--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -163,8 +163,10 @@ func (v *validator) IsValidUpgradeConfig(c client.Client, uC *upgradev1alpha1.Up
 				Message:           err.Error(),
 			}, err
 		}
-	} else {
-		// Just check that CVO reports it as an available update
+	}
+
+	// For z-stream upgrades only, verify that CVO knows about the version already
+	if ucChannel == cV.Spec.Channel {
 		updateAvailable := false
 		for _, update := range cV.Status.AvailableUpdates {
 			if update.Version == uC.Spec.Desired.Version {


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?

PR #340 had an issue where it was checking CVO's availableUpgrades for y-stream upgrades when cincinatti-checking was disabled.

### Which Jira/Github issue(s) this PR fixes?

[OSD-13087](https://issues.redhat.com//browse/OSD-13087)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

