### PR TITLE
No worker machinepool HealthCheck

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -47,15 +47,16 @@ const (
 	WorkersStartedStateValue        = "workers_started"
 	WorkersCompletedStateValue      = "workers_completed"
 
-	MonitoringNS                 = "openshift-monitoring"
-	MonitoringCAConfigMapName    = "serving-certs-ca-bundle"
-	MonitoringConfigField        = "service-ca.crt"
-	promApp                      = "prometheus-k8s"
-	clusterSVCSuffix             = ".svc.cluster.local"
-	MetricsQueryFailed           = "healthcheck_query_failed"
-	CriticalAlertsFiring         = "critical_alerts_firing"
-	ClusterOperatorsDegraded     = "cluster_operators_degraded"
-	ClusterOperatorsStatusFailed = "cluster_operator_status_failed"
+	MonitoringNS                     = "openshift-monitoring"
+	MonitoringCAConfigMapName        = "serving-certs-ca-bundle"
+	MonitoringConfigField            = "service-ca.crt"
+	promApp                          = "prometheus-k8s"
+	clusterSVCSuffix                 = ".svc.cluster.local"
+	MetricsQueryFailed               = "healthcheck_query_failed"
+	CriticalAlertsFiring             = "critical_alerts_firing"
+	ClusterOperatorsDegraded         = "cluster_operators_degraded"
+	ClusterOperatorsStatusFailed     = "cluster_operator_status_failed"
+	DefaultWorkerMachinepoolNotFound = "default_worker_machinepool_not_found"
 )
 
 // Alerts sourced from https://github.com/openshift/managed-cluster-config/blob/master/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml

--- a/pkg/notifier/notifier.go
+++ b/pkg/notifier/notifier.go
@@ -12,12 +12,14 @@ import (
 )
 
 // Notifier is an interface that enables implementation of a Notifier
+//
 //go:generate mockgen -destination=mocks/notifier.go -package=mocks github.com/openshift/managed-upgrade-operator/pkg/notifier Notifier
 type Notifier interface {
 	NotifyState(value MuoState, description string) error
 }
 
 // NotifierBuilder is an interface that enables implementation of a NotifierBuilder
+//
 //go:generate mockgen -destination=mocks/notifier_builder.go -package=mocks github.com/openshift/managed-upgrade-operator/pkg/notifier NotifierBuilder
 type NotifierBuilder interface {
 	New(client.Client, configmanager.ConfigManagerBuilder, upgradeconfigmanager.UpgradeConfigManagerBuilder) (Notifier, error)
@@ -25,14 +27,15 @@ type NotifierBuilder interface {
 
 // Represents valid notify states that can be reported
 const (
-	MuoStatePending   MuoState = "StatePending"
-	MuoStateStarted   MuoState = "StateStarted"
-	MuoStateCompleted MuoState = "StateCompleted"
-	MuoStateDelayed   MuoState = "StateDelayed"
-	MuoStateFailed    MuoState = "StateFailed"
-	MuoStateCancelled MuoState = "StateCancelled"
-	MuoStateScheduled MuoState = "StateScheduled"
-	MuoStateSkipped   MuoState = "StateSkipped"
+	MuoStatePending      MuoState = "StatePending"
+	MuoStateStarted      MuoState = "StateStarted"
+	MuoStateCompleted    MuoState = "StateCompleted"
+	MuoStateDelayed      MuoState = "StateDelayed"
+	MuoStateFailed       MuoState = "StateFailed"
+	MuoStateCancelled    MuoState = "StateCancelled"
+	MuoStateScaleSkipped MuoState = "StateScaleSkipped"
+	MuoStateScheduled    MuoState = "StateScheduled"
+	MuoStateSkipped      MuoState = "StateSkipped"
 )
 
 // MuoState is a type

--- a/pkg/upgraders/healthcheckstep_test.go
+++ b/pkg/upgraders/healthcheckstep_test.go
@@ -95,12 +95,14 @@ var _ = Describe("HealthCheck Step", func() {
 
 			JustBeforeEach(func() {
 				alertsResponse = &metrics.AlertResponse{}
+				upgradeConfig.Spec.CapacityReservation = true
 			})
 			It("will satisfy a pre-upgrade health check", func() {
 				gomock.InOrder(
 					mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(false, nil),
 					mockMetricsClient.EXPECT().Query(gomock.Any()).Return(alertsResponse, nil),
 					mockCVClient.EXPECT().HasDegradedOperators().Return(&clusterversion.HasDegradedOperatorsResult{Degraded: []string{}}, nil),
+					mockScalerClient.EXPECT().CanScale(gomock.Any(), logger).Return(true, nil),
 					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name),
 				)
 				result, err := upgrader.PreUpgradeHealthCheck(context.TODO(), logger)
@@ -117,6 +119,7 @@ var _ = Describe("HealthCheck Step", func() {
 							return &metrics.AlertResponse{}, nil
 						}),
 					mockCVClient.EXPECT().HasDegradedOperators().Return(&clusterversion.HasDegradedOperatorsResult{Degraded: []string{}}, nil),
+					mockScalerClient.EXPECT().CanScale(mockKubeClient, logger).Return(true, nil),
 					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name),
 				)
 				result, err := upgrader.PreUpgradeHealthCheck(context.TODO(), logger)
@@ -131,6 +134,7 @@ var _ = Describe("HealthCheck Step", func() {
 						return &metrics.AlertResponse{}, nil
 					})
 				mockCVClient.EXPECT().HasDegradedOperators().Return(&clusterversion.HasDegradedOperatorsResult{Degraded: []string{}}, nil)
+				mockScalerClient.EXPECT().CanScale(mockKubeClient, logger).Return(true, nil)
 				mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name)
 				result, err := upgrader.PreUpgradeHealthCheck(context.TODO(), logger)
 				Expect(err).To(Not(HaveOccurred()))
@@ -152,6 +156,7 @@ var _ = Describe("HealthCheck Step", func() {
 
 			JustBeforeEach(func() {
 				alertsResponse = &metrics.AlertResponse{}
+				upgradeConfig.Spec.CapacityReservation = true
 			})
 
 			It("will satisfy a pre-Upgrade health check", func() {
@@ -159,6 +164,7 @@ var _ = Describe("HealthCheck Step", func() {
 					mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(false, nil),
 					mockMetricsClient.EXPECT().Query(gomock.Any()).Return(alertsResponse, nil),
 					mockCVClient.EXPECT().HasDegradedOperators().Return(&clusterversion.HasDegradedOperatorsResult{Degraded: []string{}}, nil),
+					mockScalerClient.EXPECT().CanScale(mockKubeClient, logger).Return(true, nil),
 					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name),
 				)
 				result, err := upgrader.PreUpgradeHealthCheck(context.TODO(), logger)

--- a/pkg/upgraders/notifierstep.go
+++ b/pkg/upgraders/notifierstep.go
@@ -2,6 +2,7 @@ package upgraders
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
 
 	"github.com/openshift/managed-upgrade-operator/pkg/notifier"
@@ -33,4 +34,13 @@ func (c *clusterUpgrader) SendCompletedNotification(ctx context.Context, logger 
 		return false, err
 	}
 	return true, nil
+}
+
+// SendScaleSkippedNotification sends a notification on Muo skip capacityreservation
+func (c *clusterUpgrader) SendScaleSkippedNotification(ctx context.Context, logger logr.Logger) error {
+	err := c.notifier.Notify(notifier.MuoStateScaleSkipped)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/upgraders/notifierstep_test.go
+++ b/pkg/upgraders/notifierstep_test.go
@@ -3,6 +3,7 @@ package upgraders
 import (
 	"context"
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -132,6 +133,17 @@ var _ = Describe("NotifierStep", func() {
 			result, err := upgrader.SendCompletedNotification(context.TODO(), logger)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(BeFalse())
+		})
+	})
+	Context("When running the scale-skipped-notification phase", func() {
+		Context("When the cluster is upgrading", func() {
+			It("will return without doing anything", func() {
+				gomock.InOrder(
+					mockEMClient.EXPECT().Notify(notifier.MuoStateScaleSkipped),
+				)
+				err := upgrader.SendScaleSkippedNotification(context.TODO(), logger)
+				Expect(err).NotTo(HaveOccurred())
+			})
 		})
 	})
 })

--- a/pkg/upgraders/scalerstep_test.go
+++ b/pkg/upgraders/scalerstep_test.go
@@ -90,6 +90,7 @@ var _ = Describe("ScalerStep", func() {
 				gomock.InOrder(
 					mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(false, nil),
 					mockScalerClient.EXPECT().CanScale(gomock.Any(), gomock.Any()).Return(false, nil),
+					mockEMClient.EXPECT().Notify(notifier.MuoStateScaleSkipped),
 				)
 				ok, err := upgrader.EnsureExtraUpgradeWorkers(context.TODO(), logger)
 				Expect(err).To(Not(HaveOccurred()))


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
- Send notification during upgrade in case MUO is unable to perform compute capacity reservation because the default worker machine pool is deleted 
- As part of the health check it verify the default worker machine pool exists in the cluster or not and returns the value accordingly
- Set metrics if the health check fails

### Which Jira/Github issue(s) this PR fixes?
_Fixes #_[OSD-22459](https://issues.redhat.com/browse/OSD-22459)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

