### PR TITLE
Removing HealthCheckDuration spec field

### DIFF
--- a/api/v1alpha1/upgradeconfig_types.go
+++ b/api/v1alpha1/upgradeconfig_types.go
@@ -35,14 +35,6 @@ type UpgradeConfigSpec struct {
 
 	// Specify if scaling up an extra node for capacity reservation before upgrade starts is needed
 	CapacityReservation bool `json:"capacityReservation,omitempty"`
-
-	// +kubebuilder:validation:Minimum:=2
-	// +kubebuilder:validation:Default:=2
-	// +kubebuilder:default:=2
-	// +kubebuilder:validation:Optional
-	// HealthCheckDuration specifies minimum duration of 2 hours before upgrade time to run healthcheck.
-	// If an upgrade is scheduled within 2 hours from now, healthcheck won't run.
-	HealthCheckDuration int32 `json:"HealthCheckDuration,omitempty"`
 }
 
 // UpgradeConfigStatus defines the observed state of UpgradeConfig
@@ -189,13 +181,7 @@ func (uc *UpgradeConfig) GetPDBDrainTimeoutDuration() time.Duration {
 
 // GetHealthCheckDuration returns the duration to perform HealthCheck in hours
 func (uc *UpgradeConfig) GetHealthCheckDuration() time.Duration {
-	hcTime := uc.Spec.HealthCheckDuration
-
-	if hcTime == 0 {
-		return time.Duration(time.Hour * 2)
-	}
-
-	return time.Duration(uc.Spec.HealthCheckDuration) * time.Hour * time.Duration(hcTime)
+	return time.Duration(time.Hour * 2)
 }
 
 // +kubebuilder:object:root=true

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-896.1716497715
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-896.1717584414
 
 ENV USER_UID=1001 \
     USER_NAME=managed-upgrade-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-896.1716497715
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-896.1717584414
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/deploy/crds/upgrade.managed.openshift.io_upgradeconfigs.yaml
+++ b/deploy/crds/upgrade.managed.openshift.io_upgradeconfigs.yaml
@@ -61,14 +61,6 @@ spec:
             description: UpgradeConfigSpec defines the desired state of UpgradeConfig
               and upgrade window and freeze window
             properties:
-              HealthCheckDuration:
-                default: 2
-                description: |-
-                  HealthCheckDuration specifies minimum duration of 2 hours before upgrade time to run healthcheck.
-                  If an upgrade is scheduled within 2 hours from now, healthcheck won't run.
-                format: int32
-                minimum: 2
-                type: integer
               PDBForceDrainTimeout:
                 description: The maximum grace period granted to a node whose drain
                   is blocked by a Pod Disruption Budget, before that drain is forced.

--- a/docs/controllers/upgradeconfig.md
+++ b/docs/controllers/upgradeconfig.md
@@ -46,7 +46,7 @@ The reconciler then checks the current phase of the `UpgradeConfig`.
 If the phase is `New`:
 
 - The time to upgrade is checked to decide if a Pre-HealthCheck is required to be run or not. This gives users/customers a notification in advance about what's wrong or can impact an upgrade and has time to address it when the upgrade actually starts at scheduled time.
-- If the scheduled upgrade time is greater than the `HealthCheckDuration` time (defaults to 2 hours), then the Pre-HealthCheck is run. Else, the HealthCheck is run as per usual upgrade process as such just before the upgrade starts.
+- If the scheduled upgrade time is greater than 2 hours, then the Pre-HealthCheck is run. Else, the HealthCheck is run as per usual upgrade process as such just before the upgrade starts.
 - Once the Pre-HealthCheck is run, the upgrade phase is set to "Pending" state.
 
 If the phase is `Pending`:


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
This PR fixes a bug related to PR https://github.com/openshift/managed-upgrade-operator/pull/426 where the `HealthCheckDuration` API spec gets updated in the UpgradeConfig resource once the UpgradePolicy is synced. Post this change, the UpgradeConfig gets recreated in a loop. This wasn't caught before due to the CRD not getting updated. With the CRD change and CSV bundle, the UpgradeConfig API got updated with this spec. Since this API field is not exposed to OCM (yet), we will maintain a standard of 2 hours as threshold for PreHealthChecks and not expose it via UpgradeConfig for time being. The bug was caught in staging environment in CI and gap analysis.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [OSD-23923](https://issues.redhat.com/browse/OSD-23923)

### Special notes for your reviewer:
- Tested two upgrades on different clusters and the upgrades worked fine with the image with fix.

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR

