### PR TITLE
Integrating Pre-HealthCheck with UpgradeConfig controller

### DIFF
--- a/api/v1alpha1/upgradeconfig_types.go
+++ b/api/v1alpha1/upgradeconfig_types.go
@@ -35,6 +35,14 @@ type UpgradeConfigSpec struct {
 
 	// Specify if scaling up an extra node for capacity reservation before upgrade starts is needed
 	CapacityReservation bool `json:"capacityReservation,omitempty"`
+
+	// +kubebuilder:validation:Minimum:=2
+	// +kubebuilder:validation:Default:=2
+	// +kubebuilder:default:=2
+	// +kubebuilder:validation:Optional
+	// HealthCheckDuration specifies minimum duration of 2 hours before upgrade time to run healthcheck.
+	// If an upgrade is scheduled within 2 hours from now, healthcheck won't run.
+	HealthCheckDuration int32 `json:"HealthCheckDuration,omitempty"`
 }
 
 // UpgradeConfigStatus defines the observed state of UpgradeConfig
@@ -177,6 +185,17 @@ type UpgradeConfig struct {
 // GetPDBDrainTimeoutDuration returns the PDB timeout
 func (uc *UpgradeConfig) GetPDBDrainTimeoutDuration() time.Duration {
 	return time.Duration(uc.Spec.PDBForceDrainTimeout) * time.Minute
+}
+
+// GetHealthCheckDuration returns the duration to perform HealthCheck in hours
+func (uc *UpgradeConfig) GetHealthCheckDuration() time.Duration {
+	hcTime := uc.Spec.HealthCheckDuration
+
+	if hcTime == 0 {
+		return time.Duration(time.Hour * 2)
+	}
+
+	return time.Duration(uc.Spec.HealthCheckDuration) * time.Hour * time.Duration(hcTime)
 }
 
 // +kubebuilder:object:root=true

--- a/controllers/upgradeconfig/upgradeconfig_controller.go
+++ b/controllers/upgradeconfig/upgradeconfig_controller.go
@@ -153,11 +153,22 @@ func (r *ReconcileUpgradeConfig) Reconcile(ctx context.Context, request reconcil
 	// in "New" phase and move to "Pending" phase once healthcheck
 	// is done.
 	case upgradev1alpha1.UpgradePhaseNew:
-		reqLogger.Info("Running Pre-Health Check for upgrade")
 
-		result, err := upgrader.HealthCheck(ctx, instance, reqLogger)
-		if err != nil || !result {
-			return reconcile.Result{}, err
+		schedulerResult := r.Scheduler.IsReadyToUpgrade(instance, cfg.GetUpgradeWindowTimeOutDuration())
+		timeToUpgrade := schedulerResult.TimeUntilUpgrade.Minutes()
+		healthCheckDuration := instance.GetHealthCheckDuration().Minutes()
+		if time.Duration(timeToUpgrade) > time.Duration(healthCheckDuration) {
+			reqLogger.Info("Running Pre-Health Check for upgrade")
+			// We do not block the upgrade from going to pending state deliberately
+			// since we want to notify and give a heads up regarding pre healthcheck
+			// failure which can be fixed before actual upgrade starts. During the upgrade
+			// time, the pre healthcheck will run again and catch any failures as such.
+			result, err := upgrader.HealthCheck(ctx, instance, reqLogger)
+			if err != nil || !result {
+				reqLogger.Error(err, "Pre HealthCheck failed on scheduling upgrade")
+			}
+		} else {
+			reqLogger.Info("Skipping pre healthcheck")
 		}
 
 		history.Phase = upgradev1alpha1.UpgradePhasePending
@@ -258,18 +269,6 @@ func (r *ReconcileUpgradeConfig) Reconcile(ctx context.Context, request reconcil
 
 	case upgradev1alpha1.UpgradePhaseUpgrading:
 		reqLogger.Info("Cluster detected as already upgrading.")
-
-		target := muocfg.CMTarget{Namespace: request.Namespace}
-		cmTarget, err := target.NewCMTarget()
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-
-		cfm := r.ConfigManagerBuilder.New(r.Client, cmTarget)
-		upgrader, err := r.ClusterUpgraderBuilder.NewClient(r.Client, cfm, metricsClient, eventClient, instance.Spec.Type)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
 		return r.upgradeCluster(upgrader, instance, reqLogger)
 	case upgradev1alpha1.UpgradePhaseUpgraded:
 		reqLogger.Info("Cluster is already upgraded")

--- a/controllers/upgradeconfig/upgradeconfig_controller.go
+++ b/controllers/upgradeconfig/upgradeconfig_controller.go
@@ -233,6 +233,12 @@ func (r *ReconcileUpgradeConfig) Reconcile(ctx context.Context, request reconcil
 
 			if remoteChanged {
 				reqLogger.Info("The cluster's upgrade policy has changed, so the operator will re-reconcile.")
+				history.Phase = upgradev1alpha1.UpgradePhaseNew
+				instance.Status.History.SetHistory(*history)
+				err = r.Client.Status().Update(context.TODO(), instance)
+				if err != nil {
+					return reconcile.Result{}, err
+				}
 				return reconcile.Result{}, nil
 			}
 

--- a/controllers/upgradeconfig/upgradeconfig_controller.go
+++ b/controllers/upgradeconfig/upgradeconfig_controller.go
@@ -126,21 +126,57 @@ func (r *ReconcileUpgradeConfig) Reconcile(ctx context.Context, request reconcil
 		}
 	}
 
+	// Set up the ConfigManager and load MUO config
+	target := muocfg.CMTarget{Namespace: request.Namespace}
+	cmTarget, err := target.NewCMTarget()
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	cfm := r.ConfigManagerBuilder.New(r.Client, cmTarget)
+	cfg := &config{}
+
+	upgrader, err := r.ClusterUpgraderBuilder.NewClient(r.Client, cfm, metricsClient, eventClient, instance.Spec.Type)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	status := history.Phase
 	reqLogger.Info("Current cluster status", "status", status)
-	switch status {
-	case upgradev1alpha1.UpgradePhaseNew, upgradev1alpha1.UpgradePhasePending:
-		reqLogger.Info("Validating UpgradeConfig")
 
-		// Set up the ConfigManager and load MUO config
-		target := muocfg.CMTarget{Namespace: request.Namespace}
-		cmTarget, err := target.NewCMTarget()
+	switch status {
+
+	// "New" UpgradePhase is when an upgrade is scheduled.
+	//
+	// Since we want to run the pre healthcheck only once and not
+	// want to run it for every reconcile, we run the healthcheck
+	// in "New" phase and move to "Pending" phase once healthcheck
+	// is done.
+	case upgradev1alpha1.UpgradePhaseNew:
+		reqLogger.Info("Running Pre-Health Check for upgrade")
+
+		result, err := upgrader.HealthCheck(ctx, instance, reqLogger)
+		if err != nil || !result {
+			return reconcile.Result{}, err
+		}
+
+		history.Phase = upgradev1alpha1.UpgradePhasePending
+		instance.Status.History.SetHistory(*history)
+		err = r.Client.Status().Update(context.TODO(), instance)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
 
-		cfm := r.ConfigManagerBuilder.New(r.Client, cmTarget)
-		cfg := &config{}
+		return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
+
+	// "Pending" UpgradePhase is when an upgrade is scheduled but waiting to start.
+	//
+	// This phase validates the UpgradeConfig and checks if the upgrade is ready to
+	// begin or not. When it is ready to begin, it will sync the latest changes from
+	// configmanager (as relevant) and proceed to "Upgrading" phase.
+	case upgradev1alpha1.UpgradePhasePending:
+		reqLogger.Info("Validating UpgradeConfig")
+
 		err = cfm.Into(cfg)
 		if err != nil {
 			return reconcile.Result{}, err
@@ -187,12 +223,6 @@ func (r *ReconcileUpgradeConfig) Reconcile(ctx context.Context, request reconcil
 			if remoteChanged {
 				reqLogger.Info("The cluster's upgrade policy has changed, so the operator will re-reconcile.")
 				return reconcile.Result{}, nil
-			}
-
-			upgrader, err := r.ClusterUpgraderBuilder.NewClient(r.Client, cfm, metricsClient, eventClient, instance.Spec.Type)
-
-			if err != nil {
-				return reconcile.Result{}, err
 			}
 
 			now := time.Now()

--- a/deploy/crds/upgrade.managed.openshift.io_upgradeconfigs.yaml
+++ b/deploy/crds/upgrade.managed.openshift.io_upgradeconfigs.yaml
@@ -61,6 +61,14 @@ spec:
             description: UpgradeConfigSpec defines the desired state of UpgradeConfig
               and upgrade window and freeze window
             properties:
+              HealthCheckDuration:
+                default: 2
+                description: |-
+                  HealthCheckDuration specifies minimum duration of 2 hours before upgrade time to run healthcheck.
+                  If an upgrade is scheduled within 2 hours from now, healthcheck won't run.
+                format: int32
+                minimum: 2
+                type: integer
               PDBForceDrainTimeout:
                 description: The maximum grace period granted to a node whose drain
                   is blocked by a Pod Disruption Budget, before that drain is forced.

--- a/pkg/upgraders/aroupgrader.go
+++ b/pkg/upgraders/aroupgrader.go
@@ -85,3 +85,11 @@ func (u *aroUpgrader) UpgradeCluster(ctx context.Context, upgradeConfig *upgrade
 	u.upgradeConfig = upgradeConfig
 	return u.runSteps(ctx, logger, u.steps)
 }
+
+// HealthCheck performs a pre-upgrade healthcheck when an upgrade is scheduled in advance mainly
+// to highlight and notify of issues which could get fixed before the upgrade begins.
+func (u *aroUpgrader) HealthCheck(ctx context.Context, upgradeConfig *upgradev1alpha1.UpgradeConfig, logger logr.Logger) (bool, error) {
+	u.upgradeConfig = upgradeConfig
+	ok, err := u.PreUpgradeHealthCheck(ctx, logger)
+	return ok, err
+}

--- a/pkg/upgraders/builder.go
+++ b/pkg/upgraders/builder.go
@@ -14,12 +14,15 @@ import (
 
 // ClusterUpgrader enables an implementation of a ClusterUpgrader
 // Interface describing the functions of a cluster upgrader.
+//
 //go:generate mockgen -destination=mocks/cluster_upgrader.go -package=mocks github.com/openshift/managed-upgrade-operator/pkg/upgraders ClusterUpgrader
 type ClusterUpgrader interface {
+	HealthCheck(ctx context.Context, upgradeConfig *upgradev1alpha1.UpgradeConfig, logger logr.Logger) (bool, error)
 	UpgradeCluster(ctx context.Context, upgradeConfig *upgradev1alpha1.UpgradeConfig, logger logr.Logger) (upgradev1alpha1.UpgradePhase, error)
 }
 
 // ClusterUpgraderBuilder enables an implementation of a ClusterUpgraderBuilder
+//
 //go:generate mockgen -destination=mocks/cluster_upgrader_builder.go -package=mocks github.com/openshift/managed-upgrade-operator/pkg/upgraders ClusterUpgraderBuilder
 type ClusterUpgraderBuilder interface {
 	NewClient(client.Client, configmanager.ConfigManager, metrics.Metrics, eventmanager.EventManager, upgradev1alpha1.UpgradeType) (ClusterUpgrader, error)

--- a/pkg/upgraders/mocks/cluster_upgrader.go
+++ b/pkg/upgraders/mocks/cluster_upgrader.go
@@ -41,6 +41,21 @@ func (m *MockClusterUpgrader) EXPECT() *MockClusterUpgraderMockRecorder {
 	return m.recorder
 }
 
+// HealthCheck mocks base method.
+func (m *MockClusterUpgrader) HealthCheck(arg0 context.Context, arg1 *v1alpha1.UpgradeConfig, arg2 logr.Logger) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HealthCheck", arg0, arg1, arg2)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HealthCheck indicates an expected call of HealthCheck.
+func (mr *MockClusterUpgraderMockRecorder) HealthCheck(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HealthCheck", reflect.TypeOf((*MockClusterUpgrader)(nil).HealthCheck), arg0, arg1, arg2)
+}
+
 // UpgradeCluster mocks base method.
 func (m *MockClusterUpgrader) UpgradeCluster(arg0 context.Context, arg1 *v1alpha1.UpgradeConfig, arg2 logr.Logger) (v1alpha1.UpgradePhase, error) {
 	m.ctrl.T.Helper()

--- a/pkg/upgraders/osdupgrader.go
+++ b/pkg/upgraders/osdupgrader.go
@@ -101,6 +101,14 @@ func (u *osdUpgrader) UpgradeCluster(ctx context.Context, upgradeConfig *upgrade
 	return u.runSteps(ctx, logger, u.steps)
 }
 
+// HealthCheck performs a pre-upgrade healthcheck when an upgrade is scheduled in advance mainly
+// to highlight and notify of issues which could get fixed before the upgrade begins.
+func (u *osdUpgrader) HealthCheck(ctx context.Context, upgradeConfig *upgradev1alpha1.UpgradeConfig, logger logr.Logger) (bool, error) {
+	u.upgradeConfig = upgradeConfig
+	ok, err := u.PreUpgradeHealthCheck(ctx, logger)
+	return ok, err
+}
+
 // shouldFailUpgrade checks if the cluster has reached a condition during upgrade
 // where it should be treated as failed.
 // If the cluster should fail its upgrade a condition of 'true' is returned.


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?

This feature PR enables running the Pre-HealthCheck when an upgrade is scheduled in advance (atleast more than 2 hours by default) and notifies the user/admin of any healthcheck failures before the upgrade starts. It would help the users/admin to take action on failing healthchecks (as relevant) which will ensure higher success rate of upgrades. The requirement is to the Pre-HealthCheck once and only once before the upgrade starts but once the upgrade is scheduled. Thus, it's implemented in the `New` Upgrade phase.

At a high level following are the noteworthy points regarding the change:
- Previously, the `New` and `Pending` state were treated the same but now, they are split into separate states. This is a crucial change which requires additional tests/validation.
- When an upgrade is scheduled, the upgrade phase is set to `New` first.
- In the `New` state, a Pre-HealthCheck is run **only** if the time to upgrade is more than 2 hours. This value of 2 hours is defined by new field in `UpgradeConfig` API called `HealthCheckDuration`. Currently, this won't be exposed to OCM API and will always be 2 hours unless an upgrade is run in LOCAL mode.
- Regardless of whether the Pre-HealthCheck will pass or fail, the upgrade state is moved to "Pending" state in one minute reconcile time where it will wait for the upgrade schedule time to proceed with upgrade.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [OSD-22454](https://issues.redhat.com/browse/OSD-22454)

### Special notes for your reviewer:

Following tests were done so far:
- Scheduling upgrade from OCM in advance and checking if Pre-HealthCheck is run = PASS
- Scheduling upgrade from OCM immediately and checkig if Pre-HealthCheck is skipped = PASS
- Scheduling an upgrade and cancelling it = PASS
- Local run of upgrade passes as well with tests = PASS
- Checking metrics for health check run = PASS

Some additional noteworthy points:
- Scheduling an upgrade and cancelling it works. However, this needs more testing and validation. The UpgradeConfig remains in Pending state before the next OCM poll is going to sync and get the UpgradeConfig removed. The end state is fine but the interim state till OCM sync happens doesn't seem right. Will need to fix this separately.
- The default value for `HealthCheckDuration` needs some more testing as well. For now, the value is enforced via a separate function. Will need to test this better.

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR

