### PR TITLE
adds separate template for FedRAMP to allow for VPCE creation

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.fedramp.yaml
+++ b/hack/olm-registry/olm-artifacts-template.fedramp.yaml
@@ -1,0 +1,255 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: selectorsyncset-template
+
+parameters:
+  - name: REGISTRY_IMG
+    required: true
+  - name: CHANNEL
+    value: staging
+    required: true
+  - name: IMAGE_TAG
+    required: true
+  - name: IMAGE_DIGEST
+    required: true
+  - name: REPO_NAME
+    value: managed-upgrade-operator
+    required: true
+  - name: DISPLAY_NAME
+    value: Managed Upgrade Operator
+    required: true
+  - name: OCM_VPCE_SERVICE_NAME_EAST
+    required: true
+  - name: OCM_VPCE_SERVICE_NAME_WEST
+    required: true
+  - name: OCM_DOMAIN
+    required: true
+  - name: OCM_HOSTNAME
+    required: true   
+
+objects:
+  - apiVersion: hive.openshift.io/v1
+    kind: SelectorSyncSet
+    metadata:
+      annotations:
+        component-display-name: ${DISPLAY_NAME}
+        component-name: ${REPO_NAME}
+        telemeter-query: csv_succeeded{_id="$CLUSTER_ID",name=~"${REPO_NAME}.*",exported_namespace=~"openshift-.*",namespace="openshift-operator-lifecycle-manager"} == 1
+      labels:
+        managed.openshift.io/gitHash: ${IMAGE_TAG}
+        managed.openshift.io/gitRepoName: ${REPO_NAME}
+        managed.openshift.io/osd: "true"
+      name: managed-upgrade-operator
+    spec:
+      clusterDeploymentSelector:
+        matchLabels:
+          api.openshift.com/managed: "true"
+      resourceApplyMode: Sync
+      resources:
+        - apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: openshift-managed-upgrade-operator
+            labels:
+              openshift.io/cluster-monitoring: "true"
+        - apiVersion: operators.coreos.com/v1alpha1
+          kind: CatalogSource
+          metadata:
+            name: managed-upgrade-operator-catalog
+            namespace: openshift-managed-upgrade-operator
+          spec:
+            sourceType: grpc
+            grpcPodConfig:
+              securityContextConfig: restricted
+              nodeSelector:
+                node-role.kubernetes.io: infra
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/infra
+                operator: Exists
+            image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
+            displayName: Managed Upgrade Operator
+            publisher: Red Hat
+        - apiVersion: operators.coreos.com/v1
+          kind: OperatorGroup
+          metadata:
+            name: managed-upgrade-operator-og
+            namespace: openshift-managed-upgrade-operator
+            annotations:
+              olm.operatorframework.io/exclude-global-namespace-resolution: 'true'
+          spec:
+            targetNamespaces:
+              - openshift-managed-upgrade-operator
+        - apiVersion: operators.coreos.com/v1alpha1
+          kind: Subscription
+          metadata:
+            name: managed-upgrade-operator
+            namespace: openshift-managed-upgrade-operator
+          spec:
+            channel: ${CHANNEL}
+            name: managed-upgrade-operator
+            source: managed-upgrade-operator-catalog
+            sourceNamespace: openshift-managed-upgrade-operator
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            name: muo-monitoring-reader
+            namespace: openshift-monitoring
+          rules:
+          - apiGroups:
+            - ""
+            resources:
+            - configmaps
+            - serviceaccounts
+            - secrets
+            - services
+            verbs:
+            - get
+            - list
+            - watch
+          - apiGroups:
+            - route.openshift.io
+            resources:
+            - routes
+            verbs:
+            - get
+            - list
+            - watch
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            name: muo-pullsecret-reader
+            namespace: openshift-config
+          rules:
+          - apiGroups:
+            - ""
+            resources:
+            - secrets
+            verbs:
+            - get
+            - list
+            - watch
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            name: muo-monitoring-reader
+            namespace: openshift-monitoring
+          roleRef:
+            kind: Role
+            name: muo-monitoring-reader
+          subjects:
+          - kind: ServiceAccount
+            name: managed-upgrade-operator
+            namespace: openshift-managed-upgrade-operator
+        - apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            name: muo-pullsecret-reader
+            namespace: openshift-config
+          roleRef:
+            kind: Role
+            name: muo-pullsecret-reader
+          subjects:
+          - kind: ServiceAccount
+            name: managed-upgrade-operator
+            namespace: openshift-managed-upgrade-operator
+  - apiVersion: hive.openshift.io/v1
+    kind: SelectorSyncSet
+    metadata:
+      name: sss-muo-vpce-east
+    spec:
+      clusterDeploymentSelector:
+        matchExpressions:
+        - key: api.openshift.com/fedramp
+          operator: In
+          values:
+          - "true"
+        - key: hive.openshift.io/cluster-region
+          operator: In
+          values:
+          - us-gov-east-1
+        - key: api.openshift.com/private-link
+          operator: In
+          values:
+          - "true"
+        - key: appsre-prod
+          operator: NotIn
+          values:
+          - "true"           
+        matchLabels:
+          api.openshift.com/managed: "true"
+      resourceApplyMode: Sync
+      resources:
+      - apiVersion: avo.openshift.io/v1alpha2
+        kind: VpcEndpoint
+        metadata:
+          name: managed-upgrade-operator
+          namespace: openshift-managed-upgrade-operator
+        spec:
+          serviceName: ${OCM_VPCE_SERVICE_NAME_EAST}
+          securityGroup:
+            ingressRules:
+              - fromPort: 443
+                toPort: 443
+                protocol: tcp
+          vpc:
+            autoDiscoverSubnets: true
+          customDns:
+            route53PrivateHostedZone:
+              autoDiscoverPrivateHostedZone: false
+              domainName: ${OCM_DOMAIN}
+              record:
+                hostname: ${OCM_HOSTNAME}
+                externalNameService:
+                  name: muo-vpce-svc
+  - apiVersion: hive.openshift.io/v1
+    kind: SelectorSyncSet
+    metadata:
+      name: sss-muo-vpce-west
+    spec:
+      clusterDeploymentSelector:
+        matchExpressions:
+        - key: api.openshift.com/fedramp
+          operator: In
+          values:
+          - "true"
+        - key: hive.openshift.io/cluster-region
+          operator: In
+          values:
+          - us-gov-west-1
+        - key: api.openshift.com/private-link
+          operator: In
+          values:
+          - "true"
+        - key: appsre-prod
+          operator: NotIn
+          values:
+          - "true"        
+        matchLabels:
+          api.openshift.com/managed: "true"
+      resourceApplyMode: Sync
+      resources:
+      - apiVersion: avo.openshift.io/v1alpha2
+        kind: VpcEndpoint
+        metadata:
+          name: managed-upgrade-operator
+          namespace: openshift-managed-upgrade-operator
+        spec:
+          serviceName: ${OCM_VPCE_SERVICE_NAME_WEST}
+          securityGroup:
+            ingressRules:
+              - fromPort: 443
+                toPort: 443
+                protocol: tcp
+          vpc:
+            autoDiscoverSubnets: true
+          customDns:
+            route53PrivateHostedZone:
+              autoDiscoverPrivateHostedZone: false
+              domainName: ${OCM_DOMAIN}
+              record:
+                hostname: ${OCM_HOSTNAME}
+                externalNameService:
+                  name: muo-vpce-svc
+  


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation/test/refactor)_

feature/refactor

### What this PR does / why we need it?

MUO in FedRAMP will need to communicate with OCM via Privatelink by way of using VPC Endpoints. We will be using the AWS VPCE Operator to facilitate those endpoints but the AVO CR's require FedRAMP sensitive data that we cannot put in a public Github repo. This PR adds a second template for use by FedRAMP that duplicates the existing template but adds the VpcEndpoint CR's and some new parameters so that we can pass them using the saas file in App Interface. 

### Which Jira/Github issue(s) this PR fixes?

For [OSD-19338](https://issues.redhat.com//browse/OSD-19338) and [SDE-3511](https://issues.redhat.com//browse/SDE-3511)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR

