### PR TITLE
OSD-23984 Add node unschedulable taint check

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -31,6 +31,7 @@ find .
 
 ### Mocking interfaces
 
+#### Basic Mock knowledge and process
 This project makes use of [`GoMock`](https://github.com/golang/mock) to mock service interfaces. This comes with the `mockgen` utility which can be used to generate or re-generate mock interfaces that can be used to simulate the behaviour of an external dependency.
 
 Once installed, an interface can be mocked by running: 
@@ -48,4 +49,13 @@ Internal interfaces including `pkg/maintenance/maintenance.go` and `pkg/controll
 To regenerate controller-runtime mock (cr-client.go), run
 
 ```
-mockgen -package mocks -destination=util/mocks/cr-client.go sigs.k8s.io/controller-runtime/pkg/client Client,StatusWriter,Reader,Writer```
+mockgen -package mocks -destination=util/mocks/cr-client.go sigs.k8s.io/controller-runtime/pkg/client Client,StatusWriter,Reader,Writer
+```
+#### Update Mock via boilerplate container
+
+The easiest and recommend way to make an update on the Mock when there is any interface update is using boilerplate-container. Because boilerplate container installs all the dependencies and has all the environment setup. Most important, boilerplate container resolves a lot of platform, arch and version impacts while generate the mocks manually.
+
+To regenerate the mocks by using boilerplate container, simply run the following command
+```
+./boilerplate/_lib/container-make generate
+```

--- a/pkg/machinery/machinery.go
+++ b/pkg/machinery/machinery.go
@@ -18,6 +18,9 @@ type Machinery interface {
 	IsUpgrading(c client.Client, nodeType string) (*UpgradingResult, error)
 	IsNodeCordoned(node *corev1.Node) *IsCordonedResult
 	IsNodeUpgrading(node *corev1.Node) bool
+	HasMemoryPressure(node *corev1.Node) bool
+	HasDiskPressure(node *corev1.Node) bool
+	HasPidPressure(node *corev1.Node) bool
 }
 
 type machinery struct{}

--- a/pkg/machinery/mocks/machinery.go
+++ b/pkg/machinery/mocks/machinery.go
@@ -41,6 +41,48 @@ func (m *MockMachinery) EXPECT() *MockMachineryMockRecorder {
 	return m.recorder
 }
 
+// HasDiskPressure mocks base method.
+func (m *MockMachinery) HasDiskPressure(arg0 *v1.Node) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasDiskPressure", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasDiskPressure indicates an expected call of HasDiskPressure.
+func (mr *MockMachineryMockRecorder) HasDiskPressure(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasDiskPressure", reflect.TypeOf((*MockMachinery)(nil).HasDiskPressure), arg0)
+}
+
+// HasMemoryPressure mocks base method.
+func (m *MockMachinery) HasMemoryPressure(arg0 *v1.Node) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasMemoryPressure", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasMemoryPressure indicates an expected call of HasMemoryPressure.
+func (mr *MockMachineryMockRecorder) HasMemoryPressure(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasMemoryPressure", reflect.TypeOf((*MockMachinery)(nil).HasMemoryPressure), arg0)
+}
+
+// HasPidPressure mocks base method.
+func (m *MockMachinery) HasPidPressure(arg0 *v1.Node) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasPidPressure", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasPidPressure indicates an expected call of HasPidPressure.
+func (mr *MockMachineryMockRecorder) HasPidPressure(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPidPressure", reflect.TypeOf((*MockMachinery)(nil).HasPidPressure), arg0)
+}
+
 // IsNodeCordoned mocks base method.
 func (m *MockMachinery) IsNodeCordoned(arg0 *v1.Node) *machinery.IsCordonedResult {
 	m.ctrl.T.Helper()

--- a/pkg/machinery/node.go
+++ b/pkg/machinery/node.go
@@ -39,3 +39,39 @@ func (m *machinery) IsNodeUpgrading(node *corev1.Node) bool {
 		return false
 	}
 }
+
+func (m *machinery) HasMemoryPressure(node *corev1.Node) bool {
+	if len(node.Spec.Taints) > 0 {
+		// Only check if there are taints
+		for _, n := range node.Spec.Taints {
+			if n.Effect == corev1.TaintEffectNoSchedule && n.Key == corev1.TaintNodeMemoryPressure {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (m *machinery) HasDiskPressure(node *corev1.Node) bool {
+	if len(node.Spec.Taints) > 0 {
+		// Only check if there are taints
+		for _, n := range node.Spec.Taints {
+			if n.Effect == corev1.TaintEffectNoSchedule && n.Key == corev1.TaintNodeDiskPressure {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (m *machinery) HasPidPressure(node *corev1.Node) bool {
+	if len(node.Spec.Taints) > 0 {
+		// Only check if there are taints
+		for _, n := range node.Spec.Taints {
+			if n.Effect == corev1.TaintEffectNoSchedule && n.Key == corev1.TaintNodePIDPressure {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -59,6 +59,7 @@ const (
 	DefaultWorkerMachinepoolNotFound = "default_worker_machinepool_not_found"
 	ClusterNodeQueryFailed           = "cluster_node_query_failed"
 	ClusterNodesManuallyCordoned     = "cluster_node_manually_cordoned"
+	ClusterNodesTaintedUnschedulable = "cluster_node_taint_unschedulable"
 )
 
 // Alerts sourced from https://github.com/openshift/managed-cluster-config/blob/master/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml

--- a/pkg/upgraders/healthcheck_nodes.go
+++ b/pkg/upgraders/healthcheck_nodes.go
@@ -51,3 +51,66 @@ func ManuallyCordonedNodes(metricsClient metrics.Metrics, machinery machinery.Ma
 	logger.Info("Prehealth check for manually cordoned node passed")
 	return true, nil
 }
+
+func NodeUnschedulableTaints(metricsClient metrics.Metrics, machinery machinery.Machinery, c client.Client, ug *upgradev1alpha1.UpgradeConfig, logger logr.Logger) (bool, error) {
+	nodes := &corev1.NodeList{}
+	cops := &client.ListOptions{}
+	// Get the list of worker nodes
+	err := c.List(context.TODO(), nodes, cops)
+	if err != nil {
+		logger.Info("Unable to fetch node list")
+		metricsClient.UpdateMetricHealthcheckFailed(ug.Name, metrics.ClusterNodeQueryFailed)
+		return false, err
+	}
+
+	// Check if worker node has been manually cordoned.
+	var memPressureNodes []string
+	var diskPressureNodes []string
+	var pidPressureNodes []string
+	var unschedulableNodes []string
+	isHealthCheckFailed := false
+	for _, node := range nodes.Items {
+		node := node
+		if machinery.HasMemoryPressure(&node) {
+			//Node has memory pressure and unschedulable taint , set the flag and record the node name
+			isHealthCheckFailed = true
+			memPressureNodes = append(memPressureNodes, node.Name)
+		}
+
+		if machinery.HasDiskPressure(&node) {
+			//Node has disk pressure and unschedulable taint, set the flag and record the node name
+			isHealthCheckFailed = true
+			diskPressureNodes = append(diskPressureNodes, node.Name)
+		}
+
+		if machinery.HasPidPressure(&node) {
+			//Node has PID pressure and unschedulable taint, set the flag and record the node name
+			isHealthCheckFailed = true
+			pidPressureNodes = append(pidPressureNodes, node.Name)
+		}
+	}
+
+	if isHealthCheckFailed {
+		// Node unschedulable taints check failed, fail the healthcheck and return failed nodes
+		logger.Info(" Unschedulable node taints check failed")
+		metricsClient.UpdateMetricHealthcheckFailed(ug.Name, metrics.ClusterNodesTaintedUnschedulable)
+		if len(memPressureNodes) > 0 {
+			logger.Info(fmt.Sprintf("%s has/have memory pressure", strings.Join(memPressureNodes, ", ")))
+			unschedulableNodes = append(unschedulableNodes, memPressureNodes...)
+		}
+
+		if len(diskPressureNodes) > 0 {
+			logger.Info(fmt.Sprintf("%s has/have disk pressure", strings.Join(diskPressureNodes, ", ")))
+			unschedulableNodes = append(unschedulableNodes, diskPressureNodes...)
+		}
+
+		if len(pidPressureNodes) > 0 {
+			logger.Info(fmt.Sprintf("%s has/have PID pressure", strings.Join(pidPressureNodes, ", ")))
+			unschedulableNodes = append(unschedulableNodes, pidPressureNodes...)
+		}
+
+		return false, fmt.Errorf("unschedulable taints on nodes: %s", strings.Join(unschedulableNodes, ", "))
+	}
+	logger.Info("Prehealth check for unschedulable node taints passed")
+	return true, nil
+}

--- a/pkg/upgraders/healthcheckstep.go
+++ b/pkg/upgraders/healthcheckstep.go
@@ -63,6 +63,16 @@ func (c *clusterUpgrader) PreUpgradeHealthCheck(ctx context.Context, logger logr
 		return false, err
 	}
 
+	ok, err = NodeUnschedulableTaints(c.metrics, c.machinery, c.client, c.upgradeConfig, logger)
+	if err != nil || !ok {
+		logger.Info(fmt.Sprintf("upgrade delayed due to there are unschedulable taints on nodes: %s", err))
+		errResult := c.notifier.Notify(notifier.MuoStateHealthCheck)
+		if errResult != nil {
+			err = errResult
+		}
+		return false, err
+	}
+
 	c.metrics.UpdateMetricHealthcheckSucceeded(c.upgradeConfig.Name)
 
 	return true, nil

--- a/pkg/upgraders/healthcheckstep_test.go
+++ b/pkg/upgraders/healthcheckstep_test.go
@@ -118,6 +118,10 @@ var _ = Describe("HealthCheck Step", func() {
 					mockScalerClient.EXPECT().CanScale(gomock.Any(), logger).Return(true, nil),
 					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes),
 					mockMachineryClient.EXPECT().IsNodeCordoned(gomock.Any()).Return(&machinery.IsCordonedResult{IsCordoned: false, AddedAt: cordonAddedTime}),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes),
+					mockMachineryClient.EXPECT().HasMemoryPressure(gomock.Any()).Return(false),
+					mockMachineryClient.EXPECT().HasDiskPressure(gomock.Any()).Return(false),
+					mockMachineryClient.EXPECT().HasPidPressure(gomock.Any()).Return(false),
 					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name),
 				)
 				result, err := upgrader.PreUpgradeHealthCheck(context.TODO(), logger)
@@ -137,6 +141,10 @@ var _ = Describe("HealthCheck Step", func() {
 					mockScalerClient.EXPECT().CanScale(mockKubeClient, logger).Return(true, nil),
 					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes),
 					mockMachineryClient.EXPECT().IsNodeCordoned(gomock.Any()).Return(&machinery.IsCordonedResult{IsCordoned: false, AddedAt: cordonAddedTime}),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes),
+					mockMachineryClient.EXPECT().HasMemoryPressure(gomock.Any()).Return(false),
+					mockMachineryClient.EXPECT().HasDiskPressure(gomock.Any()).Return(false),
+					mockMachineryClient.EXPECT().HasPidPressure(gomock.Any()).Return(false),
 					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name),
 				)
 				result, err := upgrader.PreUpgradeHealthCheck(context.TODO(), logger)
@@ -154,6 +162,10 @@ var _ = Describe("HealthCheck Step", func() {
 				mockScalerClient.EXPECT().CanScale(mockKubeClient, logger).Return(true, nil)
 				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes)
 				mockMachineryClient.EXPECT().IsNodeCordoned(gomock.Any()).Return(&machinery.IsCordonedResult{IsCordoned: false, AddedAt: cordonAddedTime})
+				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes)
+				mockMachineryClient.EXPECT().HasMemoryPressure(gomock.Any()).Return(false)
+				mockMachineryClient.EXPECT().HasDiskPressure(gomock.Any()).Return(false)
+				mockMachineryClient.EXPECT().HasPidPressure(gomock.Any()).Return(false)
 				mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name)
 				result, err := upgrader.PreUpgradeHealthCheck(context.TODO(), logger)
 				Expect(err).To(Not(HaveOccurred()))
@@ -186,6 +198,10 @@ var _ = Describe("HealthCheck Step", func() {
 					mockScalerClient.EXPECT().CanScale(mockKubeClient, logger).Return(true, nil),
 					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes),
 					mockMachineryClient.EXPECT().IsNodeCordoned(gomock.Any()).Return(&machinery.IsCordonedResult{IsCordoned: false, AddedAt: cordonAddedTime}),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes),
+					mockMachineryClient.EXPECT().HasMemoryPressure(gomock.Any()).Return(false),
+					mockMachineryClient.EXPECT().HasDiskPressure(gomock.Any()).Return(false),
+					mockMachineryClient.EXPECT().HasPidPressure(gomock.Any()).Return(false),
 					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name),
 				)
 				result, err := upgrader.PreUpgradeHealthCheck(context.TODO(), logger)
@@ -218,6 +234,10 @@ var _ = Describe("HealthCheck Step", func() {
 					mockScalerClient.EXPECT().CanScale(mockKubeClient, logger).Return(true, nil),
 					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes),
 					mockMachineryClient.EXPECT().IsNodeCordoned(gomock.Any()).Return(&machinery.IsCordonedResult{IsCordoned: false, AddedAt: cordonAddedTime}),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes),
+					mockMachineryClient.EXPECT().HasMemoryPressure(gomock.Any()).Return(false),
+					mockMachineryClient.EXPECT().HasDiskPressure(gomock.Any()).Return(false),
+					mockMachineryClient.EXPECT().HasPidPressure(gomock.Any()).Return(false),
 					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name),
 				)
 				result, err := upgrader.PreUpgradeHealthCheck(context.TODO(), logger)
@@ -251,6 +271,10 @@ var _ = Describe("HealthCheck Step", func() {
 					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes),
 					mockMachineryClient.EXPECT().IsNodeCordoned(gomock.Any()).Return(&machinery.IsCordonedResult{IsCordoned: true, AddedAt: cordonAddedTime}),
 					mockMachineryClient.EXPECT().IsNodeUpgrading(gomock.Any()).Return(true),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes),
+					mockMachineryClient.EXPECT().HasMemoryPressure(gomock.Any()).Return(false),
+					mockMachineryClient.EXPECT().HasDiskPressure(gomock.Any()).Return(false),
+					mockMachineryClient.EXPECT().HasPidPressure(gomock.Any()).Return(false),
 					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name),
 				)
 				result, err := upgrader.PreUpgradeHealthCheck(context.TODO(), logger)
@@ -367,29 +391,252 @@ var _ = Describe("HealthCheck Step", func() {
 				Expect(result).To(BeFalse())
 			})
 		})
-	})
 
-	Context("When the cluster's upgrade process has commenced", func() {
-		It("will not re-perform a pre-upgrade health check", func() {
-			gomock.InOrder(
-				mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(true, nil),
-			)
-			result, err := upgrader.PreUpgradeHealthCheck(context.TODO(), logger)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(BeTrue())
+		Context("When node unschedulable taint check failed", func() {
+			var alertsResponse *metrics.AlertResponse
+			var addedTime *metav1.Time
+			JustBeforeEach(func() {
+				alertsResponse = &metrics.AlertResponse{}
+			})
+			It("Memory pressure taint will not satisfy a pre-Upgrade health check", func() {
+				nodes := &corev1.NodeList{
+					TypeMeta: metav1.TypeMeta{},
+					ListMeta: metav1.ListMeta{},
+					Items: []corev1.Node{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "testNode"},
+							Spec: corev1.NodeSpec{
+								Taints: []corev1.Taint{
+									{
+										Effect:    corev1.TaintEffectNoSchedule,
+										Key:       corev1.TaintNodeMemoryPressure,
+										TimeAdded: addedTime,
+									},
+								},
+							},
+						},
+					},
+				}
+				gomock.InOrder(
+					mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(false, nil),
+					mockMetricsClient.EXPECT().Query(gomock.Any()).Return(alertsResponse, nil),
+					mockCVClient.EXPECT().HasDegradedOperators().Return(&clusterversion.HasDegradedOperatorsResult{Degraded: []string{}}, nil),
+					mockScalerClient.EXPECT().CanScale(mockKubeClient, logger).Return(true, nil),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes),
+					mockMachineryClient.EXPECT().IsNodeCordoned(gomock.Any()).Return(&machinery.IsCordonedResult{IsCordoned: false, AddedAt: addedTime}),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes),
+					mockMachineryClient.EXPECT().HasMemoryPressure(gomock.Any()).Return(true),
+					mockMachineryClient.EXPECT().HasDiskPressure(gomock.Any()).Return(false),
+					mockMachineryClient.EXPECT().HasPidPressure(gomock.Any()).Return(false),
+					mockMetricsClient.EXPECT().UpdateMetricHealthcheckFailed(upgradeConfig.Name, gomock.Any()),
+					mockEMClient.EXPECT().Notify(gomock.Any()).Return(nil),
+				)
+				result, err := upgrader.PreUpgradeHealthCheck(context.TODO(), logger)
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+
+			It("Disk pressure taint will not satisfy a pre-Upgrade health check", func() {
+				nodes := &corev1.NodeList{
+					TypeMeta: metav1.TypeMeta{},
+					ListMeta: metav1.ListMeta{},
+					Items: []corev1.Node{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "testNode"},
+							Spec: corev1.NodeSpec{
+								Taints: []corev1.Taint{
+									{
+										Effect:    corev1.TaintEffectNoSchedule,
+										Key:       corev1.TaintNodeDiskPressure,
+										TimeAdded: addedTime,
+									},
+								},
+							},
+						},
+					},
+				}
+				gomock.InOrder(
+					mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(false, nil),
+					mockMetricsClient.EXPECT().Query(gomock.Any()).Return(alertsResponse, nil),
+					mockCVClient.EXPECT().HasDegradedOperators().Return(&clusterversion.HasDegradedOperatorsResult{Degraded: []string{}}, nil),
+					mockScalerClient.EXPECT().CanScale(mockKubeClient, logger).Return(true, nil),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes),
+					mockMachineryClient.EXPECT().IsNodeCordoned(gomock.Any()).Return(&machinery.IsCordonedResult{IsCordoned: false, AddedAt: addedTime}),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes),
+					mockMachineryClient.EXPECT().HasMemoryPressure(gomock.Any()).Return(false),
+					mockMachineryClient.EXPECT().HasDiskPressure(gomock.Any()).Return(true),
+					mockMachineryClient.EXPECT().HasPidPressure(gomock.Any()).Return(false),
+					mockMetricsClient.EXPECT().UpdateMetricHealthcheckFailed(upgradeConfig.Name, gomock.Any()),
+					mockEMClient.EXPECT().Notify(gomock.Any()).Return(nil),
+				)
+				result, err := upgrader.PreUpgradeHealthCheck(context.TODO(), logger)
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+
+			It("PID pressure taint will not satisfy a pre-Upgrade health check", func() {
+				nodes := &corev1.NodeList{
+					TypeMeta: metav1.TypeMeta{},
+					ListMeta: metav1.ListMeta{},
+					Items: []corev1.Node{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "testNode"},
+							Spec: corev1.NodeSpec{
+								Taints: []corev1.Taint{
+									{
+										Effect:    corev1.TaintEffectNoSchedule,
+										Key:       corev1.TaintNodePIDPressure,
+										TimeAdded: addedTime,
+									},
+								},
+							},
+						},
+					},
+				}
+				gomock.InOrder(
+					mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(false, nil),
+					mockMetricsClient.EXPECT().Query(gomock.Any()).Return(alertsResponse, nil),
+					mockCVClient.EXPECT().HasDegradedOperators().Return(&clusterversion.HasDegradedOperatorsResult{Degraded: []string{}}, nil),
+					mockScalerClient.EXPECT().CanScale(mockKubeClient, logger).Return(true, nil),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes),
+					mockMachineryClient.EXPECT().IsNodeCordoned(gomock.Any()).Return(&machinery.IsCordonedResult{IsCordoned: false, AddedAt: addedTime}),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes),
+					mockMachineryClient.EXPECT().HasMemoryPressure(gomock.Any()).Return(false),
+					mockMachineryClient.EXPECT().HasDiskPressure(gomock.Any()).Return(false),
+					mockMachineryClient.EXPECT().HasPidPressure(gomock.Any()).Return(true),
+					mockMetricsClient.EXPECT().UpdateMetricHealthcheckFailed(upgradeConfig.Name, gomock.Any()),
+					mockEMClient.EXPECT().Notify(gomock.Any()).Return(nil),
+				)
+				result, err := upgrader.PreUpgradeHealthCheck(context.TODO(), logger)
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+
+			It("There are 2 pressure taints which will not satisfy a pre-Upgrade health check", func() {
+				nodes := &corev1.NodeList{
+					TypeMeta: metav1.TypeMeta{},
+					ListMeta: metav1.ListMeta{},
+					Items: []corev1.Node{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "testNode"},
+							Spec: corev1.NodeSpec{
+								Taints: []corev1.Taint{
+									{
+										Effect:    corev1.TaintEffectNoSchedule,
+										Key:       corev1.TaintNodeMemoryPressure,
+										TimeAdded: addedTime,
+									},
+									{
+										Effect:    corev1.TaintEffectNoSchedule,
+										Key:       corev1.TaintNodePIDPressure,
+										TimeAdded: addedTime,
+									},
+								},
+							},
+						},
+					},
+				}
+				gomock.InOrder(
+					mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(false, nil),
+					mockMetricsClient.EXPECT().Query(gomock.Any()).Return(alertsResponse, nil),
+					mockCVClient.EXPECT().HasDegradedOperators().Return(&clusterversion.HasDegradedOperatorsResult{Degraded: []string{}}, nil),
+					mockScalerClient.EXPECT().CanScale(mockKubeClient, logger).Return(true, nil),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes),
+					mockMachineryClient.EXPECT().IsNodeCordoned(gomock.Any()).Return(&machinery.IsCordonedResult{IsCordoned: false, AddedAt: addedTime}),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes),
+					mockMachineryClient.EXPECT().HasMemoryPressure(gomock.Any()).Return(true),
+					mockMachineryClient.EXPECT().HasDiskPressure(gomock.Any()).Return(false),
+					mockMachineryClient.EXPECT().HasPidPressure(gomock.Any()).Return(true),
+					mockMetricsClient.EXPECT().UpdateMetricHealthcheckFailed(upgradeConfig.Name, gomock.Any()),
+					mockEMClient.EXPECT().Notify(gomock.Any()).Return(nil),
+				)
+				result, err := upgrader.PreUpgradeHealthCheck(context.TODO(), logger)
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+
+			It("There are all 3 pressure taints which will not satisfy a pre-Upgrade health check", func() {
+				nodes := &corev1.NodeList{
+					TypeMeta: metav1.TypeMeta{},
+					ListMeta: metav1.ListMeta{},
+					Items: []corev1.Node{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "memPressureNode"},
+							Spec: corev1.NodeSpec{
+								Taints: []corev1.Taint{
+									{
+										Effect:    corev1.TaintEffectNoSchedule,
+										Key:       corev1.TaintNodeMemoryPressure,
+										TimeAdded: addedTime,
+									},
+								},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "diskAndPIDPressureNode"},
+							Spec: corev1.NodeSpec{
+								Taints: []corev1.Taint{
+									{
+										Effect:    corev1.TaintEffectNoSchedule,
+										Key:       corev1.TaintNodeDiskPressure,
+										TimeAdded: addedTime,
+									},
+									{
+										Effect:    corev1.TaintEffectNoSchedule,
+										Key:       corev1.TaintNodePIDPressure,
+										TimeAdded: addedTime,
+									},
+								},
+							},
+						},
+					},
+				}
+				gomock.InOrder(
+					mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(false, nil),
+					mockMetricsClient.EXPECT().Query(gomock.Any()).Return(alertsResponse, nil),
+					mockCVClient.EXPECT().HasDegradedOperators().Return(&clusterversion.HasDegradedOperatorsResult{Degraded: []string{}}, nil),
+					mockScalerClient.EXPECT().CanScale(mockKubeClient, logger).Return(true, nil),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes),
+					mockMachineryClient.EXPECT().IsNodeCordoned(gomock.Any()).Return(&machinery.IsCordonedResult{IsCordoned: false, AddedAt: addedTime}),
+					mockMachineryClient.EXPECT().IsNodeCordoned(gomock.Any()).Return(&machinery.IsCordonedResult{IsCordoned: false, AddedAt: addedTime}),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes),
+					mockMachineryClient.EXPECT().HasMemoryPressure(gomock.Any()).Return(true),
+					mockMachineryClient.EXPECT().HasDiskPressure(gomock.Any()).Return(false),
+					mockMachineryClient.EXPECT().HasPidPressure(gomock.Any()).Return(false),
+					mockMachineryClient.EXPECT().HasMemoryPressure(gomock.Any()).Return(false),
+					mockMachineryClient.EXPECT().HasDiskPressure(gomock.Any()).Return(true),
+					mockMachineryClient.EXPECT().HasPidPressure(gomock.Any()).Return(true),
+					mockMetricsClient.EXPECT().UpdateMetricHealthcheckFailed(upgradeConfig.Name, gomock.Any()),
+					mockEMClient.EXPECT().Notify(gomock.Any()).Return(nil),
+				)
+				result, err := upgrader.PreUpgradeHealthCheck(context.TODO(), logger)
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
 		})
-	})
 
-	Context("When the upgrader can't tell if the cluster's upgrade has commenced", func() {
-		var fakeError = fmt.Errorf("fake upgradeCommenced error")
-		It("will abort the pre-upgrade health check", func() {
-			gomock.InOrder(
-				mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(true, fakeError),
-			)
-			result, err := upgrader.PreUpgradeHealthCheck(context.TODO(), logger)
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(Equal(fakeError))
-			Expect(result).To(BeFalse())
+		Context("When the cluster's upgrade process has commenced", func() {
+			It("will not re-perform a pre-upgrade health check", func() {
+				gomock.InOrder(
+					mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(true, nil),
+				)
+				result, err := upgrader.PreUpgradeHealthCheck(context.TODO(), logger)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+			})
+		})
+
+		Context("When the upgrader can't tell if the cluster's upgrade has commenced", func() {
+			var fakeError = fmt.Errorf("fake upgradeCommenced error")
+			It("will abort the pre-upgrade health check", func() {
+				gomock.InOrder(
+					mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(true, fakeError),
+				)
+				result, err := upgrader.PreUpgradeHealthCheck(context.TODO(), logger)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(Equal(fakeError))
+				Expect(result).To(BeFalse())
+			})
 		})
 	})
 })


### PR DESCRIPTION
### What type of PR is this?
[OSD-23984](https://issues.redhat.com/browse/OSD-23984) Add node unschedulable taints check


### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?
Managed upgrade operator preflight health check 



