### PR TITLE
added operator upgrade e2e test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/openshift/library-go v0.0.0-20230112164258-24668b1349e6
 	github.com/openshift/machine-config-operator v0.0.1-0.20230330142923-2832f049b3f4
 	github.com/openshift/operator-custom-metrics v0.5.1
-	github.com/openshift/osde2e-common v0.0.0-20230627123718-79ec4c181d85
+	github.com/openshift/osde2e-common v0.0.0-20230830054343-f487e353dac0
 	github.com/operator-framework/operator-lib v0.9.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.64.0
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.64.0

--- a/go.sum
+++ b/go.sum
@@ -665,8 +665,8 @@ github.com/openshift/machine-config-operator v0.0.1-0.20230330142923-2832f049b3f
 github.com/openshift/machine-config-operator v0.0.1-0.20230330142923-2832f049b3f4/go.mod h1:p8S2oRbRzYFB6y8vN1QBI9uExCUkXZGpZ/yW8s9ZO+Y=
 github.com/openshift/operator-custom-metrics v0.5.1 h1:1pk4YMUV+cmqfV0f2fyxY62cl7Gc76kwudJT+EdcfYM=
 github.com/openshift/operator-custom-metrics v0.5.1/go.mod h1:0dYDHi/ubKRWzsC9MmW6bRMdBgo1QSOuAh3GupTe0Sw=
-github.com/openshift/osde2e-common v0.0.0-20230627123718-79ec4c181d85 h1:oRWhSeC5i+26g4RiIOziLL2UidhU7ZSwpG52bFK6e1Y=
-github.com/openshift/osde2e-common v0.0.0-20230627123718-79ec4c181d85/go.mod h1:qP+tI/gaFODlcRTSzD7IL3Z6Eh7C/eKdxK4z7J/bYNE=
+github.com/openshift/osde2e-common v0.0.0-20230830054343-f487e353dac0 h1:3XKwwvrFlLHU0OeQRcn1jktg/UKFQHNSGnQhNbPhY/k=
+github.com/openshift/osde2e-common v0.0.0-20230830054343-f487e353dac0/go.mod h1:bkreMB6T7SoOuEceXyXCvMHF4/9augfiWsixGaQ/Yo0=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=

--- a/osde2e/managed_upgrade_operator_tests.go
+++ b/osde2e/managed_upgrade_operator_tests.go
@@ -155,7 +155,7 @@ var _ = ginkgo.Describe("managed-upgrade-operator", ginkgo.Ordered, func() {
 				defer cancel()
 				vector, err := prom.InstantQuery(context, query)
 				return err == nil && vector.Len() == 1
-			}).WithTimeout(60*time.Second).WithPolling(5*time.Second).Should(BeTrue(),
+			}).WithContext(ctx).WithTimeout(60*time.Second).WithPolling(5*time.Second).Should(BeTrue(),
 				"MUO should raise prometheus metric for invalid start time for upgrade config", upgradeConfigResourceName)
 		})
 
@@ -167,6 +167,11 @@ var _ = ginkgo.Describe("managed-upgrade-operator", ginkgo.Ordered, func() {
 				Expect(err).NotTo(HaveOccurred(), "Could not clean up upgrade config")
 			}
 		})
+	})
+
+	ginkgo.It("can be upgraded", func(ctx context.Context) {
+		err := k8s.UpgradeOperator(ctx, operatorName, operatorNamespace)
+		Expect(err).NotTo(HaveOccurred(), "operator upgrade failed")
 	})
 
 })


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation/test/refactor)_
test

### What this PR does / why we need it?
 
This change  adds assertion to verify that operator can be upgraded. It downgrades operator to n-1 version, which kicks off an upgrade. Test asserts that this succeeds.



### Which Jira/Github issue(s) this PR fixes?

 https://issues.redhat.com/browse/SDCICD-1102

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

