### PR TITLE
Increase ErrClusterIDNotFound verbosity

### DIFF
--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -32,7 +32,7 @@ var log = logf.Log.WithName("ocm-client")
 
 var (
 	// ErrClusterIdNotFound is an error describing the cluster ID can not be found
-	ErrClusterIdNotFound = fmt.Errorf("cluster ID can't be found")
+	ErrClusterIdNotFound = fmt.Errorf("OCM did not return a valid cluster ID: pull-secret may be invalid")
 )
 
 // OcmClient enables an implementation of an ocm client

--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -32,7 +32,7 @@ var log = logf.Log.WithName("ocm-client")
 
 var (
 	// ErrClusterIdNotFound is an error describing the cluster ID can not be found
-	ErrClusterIdNotFound = fmt.Errorf("OCM did not return a valid cluster ID: pull-secret may be invalid")
+	ErrClusterIdNotFound = fmt.Errorf("OCM did not return a valid cluster ID: pull-secret may be invalid OR cluster's owner is disabled/banned in OCM")
 )
 
 // OcmClient enables an implementation of an ocm client

--- a/pkg/ocmprovider/ocmprovider.go
+++ b/pkg/ocmprovider/ocmprovider.go
@@ -19,7 +19,6 @@ var log = logf.Log.WithName("ocm-config-getter")
 // Errors
 var (
 	ErrProviderUnavailable = fmt.Errorf("OCM Provider unavailable")
-	ErrClusterIdNotFound   = fmt.Errorf("cluster ID can't be found")
 	ErrRetrievingPolicies  = fmt.Errorf("could not retrieve provider upgrade policies")
 	ErrProcessingPolicies  = fmt.Errorf("could not process provider upgrade policies")
 )
@@ -64,7 +63,7 @@ func (s *ocmProvider) Get() ([]upgradev1alpha1.UpgradeConfigSpec, error) {
 	}
 	// In case a response was returned that has no cluster ID
 	if cluster.Id == "" {
-		return nil, ErrClusterIdNotFound
+		return nil, ocm.ErrClusterIdNotFound
 	}
 
 	// Retrieve the cluster's available upgrade policies from Cluster Services

--- a/pkg/ocmprovider/ocmprovider_test.go
+++ b/pkg/ocmprovider/ocmprovider_test.go
@@ -249,7 +249,7 @@ var _ = Describe("OCM Provider", func() {
 				mockOcmClient.EXPECT().GetCluster().Return(nil, ocm.ErrClusterIdNotFound),
 			)
 			specs, err := provider.Get()
-			Expect(err).To(Equal(ErrClusterIdNotFound))
+			Expect(err).To(Equal(ocm.ErrClusterIdNotFound))
 			Expect(specs).To(BeNil())
 		})
 


### PR DESCRIPTION
### What type of PR is this?
_cleanup_

### What this PR does / why we need it?
Increases the verbosity of the `ErrClusterIDNotFound` error message. 

Anecdotally, this error is thrown most often when MUO is unauthorized to lookup clusters in OCM. As it stands, the error gives no indication that the problem may be a pull-secret/authentication one; suggesting this within the operator short-circuits what can be otherwise lengthy investigations.

