### PR TITLE
OSD-17840 handle removed upgradeconfigs

### DIFF
--- a/pkg/ocmprovider/ocmprovider.go
+++ b/pkg/ocmprovider/ocmprovider.go
@@ -135,8 +135,15 @@ func getNextOccurringUpgradePolicy(uPs *ocm.UpgradePolicyList) (*ocm.UpgradePoli
 // UpgradeConfig
 func isActionableUpgradePolicy(up *ocm.UpgradePolicy, state *ocm.UpgradePolicyState) bool {
 
-	// Policies that aren't in a SCHEDULED state should be ignored
-	if strings.ToLower(state.Value) != "scheduled" {
+	switch strings.ToLower(state.Value) {
+	case "pending":
+		// Policies that are in a PENDING state should be ignored, because they aren't scheduled
+		return false
+	case "completed":
+		// Policies that are in a COMPLETED state should be ignored, because they're already acted on
+		return false
+	case "cancelled":
+		// Policies that are in a CANCELLED state should be ignored, because they're no longer valid
 		return false
 	}
 

--- a/pkg/ocmprovider/ocmprovider_test.go
+++ b/pkg/ocmprovider/ocmprovider_test.go
@@ -278,11 +278,21 @@ var _ = Describe("OCM Provider", func() {
 		})
 		It("Will not action a policy not in a pending state", func() {
 			u := upgradePolicyListResponse.Items[0]
-			u.Version = ""
-			upgradePolicyStateResponse.Value = "somethingelse"
+			upgradePolicyStateResponse.Value = "pending"
 			result := isActionableUpgradePolicy(&u, &upgradePolicyStateResponse)
 			Expect(result).To(BeFalse())
 		})
-
+		It("Will not action a policy not in a completed state", func() {
+			u := upgradePolicyListResponse.Items[0]
+			upgradePolicyStateResponse.Value = "completed"
+			result := isActionableUpgradePolicy(&u, &upgradePolicyStateResponse)
+			Expect(result).To(BeFalse())
+		})
+		It("Will not action a policy not in a cancelled state", func() {
+			u := upgradePolicyListResponse.Items[0]
+			upgradePolicyStateResponse.Value = "cancelled"
+			result := isActionableUpgradePolicy(&u, &upgradePolicyStateResponse)
+			Expect(result).To(BeFalse())
+		})
 	})
 })

--- a/pkg/upgradeconfigmanager/upgradeconfigmanager.go
+++ b/pkg/upgradeconfigmanager/upgradeconfigmanager.go
@@ -198,17 +198,6 @@ func (s *upgradeConfigManager) Refresh() (bool, error) {
 		foundUpgradeConfig = true
 	}
 
-	// If we are in the middle of an upgrade, we should not refresh
-	cvClient := s.cvClientBuilder.New(s.client)
-	upgrading, err := upgradeInProgress(currentUpgradeConfig, cvClient)
-	if err != nil {
-		return false, err
-	}
-	if upgrading {
-		log.Info("skipping spec refresh as the cluster is currently upgrading")
-		return false, nil
-	}
-
 	// Get the latest config specs from the provider
 	pp, err := s.specProviderBuilder.New(s.client, s.configManagerBuilder)
 	if err != nil {


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
This allows MUO to be able to handle the situation where an UpgradeConfig is removed from the cluster mid-upgrade.

MUO will now always try to create/replace the UpgradeConfig on its next sync with the upgrade config provider unless:
- the upgrade policy is in a pending, cancelled or completed state, or
- there's an existing upgradeconfig on the cluster and its spec matches that of the upgrade policy

### Which Jira/Github issue(s) this PR fixes?

[OSD-17840](https://issues.redhat.com//browse/OSD-17840)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

