### PR TITLE
pkg/upgraders/upgradeable: Pass through the ClusterVersion Upgradeable message

### DIFF
--- a/pkg/upgraders/upgradeable.go
+++ b/pkg/upgraders/upgradeable.go
@@ -10,33 +10,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	upgradev1alpha1 "github.com/openshift/managed-upgrade-operator/api/v1alpha1"
 	cv "github.com/openshift/managed-upgrade-operator/pkg/clusterversion"
-
-	"k8s.io/apimachinery/pkg/types"
 )
-
-const (
-	upgradeCancelledArticleNumberForOSD = 6657541
-	upgradeCancelledArticleNumberForROSA = 6541901
-)
-
-func (c *clusterUpgrader) isRosaCluster(ctx context.Context) (bool, error) {
-	infraConfig := &configv1.Infrastructure{}
-	if err := c.client.Get(ctx, types.NamespacedName{Name: "cluster"}, infraConfig); err != nil {
-		return false, fmt.Errorf("failed fetching infrastructure config: %w", err)
-	}
-
-	platformStatus := infraConfig.Status.PlatformStatus
-
-	if platformStatus != nil && platformStatus.AWS != nil {
-		for _, resourceTag := range platformStatus.AWS.ResourceTags {
-			if resourceTag.Key == "red-hat-clustertype" {
-				return resourceTag.Value == "rosa", nil
-			}
-		}
-	}
-
-	return false, nil
-}
 
 func (c *clusterUpgrader) IsUpgradeable(ctx context.Context, logger logr.Logger) (bool, error) {
 	upgradeCommenced, err := c.cvClient.HasUpgradeCommenced(c.upgradeConfig)
@@ -68,19 +42,6 @@ func (c *clusterUpgrader) IsUpgradeable(ctx context.Context, logger logr.Logger)
 	}
 
 	// if the upgradeable is false then we need to check the current version with upgrade version for y-stream update
-	isRosaCluster, err := c.isRosaCluster(ctx)
-	if err != nil {
-		return false, err
-	}
-
-	var articleNumber int
-
-	if isRosaCluster {
-		articleNumber = upgradeCancelledArticleNumberForROSA
-	} else {
-		articleNumber = upgradeCancelledArticleNumberForOSD
-	}
-
 	upgradeTime, err := time.Parse(time.RFC3339, c.upgradeConfig.Spec.UpgradeAt)
 	if err != nil {
 		return false, fmt.Errorf("failed to parse spec.upgradeAt: %w", err)
@@ -90,10 +51,11 @@ func (c *clusterUpgrader) IsUpgradeable(ctx context.Context, logger logr.Logger)
 	for _, condition := range clusterVersion.Status.Conditions {
 		if condition.Type == configv1.OperatorUpgradeable && condition.Status == configv1.ConditionFalse && parsedDesiredVersion.Major >= parsedCurrentVersion.Major && parsedDesiredVersion.Minor > parsedCurrentVersion.Minor {
 			return false, fmt.Errorf(
-				"Cluster upgrade maintenance to version %s on %s has been cancelled due to unacknowledged user actions. See https://access.redhat.com/solutions/%d for more details.",
+				"Cluster upgrade to version %s on %s has been cancelled: %s: %s.",
 				desiredVersion,
 				upgradeTimeText,
-				articleNumber,
+				condition.Reason,
+				condition.Message,
 			)
 		}
 	}


### PR DESCRIPTION
Instead of assuming we know what the issue is, just bubble up the issue as explained by the cluster-version operator.  This thins out the update stack, simplifying maintenance, and avoids mischaracterizing issues like this ClusterVersion condition:

```yaml
conditions:
- lastTransitionTime: "2022-11-18T00:52:52Z"
  message: |-
    Cluster operator monitoring should not be upgraded between minor versions: Highly-available workload in namespace openshift-monitoring, with label map["app.kubernetes.io/name":"prometheus"] and persistent storage enabled has a single point of failure.
    Highly-available workload in namespace openshift-monitoring, with label map["app.kubernetes.io/name":"alertmanager"] and persistent storage enabled has a single point of failure.
    Manual intervention is needed to upgrade to the next minor version. For each highly-available workload that has a single point of failure please mark at least one of their PersistentVolumeClaim for deletion by annotating them with map["openshift.io/cluster-monitoring-drop-pvc":"yes"].
  reason: WorkloadSinglePointOfFailure
  status: "False"
  type: Upgradeable
```

as an "unacknowledged user actions" issue.

One complication is that responsibility for resolving `Upgradeable=False` is shared between customers (e.g. `AdminAckRequired`) and service-delivery (e.g. `WorkloadSinglePointOfFailure`), but we can mitigate that by proactively monitoring for and resolving reasons that fall on the service-delivery side of things.

### What type of PR is this?

Bug.

### What this PR does / why we need it?

Reduce customer confusion.

### Which Jira/Github issue(s) this PR fixes?

_Fixes [OSD-13797](https://issues.redhat.com/browse/OSD-13797)_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

