### PR TITLE
Fix to only return one same alert for upgrade results

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -430,7 +430,7 @@ func (c *Counter) IsClusterVersionAtVersion(version string) (bool, error) {
 func (c *Counter) AlertsFromUpgrade(upgradeStart time.Time, upgradeEnd time.Time) ([]string, error) {
 	timeSinceUpgrade := time.Since(upgradeEnd).Truncate(time.Second)
 	upgradeDuration := upgradeEnd.Sub(upgradeStart)
-	cpMetrics, err := c.Query(fmt.Sprintf(`max_over_time(ALERTS{alertstate="firing",severity="critical",alertname=~"%s"}[%s] offset %s)`, strings.Join(pagingAlerts, "|"), upgradeDuration.String(), timeSinceUpgrade.String()))
+	cpMetrics, err := c.Query(fmt.Sprintf(`sum by (alertname) (max_over_time(ALERTS{alertstate="firing",severity="critical",alertname=~"%s"}[%s] offset %s))`, strings.Join(pagingAlerts, "|"), upgradeDuration.String(), timeSinceUpgrade.String()))
 	if err != nil {
 		return []string{}, err
 	}


### PR DESCRIPTION
### What type of PR is this?
bug


### What this PR does / why we need it?
To fix the metrics query to return only one alert name and then update to upgradeoperator_upgrade_result

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [OSD-14614](https://issues.redhat.com/browse/OSD-14614)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

