### PR TITLE
Update contributing doc to use `make container-generate`

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,7 +18,7 @@ We recommend the following workflow when submitting change requests to this repo
 1. Fork the repository to your own account.
 2. Create a topic branch from the main branch.
 3. Make commits of logical units.
-4. If necessary, use `make generate` to update generated code.
+4. If necessary, use `make container-generate` to update generated code.
 5. Add or modify tests as needed. Ensure code has been [tested](testing.md) prior to PR.
 6. Push your changes to a topic branch in your fork of the repository.
 7. Submit a pull request to the original repository.


### PR DESCRIPTION
### What type of PR is this?
_(documentation)_

### What this PR does / why we need it?
Updates contributing doc to use `make container-generate`. The PR check runs `make container-validate`, which will sometimes fail if generated files are not up to date. 
### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

