### PR TITLE
go.mod go get github.com/openshift/api@release-4.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
-	github.com/openshift/api v0.0.0-20240522145529-93d6bda14341
+	github.com/openshift/api v0.0.0-20240530231226-9d1c2e5ff5a8
 	github.com/openshift/client-go v0.0.0-20240510131258-f646d5f29250
 	github.com/openshift/cluster-version-operator v1.0.1-0.20230322131514-c659e6ccaca7
 	github.com/openshift/library-go v0.0.0-20240517135010-e93e442c2b18

--- a/go.sum
+++ b/go.sum
@@ -578,8 +578,8 @@ github.com/onsi/gomega v1.33.1/go.mod h1:U4R44UsT+9eLIaYRB2a5qajjtQYn0hauxvRm16A
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/openshift/api v0.0.0-20220525145417-ee5b62754c68/go.mod h1:LEnw1IVscIxyDnltE3Wi7bQb/QzIM8BfPNKoGA1Qlxw=
-github.com/openshift/api v0.0.0-20240522145529-93d6bda14341 h1:JQpzgk+p24rkgNbNsrNR0yLm63WTKapuT60INU5BqT8=
-github.com/openshift/api v0.0.0-20240522145529-93d6bda14341/go.mod h1:qNtV0315F+f8ld52TLtPvrfivZpdimOzTi3kn9IVbtU=
+github.com/openshift/api v0.0.0-20240530231226-9d1c2e5ff5a8 h1:WIakADT8wUSbeNuebODe3xQfT3gwrnjKBOeKUdho0kY=
+github.com/openshift/api v0.0.0-20240530231226-9d1c2e5ff5a8/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a/go.mod h1:eDO5QeVi2IiXmDwB0e2z1DpAznWroZKe978pzZwFBzg=
 github.com/openshift/client-go v0.0.0-20240510131258-f646d5f29250 h1:WQ0e89xebsNeChdYw8QrxggYkFtEQOaLBEKJDkMmcUk=


### PR DESCRIPTION
### What type of PR is this?
/cleanup

### What this PR does / why we need it?

PR #429 broke the e2e binary build due to the openshift/api version being slightly off.

```
❯ make e2e-harness-build
boilerplate/openshift/golang-osd-operator/standard.mk:113: Setting GOEXPERIMENT=strictfipsruntime,boringcrypto - this generally causes builds to fail unless building inside the provided Dockerfile. If building locally consider calling 'go build .'
go: unknown GOEXPERIMENT strictfipsruntime
go mod tidy
GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GOFLAGS="-mod=mod" go test ./osde2e -v -c --tags=osde2e -o harness.test
```

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

```
❯ ginkgo run --tags=osde2e ./osde2e/ --focus upgrade
Running Suite: Managed Upgrade Operator - /var/home/bpratt/git/openshift/managed-upgrade-operator/osde2e
========================================================================================================
Random Seed: 1717424536

Will run 5 of 5 specs
••SS•

Ran 3 of 5 Specs in 22.653 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 2 Skipped
PASS

Ginkgo ran 1 suite in 23.875011094s
Test Suite Passed
```

(the skips are when no cluster upgrades are available)

/cc @ravitri @ritmun 
