### PR TITLE
OSD-22085: Send ServiceLog for alert and CO failure 

### DIFF
--- a/pkg/eventmanager/eventmanager.go
+++ b/pkg/eventmanager/eventmanager.go
@@ -31,6 +31,8 @@ const (
 	UPGRADE_SCALE_DELAY_DESC = "Cluster upgrade to version %s is experiencing a delay attempting to scale up an additional worker node. The upgrade will continue to retry. This is an informational notification and no action is required by you"
 	// UPGRADE_SCALE_DELAY_SKIP_DESC describes the upgrade scaling skipped after delay
 	UPGRADE_SCALE_DELAY_SKIP_DESC = "Cluster upgrade to version %s has experienced an issue during capacity reservation efforts. This could be caused by cloud service provider quota limitations or temporary connectivity issues to/from the new worker node. The upgrade will continue without extra compute. This is an informational notification and no action is required by you"
+	// UPGRADE_PREHEALTHCHECK_CO_DOWN_DELAY_DESC describes the upgrade pre health check delay
+	UPGRADE_PREHEALTHCHECK_CO_DOWN_DELAY_DESC = "Cluster upgrade to version %s is experiencing a delay as cluster operators are down in the cluster which could impact the upgrade's operation. The upgrade will continue to retry. This is an informational notification and no action is required by you"
 )
 
 // EventManager enables implementation of an EventManager
@@ -117,8 +119,10 @@ func (s *eventManager) Notify(state notifier.MuoState) error {
 		description = fmt.Sprintf("Cluster has been successfully upgraded to version %s", uc.Spec.Desired.Version)
 	case notifier.MuoStateFailed:
 		description = createFailureDescription(uc)
-	case notifier.MuoStateCancelled:
-		description = createFailureDescription(uc)
+	case notifier.MuoStateAlertsHealthCheckFailed:
+		description = fmt.Sprintf(UPGRADE_PREHEALTHCHECK_DELAY_DESC, uc.Spec.Desired.Version)
+	case notifier.MuoStateCOHealthCheckFailed:
+		description = fmt.Sprintf(UPGRADE_PREHEALTHCHECK_CO_DOWN_DELAY_DESC, uc.Spec.Desired.Version)
 	default:
 		return fmt.Errorf("state %v not yet implemented", state)
 	}

--- a/pkg/eventmanager/eventmanager.go
+++ b/pkg/eventmanager/eventmanager.go
@@ -31,8 +31,8 @@ const (
 	UPGRADE_SCALE_DELAY_DESC = "Cluster upgrade to version %s is experiencing a delay attempting to scale up an additional worker node. The upgrade will continue to retry. This is an informational notification and no action is required by you"
 	// UPGRADE_SCALE_DELAY_SKIP_DESC describes the upgrade scaling skipped after delay
 	UPGRADE_SCALE_DELAY_SKIP_DESC = "Cluster upgrade to version %s has experienced an issue during capacity reservation efforts. This could be caused by cloud service provider quota limitations or temporary connectivity issues to/from the new worker node. The upgrade will continue without extra compute. This is an informational notification and no action is required by you"
-	// UPGRADE_PREHEALTHCHECK_CO_DOWN_DELAY_DESC describes the upgrade pre health check delay
-	UPGRADE_PREHEALTHCHECK_CO_DOWN_DELAY_DESC = "Cluster upgrade to version %s is experiencing a delay as cluster operators are down in the cluster which could impact the upgrade's operation. The upgrade will continue to retry. This is an informational notification and no action is required by you"
+	// UPGRADE_HEALTHCHECK_DELAY_DESC describes the upgrade pre health check delay
+	UPGRADE_HEALTHCHECK_DELAY_DESC = "Cluster upgrade to version %s is experiencing a delay in the cluster which could impact the upgrade's operation. The upgrade will continue to retry. This is an informational notification and no action is required by you"
 )
 
 // EventManager enables implementation of an EventManager
@@ -119,10 +119,8 @@ func (s *eventManager) Notify(state notifier.MuoState) error {
 		description = fmt.Sprintf("Cluster has been successfully upgraded to version %s", uc.Spec.Desired.Version)
 	case notifier.MuoStateFailed:
 		description = createFailureDescription(uc)
-	case notifier.MuoStateAlertsHealthCheckFailed:
-		description = fmt.Sprintf(UPGRADE_PREHEALTHCHECK_DELAY_DESC, uc.Spec.Desired.Version)
-	case notifier.MuoStateCOHealthCheckFailed:
-		description = fmt.Sprintf(UPGRADE_PREHEALTHCHECK_CO_DOWN_DELAY_DESC, uc.Spec.Desired.Version)
+	case notifier.MuoStateHealthCheck:
+		description = fmt.Sprintf(UPGRADE_HEALTHCHECK_DELAY_DESC, uc.Spec.Desired.Version)
 	default:
 		return fmt.Errorf("state %v not yet implemented", state)
 	}

--- a/pkg/eventmanager/eventmanager.go
+++ b/pkg/eventmanager/eventmanager.go
@@ -32,7 +32,7 @@ const (
 	// UPGRADE_SCALE_DELAY_SKIP_DESC describes the upgrade scaling skipped after delay
 	UPGRADE_SCALE_DELAY_SKIP_DESC = "Cluster upgrade to version %s has experienced an issue during capacity reservation efforts. This could be caused by cloud service provider quota limitations or temporary connectivity issues to/from the new worker node. The upgrade will continue without extra compute. This is an informational notification and no action is required by you"
 	// UPGRADE_HEALTHCHECK_DELAY_DESC describes the upgrade pre health check delay
-	UPGRADE_HEALTHCHECK_DELAY_DESC = "Cluster upgrade to version %s is experiencing a delay in the cluster which could impact the upgrade's operation. The upgrade will continue to retry. This is an informational notification and no action is required by you"
+	UPGRADE_HEALTHCHECK_DELAY_DESC = "Cluster upgrade to version %s is experiencing a delay which could impact the upgrade's operation. The upgrade will continue to retry. This is an informational notification and no action is required by you"
 )
 
 // EventManager enables implementation of an EventManager

--- a/pkg/eventmanager/eventmanager.go
+++ b/pkg/eventmanager/eventmanager.go
@@ -117,6 +117,8 @@ func (s *eventManager) Notify(state notifier.MuoState) error {
 		description = fmt.Sprintf("Cluster has been successfully upgraded to version %s", uc.Spec.Desired.Version)
 	case notifier.MuoStateFailed:
 		description = createFailureDescription(uc)
+	case notifier.MuoStateCancelled:
+		description = createFailureDescription(uc)
 	default:
 		return fmt.Errorf("state %v not yet implemented", state)
 	}

--- a/pkg/eventmanager/eventmanager_test.go
+++ b/pkg/eventmanager/eventmanager_test.go
@@ -322,9 +322,9 @@ var _ = Describe("OCM Notifier", func() {
 
 	})
 
-	Context("When notifying a MuoStateAlertsHealthCheckFailed state", func() {
+	Context("When notifying a MuoStateHealthCheck state", func() {
 		var uc upgradev1alpha1.UpgradeConfig
-		var testState = notifier.MuoStateAlertsHealthCheckFailed
+		var testState = notifier.MuoStateHealthCheck
 		BeforeEach(func() {
 			upgradeConfigName = types.NamespacedName{
 				Name:      TEST_UPGRADECONFIG_CR,
@@ -349,32 +349,6 @@ var _ = Describe("OCM Notifier", func() {
 			})
 		})
 	})
-	Context("When notifying a MuoStateCOHealthCheckFailed state", func() {
-		var uc upgradev1alpha1.UpgradeConfig
-		var testState = notifier.MuoStateCOHealthCheckFailed
-		BeforeEach(func() {
-			upgradeConfigName = types.NamespacedName{
-				Name:      TEST_UPGRADECONFIG_CR,
-				Namespace: TEST_OPERATOR_NAMESPACE,
-			}
-			uc = *testStructs.NewUpgradeConfigBuilder().WithNamespacedName(upgradeConfigName).WithPhase(upgradev1alpha1.UpgradePhaseUpgrading).GetUpgradeConfig()
-			uc.Spec.Desired.Version = TEST_UPGRADE_VERSION
-			uc.Status.History[0].Version = TEST_UPGRADE_VERSION
-			uc.Spec.UpgradeAt = TEST_UPGRADE_TIME
-		})
-		Context("when the upgrade is MuoStateCOHealthCheckFailed", func() {
-			It("sends a correct notification and description", func() {
-				expectedDescription := fmt.Sprintf(UPGRADE_PREHEALTHCHECK_CO_DOWN_DELAY_DESC, uc.Spec.Desired.Version)
-				gomock.InOrder(
-					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
-					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION).Return(false, nil),
-					mockNotifier.EXPECT().NotifyState(testState, expectedDescription),
-					mockMetricsClient.EXPECT().UpdateMetricNotificationEventSent(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION),
-				)
-				err := manager.Notify(testState)
-				Expect(err).To(BeNil())
-			})
-		})
-	})
+
 
 })

--- a/pkg/eventmanager/eventmanager_test.go
+++ b/pkg/eventmanager/eventmanager_test.go
@@ -335,9 +335,9 @@ var _ = Describe("OCM Notifier", func() {
 			uc.Status.History[0].Version = TEST_UPGRADE_VERSION
 			uc.Spec.UpgradeAt = TEST_UPGRADE_TIME
 		})
-		Context("when the upgrade is MuoStateAlertsHealthCheckFailed", func() {
+		Context("when the upgrade is Alerts Health Check Failed", func() {
 			It("sends a correct notification and description", func() {
-				expectedDescription := fmt.Sprintf(UPGRADE_PREHEALTHCHECK_DELAY_DESC, uc.Spec.Desired.Version)
+				expectedDescription := fmt.Sprintf(UPGRADE_HEALTHCHECK_DELAY_DESC, uc.Spec.Desired.Version)
 				gomock.InOrder(
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION).Return(false, nil),

--- a/pkg/eventmanager/eventmanager_test.go
+++ b/pkg/eventmanager/eventmanager_test.go
@@ -322,4 +322,59 @@ var _ = Describe("OCM Notifier", func() {
 
 	})
 
+	Context("When notifying a MuoStateAlertsHealthCheckFailed state", func() {
+		var uc upgradev1alpha1.UpgradeConfig
+		var testState = notifier.MuoStateAlertsHealthCheckFailed
+		BeforeEach(func() {
+			upgradeConfigName = types.NamespacedName{
+				Name:      TEST_UPGRADECONFIG_CR,
+				Namespace: TEST_OPERATOR_NAMESPACE,
+			}
+			uc = *testStructs.NewUpgradeConfigBuilder().WithNamespacedName(upgradeConfigName).WithPhase(upgradev1alpha1.UpgradePhaseUpgrading).GetUpgradeConfig()
+			uc.Spec.Desired.Version = TEST_UPGRADE_VERSION
+			uc.Status.History[0].Version = TEST_UPGRADE_VERSION
+			uc.Spec.UpgradeAt = TEST_UPGRADE_TIME
+		})
+		Context("when the upgrade is MuoStateAlertsHealthCheckFailed", func() {
+			It("sends a correct notification and description", func() {
+				expectedDescription := fmt.Sprintf(UPGRADE_PREHEALTHCHECK_DELAY_DESC, uc.Spec.Desired.Version)
+				gomock.InOrder(
+					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
+					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION).Return(false, nil),
+					mockNotifier.EXPECT().NotifyState(testState, expectedDescription),
+					mockMetricsClient.EXPECT().UpdateMetricNotificationEventSent(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION),
+				)
+				err := manager.Notify(testState)
+				Expect(err).To(BeNil())
+			})
+		})
+	})
+	Context("When notifying a MuoStateCOHealthCheckFailed state", func() {
+		var uc upgradev1alpha1.UpgradeConfig
+		var testState = notifier.MuoStateCOHealthCheckFailed
+		BeforeEach(func() {
+			upgradeConfigName = types.NamespacedName{
+				Name:      TEST_UPGRADECONFIG_CR,
+				Namespace: TEST_OPERATOR_NAMESPACE,
+			}
+			uc = *testStructs.NewUpgradeConfigBuilder().WithNamespacedName(upgradeConfigName).WithPhase(upgradev1alpha1.UpgradePhaseUpgrading).GetUpgradeConfig()
+			uc.Spec.Desired.Version = TEST_UPGRADE_VERSION
+			uc.Status.History[0].Version = TEST_UPGRADE_VERSION
+			uc.Spec.UpgradeAt = TEST_UPGRADE_TIME
+		})
+		Context("when the upgrade is MuoStateCOHealthCheckFailed", func() {
+			It("sends a correct notification and description", func() {
+				expectedDescription := fmt.Sprintf(UPGRADE_PREHEALTHCHECK_CO_DOWN_DELAY_DESC, uc.Spec.Desired.Version)
+				gomock.InOrder(
+					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
+					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION).Return(false, nil),
+					mockNotifier.EXPECT().NotifyState(testState, expectedDescription),
+					mockMetricsClient.EXPECT().UpdateMetricNotificationEventSent(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION),
+				)
+				err := manager.Notify(testState)
+				Expect(err).To(BeNil())
+			})
+		})
+	})
+
 })

--- a/pkg/notifier/notifier.go
+++ b/pkg/notifier/notifier.go
@@ -27,16 +27,15 @@ type NotifierBuilder interface {
 
 // Represents valid notify states that can be reported
 const (
-	MuoStatePending                 MuoState = "StatePending"
-	MuoStateStarted                 MuoState = "StateStarted"
-	MuoStateCompleted               MuoState = "StateCompleted"
-	MuoStateDelayed                 MuoState = "StateDelayed"
-	MuoStateFailed                  MuoState = "StateFailed"
-	MuoStateCancelled               MuoState = "StateCancelled"
-	MuoStateScheduled               MuoState = "StateScheduled"
-	MuoStateSkipped                 MuoState = "StateSkipped"
-	MuoStateAlertsHealthCheckFailed MuoState = "MuoStateAlertsHealthCheckFailed"
-	MuoStateCOHealthCheckFailed     MuoState = "MuoStateCOHealthCheckFailed"
+	MuoStatePending     MuoState = "StatePending"
+	MuoStateStarted     MuoState = "StateStarted"
+	MuoStateCompleted   MuoState = "StateCompleted"
+	MuoStateDelayed     MuoState = "StateDelayed"
+	MuoStateFailed      MuoState = "StateFailed"
+	MuoStateCancelled   MuoState = "StateCancelled"
+	MuoStateScheduled   MuoState = "StateScheduled"
+	MuoStateSkipped     MuoState = "StateSkipped"
+	MuoStateHealthCheck MuoState = "StateHealthCheck"
 )
 
 // MuoState is a type

--- a/pkg/notifier/notifier.go
+++ b/pkg/notifier/notifier.go
@@ -12,12 +12,14 @@ import (
 )
 
 // Notifier is an interface that enables implementation of a Notifier
+//
 //go:generate mockgen -destination=mocks/notifier.go -package=mocks github.com/openshift/managed-upgrade-operator/pkg/notifier Notifier
 type Notifier interface {
 	NotifyState(value MuoState, description string) error
 }
 
 // NotifierBuilder is an interface that enables implementation of a NotifierBuilder
+//
 //go:generate mockgen -destination=mocks/notifier_builder.go -package=mocks github.com/openshift/managed-upgrade-operator/pkg/notifier NotifierBuilder
 type NotifierBuilder interface {
 	New(client.Client, configmanager.ConfigManagerBuilder, upgradeconfigmanager.UpgradeConfigManagerBuilder) (Notifier, error)
@@ -25,14 +27,16 @@ type NotifierBuilder interface {
 
 // Represents valid notify states that can be reported
 const (
-	MuoStatePending   MuoState = "StatePending"
-	MuoStateStarted   MuoState = "StateStarted"
-	MuoStateCompleted MuoState = "StateCompleted"
-	MuoStateDelayed   MuoState = "StateDelayed"
-	MuoStateFailed    MuoState = "StateFailed"
-	MuoStateCancelled MuoState = "StateCancelled"
-	MuoStateScheduled MuoState = "StateScheduled"
-	MuoStateSkipped   MuoState = "StateSkipped"
+	MuoStatePending                 MuoState = "StatePending"
+	MuoStateStarted                 MuoState = "StateStarted"
+	MuoStateCompleted               MuoState = "StateCompleted"
+	MuoStateDelayed                 MuoState = "StateDelayed"
+	MuoStateFailed                  MuoState = "StateFailed"
+	MuoStateCancelled               MuoState = "StateCancelled"
+	MuoStateScheduled               MuoState = "StateScheduled"
+	MuoStateSkipped                 MuoState = "StateSkipped"
+	MuoStateAlertsHealthCheckFailed MuoState = "MuoStateAlertsHealthCheckFailed"
+	MuoStateCOHealthCheckFailed     MuoState = "MuoStateCOHealthCheckFailed"
 )
 
 // MuoState is a type

--- a/pkg/notifier/ocmnotifier.go
+++ b/pkg/notifier/ocmnotifier.go
@@ -16,10 +16,10 @@ import (
 func NewOCMNotifier(client client.Client, ocmBaseUrl *url.URL, upgradeConfigManager upgradeconfigmanager.UpgradeConfigManager) (*ocmNotifier, error) {
 	var (
 		ocmClient ocm.OcmClient
-		err error
+		err       error
 	)
 
-	if (strings.Contains(ocmBaseUrl.String(), fmt.Sprintf("%s:%d", ocmagent.OCM_AGENT_SERVICE_URL, ocmagent.OCM_AGENT_SERVICE_PORT))) {
+	if strings.Contains(ocmBaseUrl.String(), fmt.Sprintf("%s:%d", ocmagent.OCM_AGENT_SERVICE_URL, ocmagent.OCM_AGENT_SERVICE_PORT)) {
 		ocmClient, err = ocmagent.NewBuilder().New(ocmBaseUrl)
 	} else {
 		ocmClient, err = ocm.NewBuilder().New(client, ocmBaseUrl)
@@ -48,14 +48,16 @@ const (
 )
 
 var stateMap = map[MuoState]OcmState{
-	MuoStatePending:   OcmStatePending,
-	MuoStateCancelled: OcmStateCancelled,
-	MuoStateStarted:   OcmStateStarted,
-	MuoStateCompleted: OcmStateCompleted,
-	MuoStateDelayed:   OcmStateDelayed,
-	MuoStateFailed:    OcmStateFailed,
-	MuoStateScheduled: OcmStateScheduled,
-	MuoStateSkipped:   OcmStateDelayed,
+	MuoStatePending:                 OcmStatePending,
+	MuoStateCancelled:               OcmStateCancelled,
+	MuoStateStarted:                 OcmStateStarted,
+	MuoStateCompleted:               OcmStateCompleted,
+	MuoStateDelayed:                 OcmStateDelayed,
+	MuoStateFailed:                  OcmStateFailed,
+	MuoStateScheduled:               OcmStateScheduled,
+	MuoStateSkipped:                 OcmStateDelayed,
+	MuoStateCOHealthCheckFailed:     OcmStateDelayed,
+	MuoStateAlertsHealthCheckFailed: OcmStateDelayed,
 }
 
 type ocmNotifier struct {
@@ -168,6 +170,10 @@ func validateStateTransition(from MuoState, to MuoState) bool {
 		case MuoStateCompleted:
 			return true
 		case MuoStateFailed:
+			return true
+		case MuoStateCOHealthCheckFailed:
+			return true
+		case MuoStateAlertsHealthCheckFailed:
 			return true
 		default:
 			return false

--- a/pkg/notifier/ocmnotifier.go
+++ b/pkg/notifier/ocmnotifier.go
@@ -48,16 +48,15 @@ const (
 )
 
 var stateMap = map[MuoState]OcmState{
-	MuoStatePending:                 OcmStatePending,
-	MuoStateCancelled:               OcmStateCancelled,
-	MuoStateStarted:                 OcmStateStarted,
-	MuoStateCompleted:               OcmStateCompleted,
-	MuoStateDelayed:                 OcmStateDelayed,
-	MuoStateFailed:                  OcmStateFailed,
-	MuoStateScheduled:               OcmStateScheduled,
-	MuoStateSkipped:                 OcmStateDelayed,
-	MuoStateCOHealthCheckFailed:     OcmStateDelayed,
-	MuoStateAlertsHealthCheckFailed: OcmStateDelayed,
+	MuoStatePending:     OcmStatePending,
+	MuoStateCancelled:   OcmStateCancelled,
+	MuoStateStarted:     OcmStateStarted,
+	MuoStateCompleted:   OcmStateCompleted,
+	MuoStateDelayed:     OcmStateDelayed,
+	MuoStateFailed:      OcmStateFailed,
+	MuoStateScheduled:   OcmStateScheduled,
+	MuoStateSkipped:     OcmStateDelayed,
+	MuoStateHealthCheck: OcmStateDelayed,
 }
 
 type ocmNotifier struct {
@@ -171,9 +170,7 @@ func validateStateTransition(from MuoState, to MuoState) bool {
 			return true
 		case MuoStateFailed:
 			return true
-		case MuoStateCOHealthCheckFailed:
-			return true
-		case MuoStateAlertsHealthCheckFailed:
+		case MuoStateHealthCheck:
 			return true
 		default:
 			return false

--- a/pkg/upgraders/healthcheckstep.go
+++ b/pkg/upgraders/healthcheckstep.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-logr/logr"
 
 	upgradev1alpha1 "github.com/openshift/managed-upgrade-operator/api/v1alpha1"
+	"github.com/openshift/managed-upgrade-operator/pkg/notifier"
 )
 
 // PreUpgradeHealthCheck performs cluster healthy check
@@ -24,12 +25,16 @@ func (c *clusterUpgrader) PreUpgradeHealthCheck(ctx context.Context, logger logr
 	if err != nil || !ok {
 		return false, err
 	}
+	c.notifier.Notify(notifier.MuoStateCancelled)
+	logger.Info("CriticalAlerts check completed")
 
 	ok, err = ClusterOperators(c.metrics, c.cvClient, c.upgradeConfig, logger)
 	if err != nil || !ok {
 		return false, err
 	}
 	c.metrics.UpdateMetricHealthcheckSucceeded(c.upgradeConfig.Name)
+
+	//c.notifier.Notify(notifier.MuoStateCancelled)
 	return true, nil
 }
 

--- a/pkg/upgraders/healthcheckstep.go
+++ b/pkg/upgraders/healthcheckstep.go
@@ -23,19 +23,20 @@ func (c *clusterUpgrader) PreUpgradeHealthCheck(ctx context.Context, logger logr
 
 	ok, err := CriticalAlerts(c.metrics, c.config, c.upgradeConfig, logger)
 	if err != nil || !ok {
-		c.notifier.Notify(notifier.MuoStateCancelled)
-		logger.Info("upgrade cancelled")
+		c.notifier.Notify(notifier.MuoStateAlertsHealthCheckFailed)
+		logger.Info("upgrade cancelled due to firing critical alerts")
 		return false, err
 	}
 	logger.Info("CriticalAlerts check completed")
 
 	ok, err = ClusterOperators(c.metrics, c.cvClient, c.upgradeConfig, logger)
 	if err != nil || !ok {
+		c.notifier.Notify(notifier.MuoStateCOHealthCheckFailed)
+		logger.Info("upgrade cancelled due to cluster operators not ready")
 		return false, err
 	}
 	c.metrics.UpdateMetricHealthcheckSucceeded(c.upgradeConfig.Name)
 
-	//c.notifier.Notify(notifier.MuoStateCancelled)
 	return true, nil
 }
 

--- a/pkg/upgraders/healthcheckstep.go
+++ b/pkg/upgraders/healthcheckstep.go
@@ -23,16 +23,15 @@ func (c *clusterUpgrader) PreUpgradeHealthCheck(ctx context.Context, logger logr
 
 	ok, err := CriticalAlerts(c.metrics, c.config, c.upgradeConfig, logger)
 	if err != nil || !ok {
-		c.notifier.Notify(notifier.MuoStateAlertsHealthCheckFailed)
-		logger.Info("upgrade cancelled due to firing critical alerts")
+		c.notifier.Notify(notifier.MuoStateHealthCheck)
+		logger.Info("upgrade delayed due to firing critical alerts")
 		return false, err
 	}
-	logger.Info("CriticalAlerts check completed")
 
 	ok, err = ClusterOperators(c.metrics, c.cvClient, c.upgradeConfig, logger)
 	if err != nil || !ok {
-		c.notifier.Notify(notifier.MuoStateCOHealthCheckFailed)
-		logger.Info("upgrade cancelled due to cluster operators not ready")
+		c.notifier.Notify(notifier.MuoStateHealthCheck)
+		logger.Info("upgrade delayed due to cluster operators not ready")
 		return false, err
 	}
 	c.metrics.UpdateMetricHealthcheckSucceeded(c.upgradeConfig.Name)

--- a/pkg/upgraders/healthcheckstep.go
+++ b/pkg/upgraders/healthcheckstep.go
@@ -23,9 +23,10 @@ func (c *clusterUpgrader) PreUpgradeHealthCheck(ctx context.Context, logger logr
 
 	ok, err := CriticalAlerts(c.metrics, c.config, c.upgradeConfig, logger)
 	if err != nil || !ok {
+		c.notifier.Notify(notifier.MuoStateCancelled)
+		logger.Info("upgrade cancelled")
 		return false, err
 	}
-	c.notifier.Notify(notifier.MuoStateCancelled)
 	logger.Info("CriticalAlerts check completed")
 
 	ok, err = ClusterOperators(c.metrics, c.cvClient, c.upgradeConfig, logger)

--- a/pkg/upgraders/healthcheckstep.go
+++ b/pkg/upgraders/healthcheckstep.go
@@ -23,15 +23,21 @@ func (c *clusterUpgrader) PreUpgradeHealthCheck(ctx context.Context, logger logr
 
 	ok, err := CriticalAlerts(c.metrics, c.config, c.upgradeConfig, logger)
 	if err != nil || !ok {
-		c.notifier.Notify(notifier.MuoStateHealthCheck)
 		logger.Info("upgrade delayed due to firing critical alerts")
+		errResult := c.notifier.Notify(notifier.MuoStateHealthCheck)
+		if errResult != nil {
+			err = errResult
+		}
 		return false, err
 	}
 
 	ok, err = ClusterOperators(c.metrics, c.cvClient, c.upgradeConfig, logger)
 	if err != nil || !ok {
-		c.notifier.Notify(notifier.MuoStateHealthCheck)
 		logger.Info("upgrade delayed due to cluster operators not ready")
+		errResult := c.notifier.Notify(notifier.MuoStateHealthCheck)
+		if errResult != nil {
+			err = errResult
+		}
 		return false, err
 	}
 	c.metrics.UpdateMetricHealthcheckSucceeded(c.upgradeConfig.Name)

--- a/pkg/upgraders/healthcheckstep_test.go
+++ b/pkg/upgraders/healthcheckstep_test.go
@@ -196,6 +196,7 @@ var _ = Describe("HealthCheck Step", func() {
 					mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(false, nil),
 					mockMetricsClient.EXPECT().Query(gomock.Any()).Return(alertsResponse, nil),
 					mockMetricsClient.EXPECT().UpdateMetricHealthcheckFailed(upgradeConfig.Name, gomock.Any()),
+					mockEMClient.EXPECT().Notify(gomock.Any()).Return(nil),
 				)
 				result, err := upgrader.PreUpgradeHealthCheck(context.TODO(), logger)
 				Expect(err).To(HaveOccurred())
@@ -224,6 +225,7 @@ var _ = Describe("HealthCheck Step", func() {
 					mockMetricsClient.EXPECT().Query(gomock.Any()).Return(alertsResponse, nil),
 					mockCVClient.EXPECT().HasDegradedOperators().Return(&clusterversion.HasDegradedOperatorsResult{Degraded: []string{"ClusterOperator"}}, nil),
 					mockMetricsClient.EXPECT().UpdateMetricHealthcheckFailed(upgradeConfig.Name, gomock.Any()),
+					mockEMClient.EXPECT().Notify(gomock.Any()).Return(nil),
 				)
 				result, err := upgrader.PreUpgradeHealthCheck(context.TODO(), logger)
 				Expect(err).To(HaveOccurred())


### PR DESCRIPTION
### What type of PR is this?
feature


### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

[OSD-22085](https://issues.redhat.com//browse/OSD-22085)

### Special notes for your reviewer:

### Pre-checks (if applicable):


-  Tested latest changes against a cluster

Received this SL when critical alert UpgradeConfigSyncFailureOver4HrSRE was firing. 
<img width="719" alt="Screenshot 2024-05-29 at 3 30 03 PM" src="https://github.com/openshift/managed-upgrade-operator/assets/113415183/1e286aa9-9769-4a1d-8bc2-d834c86cd3a0">



