### PR TITLE
Make catalogsource compatible with restricted SCC enforcement

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -52,6 +52,8 @@ objects:
             namespace: openshift-managed-upgrade-operator
           spec:
             sourceType: grpc
+            grpcPodConfig:
+              securityContextConfig: restricted
             image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
             displayName: Managed Upgrade Operator
             publisher: Red Hat
@@ -138,4 +140,3 @@ objects:
           - kind: ServiceAccount
             name: managed-upgrade-operator
             namespace: openshift-managed-upgrade-operator
-


### PR DESCRIPTION
* Restricted SCC enforcement will be added with OCP 4.14
* Updating the catalogsource to allow the operator to get deployed
* Clusters that don't support the setting (<4.12) will ignore it

Jira: [OSD-15623](https://issues.redhat.com//browse/OSD-15623)