### PR TITLE
reset the notification metric on failure, to make sure the MUO could sync with OCM on next schedule

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -394,6 +394,7 @@ func (c *Counter) ResetFailureMetrics() {
 		metricUpgradeControlPlaneTimeout,
 		metricUpgradeWorkerTimeout,
 		metricNodeDrainFailed,
+		metricUpgradeNotification,
 	}
 	for _, m := range failureMetricsList {
 		m.Reset()

--- a/pkg/upgraders/notifierstep.go
+++ b/pkg/upgraders/notifierstep.go
@@ -2,9 +2,6 @@ package upgraders
 
 import (
 	"context"
-	"fmt"
-	"time"
-
 	"github.com/go-logr/logr"
 
 	"github.com/openshift/managed-upgrade-operator/pkg/notifier"
@@ -34,37 +31,6 @@ func (c *clusterUpgrader) SendCompletedNotification(ctx context.Context, logger 
 	err := c.notifier.Notify(notifier.MuoStateCompleted)
 	if err != nil {
 		return false, err
-	}
-	return true, nil
-}
-
-// UpgradeDelayedCheck checks and sends a notification on a delay to upgrade commencement
-func (c *clusterUpgrader) UpgradeDelayedCheck(ctx context.Context, logger logr.Logger) (bool, error) {
-
-	// No need to send started notifications if we're in the upgrading phase
-	upgradeCommenced, err := c.cvClient.HasUpgradeCommenced(c.upgradeConfig)
-	if err != nil {
-		return false, err
-	}
-	if upgradeCommenced {
-		return true, nil
-	}
-
-	// Get the managed upgrade start time from the upgrade config history
-	h := c.upgradeConfig.Status.History.GetHistory(c.upgradeConfig.Spec.Desired.Version)
-	if h == nil {
-		logger.Info(fmt.Sprintf("no upgrade start time found for version %s in UpgradeConfig history yet", c.upgradeConfig.Spec.Desired.Version))
-		return false, nil
-	}
-	startTime := h.StartTime.Time
-
-	delayTimeoutTrigger := c.config.UpgradeWindow.GetUpgradeDelayedTriggerDuration()
-	// Send notification if the managed upgrade started but did not hit the controlplane upgrade phase in delayTimeoutTrigger minutes
-	if !startTime.IsZero() && delayTimeoutTrigger > 0 && time.Now().After(startTime.Add(delayTimeoutTrigger)) {
-		err := c.notifier.Notify(notifier.MuoStateDelayed)
-		if err != nil {
-			return false, err
-		}
 	}
 	return true, nil
 }


### PR DESCRIPTION
### Description of the issue

Pre:
OCM will cancel the upgrade which is in state pending or scheduled and schedueld at 2h2m ago

Issue:        
1. Failed upgrade will be synced to OCM, and the upgradepolicy will be delete in OCM after 2h2m.

2. New scheduled upgrade will be fetched from OCM on the next MUO sync.

3. The new upgrade will be executed with skip the  `SendStartedNotification` step and the status cannot be synced by to OCM

4. The upgrade could be finished on cluster if the failed condition in step 1 cleared 

5. OCM will delete the upgrade policy after 2h2m if the upgrade on cluster cannot be finished within 2 hours 2 minutes

6. MUO will try to sync to OCM on upgrade completed, but the OCM side upgradepolicy has been deleted

7. The upgradeconfig will be leftover on cluster and the upgrade process cannot be finished.

The reason in 3, that the second scheduled upgrade will skip the `SendStartedNotifcation ` since the `eventmanager.Notify()` function will check the metric value 
of `upgradeoperator_upgrade_notification` and return directly if the value is set. In https://github.com/openshift/managed-upgrade-operator/blob/f38e833a50512e95c6238e79dac683f12302d7b2/pkg/eventmanager/eventmanager.go#L99

The `upgradeoperator_upgrade_notification` was left from the previous upgrade which was not cleaned up.

Also clean up some unused code.

### What type of PR is this?
_bug_

### What this PR does / why we need it?
See above

### Which Jira/Github issue(s) this PR fixes?

_Fixes #OSD-13795_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

