### PR TITLE
[OSD-11675] Reset UpgradeNodeDrainFailed metric if drainStrategy is successfully executed

### DIFF
--- a/controllers/nodekeeper/nodekeeper_controller.go
+++ b/controllers/nodekeeper/nodekeeper_controller.go
@@ -123,6 +123,8 @@ func (r *ReconcileNodeKeeper) Reconcile(ctx context.Context, request reconcile.R
 			reqLogger.Info(fmt.Sprintf("Node drain timed out %s. Alerting.", node.Name))
 			metricsClient.UpdateMetricNodeDrainFailed(node.Name)
 			return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
+		} else {
+			metricsClient.ResetMetricNodeDrainFailed(node.Name)
 		}
 	}
 


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
Reset `UpgradeNodeDrainFailed` metric if `drainStrategy` is successfully executed for the node.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [OSD-11675](https://issues.redhat.com/browse/OSD-11675)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

