### PR TITLE
OSD-18440 MUO should handle missing worker machineset

### DIFF
--- a/pkg/scaler/mocks/scaler.go
+++ b/pkg/scaler/mocks/scaler.go
@@ -37,6 +37,21 @@ func (m *MockScaler) EXPECT() *MockScalerMockRecorder {
 	return m.recorder
 }
 
+// CanScale mocks base method.
+func (m *MockScaler) CanScale(arg0 client.Client, arg1 logr.Logger) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CanScale", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CanScale indicates an expected call of CanScale.
+func (mr *MockScalerMockRecorder) CanScale(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanScale", reflect.TypeOf((*MockScaler)(nil).CanScale), arg0, arg1)
+}
+
 // EnsureScaleDownNodes mocks base method.
 func (m *MockScaler) EnsureScaleDownNodes(arg0 client.Client, arg1 drain.NodeDrainStrategy, arg2 logr.Logger) (bool, error) {
 	m.ctrl.T.Helper()

--- a/pkg/scaler/scaler.go
+++ b/pkg/scaler/scaler.go
@@ -9,8 +9,10 @@ import (
 )
 
 // Scaler is an interface that enables implementations of a Scaler
+//
 //go:generate mockgen -destination=mocks/scaler.go -package=mocks github.com/openshift/managed-upgrade-operator/pkg/scaler Scaler
 type Scaler interface {
+	CanScale(client.Client, logr.Logger) (bool, error)
 	EnsureScaleUpNodes(client.Client, time.Duration, logr.Logger) (bool, error)
 	EnsureScaleDownNodes(client.Client, drain.NodeDrainStrategy, logr.Logger) (bool, error)
 }


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
It is now possible for ROSA clusters to not have a `worker` machineset [0], which was breaking MUO's capacity scaler.

This change addresses this by not performing any capacity scaling if there is no longer a `worker` machineset (as opposed to trying to scale any non-master machineset, which potentially the cluster owner may not want, especially for expensive instance types).

[0] https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html#deleting-machine-poolsrosa-managing-worker-nodes

### Which Jira/Github issue(s) this PR fixes?

OSD-18440

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

