### PR TITLE
OSD-9348 Configurable MUO drain controls

### DIFF
--- a/docs/configmap.md
+++ b/docs/configmap.md
@@ -113,16 +113,22 @@ Example:
 
 #### nodeDrain
 
-| Key | Description |
-| --- | --- |
-| timeOut | a time window to trigger the force node drain strategy, measured in minutes |
+| Key | Description                                                                                           |
+| --- |-------------------------------------------------------------------------------------------------------|
+| timeOut | a time window to trigger the force node drain strategy, measured in minutes                           |
 | expectedNodeDrainTime | expected time in minutes for a single node drain to be finished, used to setup the maintenance window |
+| disableDrainStrategies | disable any node drain completion strategies from executing (defaults to false)                       |
+| ignoredNamespacePatterns | any pods in namespaces matching the regular expressions in this list are ignored from having drain strategies applied  to them |
 
 Example:
 ```
     nodeDrain:
       timeOut: 45
       expectedNodeDrainTime: 8
+      disableDrainStrategies: true
+      ignoredNamespacePatterns:
+      - my-namespace-name
+      - example-.+
 ```
 
 #### healthCheck

--- a/pkg/drain/config.go
+++ b/pkg/drain/config.go
@@ -6,9 +6,10 @@ import (
 
 // NodeDrain holds timeout and expected drain time fields required for NodeDrain execution
 type NodeDrain struct {
-	DisableDrainStrategies bool `yaml:"disableDrainStrategies"`
-	Timeout                int  `yaml:"timeOut"`
-	ExpectedNodeDrainTime  int  `yaml:"expectedNodeDrainTime" default:"8"`
+	DisableDrainStrategies   bool     `yaml:"disableDrainStrategies"`
+	Timeout                  int      `yaml:"timeOut"`
+	ExpectedNodeDrainTime    int      `yaml:"expectedNodeDrainTime" default:"8"`
+	IgnoredNamespacePatterns []string `yaml:"ignoredNamespacePatterns"`
 }
 
 // GetTimeOutDuration returns the timout field from the NodeDrain object

--- a/pkg/drain/config.go
+++ b/pkg/drain/config.go
@@ -6,8 +6,9 @@ import (
 
 // NodeDrain holds timeout and expected drain time fields required for NodeDrain execution
 type NodeDrain struct {
-	Timeout               int `yaml:"timeOut"`
-	ExpectedNodeDrainTime int `yaml:"expectedNodeDrainTime" default:"8"`
+	DisableDrainStrategies bool `yaml:"disableDrainStrategies"`
+	Timeout                int  `yaml:"timeOut"`
+	ExpectedNodeDrainTime  int  `yaml:"expectedNodeDrainTime" default:"8"`
 }
 
 // GetTimeOutDuration returns the timout field from the NodeDrain object

--- a/pkg/drain/pod_predicates_test.go
+++ b/pkg/drain/pod_predicates_test.go
@@ -1,0 +1,46 @@
+package drain
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Pod Predicates", func() {
+
+	var (
+		pod corev1.Pod
+	)
+
+	Context("When testing pod predicates", func() {
+		BeforeEach(func() {
+			pod = corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "test-namespace",
+				},
+				Spec: corev1.PodSpec{},
+			}
+		})
+		Context("testing if pod namespace is allowed", func() {
+			It("allows pods with namespaces not in the ignore list", func() {
+				r := containsIgnoredNamespace(pod, []string{"not-same-as-pod", "also-not-the-same"})
+				Expect(r).To(BeTrue())
+			})
+			It("allows pods if there are no namespaces being ignored", func() {
+				r := containsIgnoredNamespace(pod, []string{})
+				Expect(r).To(BeTrue())
+			})
+			It("ignore pods with namespaces in the ignore list", func() {
+				r := containsIgnoredNamespace(pod, []string{"not-same-as-pod", "test-namespace"})
+				Expect(r).To(BeFalse())
+			})
+			It("ignore pods if the namespace matches a regular expression", func() {
+				r := containsIgnoredNamespace(pod, []string{"test-n.+"})
+				Expect(r).To(BeFalse())
+			})
+		})
+	})
+})

--- a/pkg/drain/strategy.go
+++ b/pkg/drain/strategy.go
@@ -79,28 +79,29 @@ func (dsb *drainStrategyBuilder) NewNodeDrainStrategy(c client.Client, logger lo
 	defaultOsdPodPredicates := []pod.PodPredicate{isNotDaemonSet}
 	isNotPdbPod := isNotPdbPod(pdbList)
 	isPdbPod := isPdbPod(pdbList)
+	isAllowedNamespace := isAllowedNamespace(cfg.IgnoredNamespacePatterns)
 	defaultDuration := cfg.GetTimeOutDuration()
 	pdbDuration := uc.GetPDBDrainTimeoutDuration() + cfg.GetExpectedDrainDuration()
 	ts := []TimedDrainStrategy{
 		newTimedStrategy(defaultPodDeleteName, "Default pod deletion", defaultDuration, &podDeletionStrategy{
 			client:  c,
-			filters: append(defaultOsdPodPredicates, isNotPdbPod),
+			filters: append(defaultOsdPodPredicates, isNotPdbPod, isAllowedNamespace),
 		}),
 		newTimedStrategy(defaultPodFinalizerRemovalName, "Default pod finalizer removal", defaultDuration, &removeFinalizersStrategy{
 			client:  c,
-			filters: append(defaultOsdPodPredicates, isNotPdbPod),
+			filters: append(defaultOsdPodPredicates, isNotPdbPod, isAllowedNamespace),
 		}),
 		newTimedStrategy(stuckTerminatingPodName, "Pod stuck terminating removal", defaultDuration, &stuckTerminatingStrategy{
 			client:  c,
-			filters: append(defaultOsdPodPredicates, isNotPdbPod),
+			filters: append(defaultOsdPodPredicates, isNotPdbPod, isAllowedNamespace),
 		}),
 		newTimedStrategy(pdbPodDeleteName, "PDB pod deletion", pdbDuration, &podDeletionStrategy{
 			client:  c,
-			filters: append(defaultOsdPodPredicates, isPdbPod),
+			filters: append(defaultOsdPodPredicates, isPdbPod, isAllowedNamespace),
 		}),
 		newTimedStrategy(pdbPodFinalizerRemovalName, "PDB Pod finalizer removal", pdbDuration, &removeFinalizersStrategy{
 			client:  c,
-			filters: append(defaultOsdPodPredicates, isPdbPod),
+			filters: append(defaultOsdPodPredicates, isPdbPod, isAllowedNamespace),
 		}),
 	}
 


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
Adds a couple of extra control valves to the `managed-upgrade-operator` node keeper (which applies drain strategies):
- Ability to disable application of any drain strategies at all via a new `disableDrainStrategies` in the MUO config map.
- Ability to specify a set of namespace patterns (regular expressions) for which pod-related drain strategies will not be applied in. 

These can be controlled via the `managed-upgrade-operator` configmap:

```
    nodeDrain:
      disableDrainStrategies: true
      ignoredNamespacePatterns:
      - my-namespace-name
      - example-.+
```
(note: this example does not make sense in reality, it's just illustrative)

Unit tests have been added for all portions of new introduced code.

### Which Jira/Github issue(s) this PR fixes?
[OSD-9348](https://issues.redhat.com//browse/OSD-9348)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

