### PR TITLE
Reset the NodeDrainFailed metric when the node deletion timestamp is set

### DIFF
--- a/controllers/nodekeeper/nodekeeper_controller.go
+++ b/controllers/nodekeeper/nodekeeper_controller.go
@@ -120,12 +120,19 @@ func (r *ReconcileNodeKeeper) Reconcile(ctx context.Context, request reconcile.R
 			return reconcile.Result{}, err
 		}
 		if hasFailed {
-			reqLogger.Info(fmt.Sprintf("Node drain timed out %s. Alerting.", node.Name))
-			// Set metric only for the node going through upgrade
-			if r.Machinery.IsNodeUpgrading(node) {
-				metricsClient.UpdateMetricNodeDrainFailed(node.Name)
+			// If the node.DeletionTimestamp is set NodeDrainFailed metric needs to be reset
+			if node.DeletionTimestamp != nil {
+				reqLogger.Info(fmt.Sprintf("DeletionTimestamp set for the node %s. Re-setting NodeDrainFailed metric",
+					node.Name))
+				metricsClient.ResetMetricNodeDrainFailed(node.Name)
+			} else {
+				reqLogger.Info(fmt.Sprintf("Node drain timed out %s. Alerting.", node.Name))
+				// Set metric only for the node going through upgrade
+				if r.Machinery.IsNodeUpgrading(node) {
+					metricsClient.UpdateMetricNodeDrainFailed(node.Name)
+				}
+				return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
 			}
-			return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
 		} else {
 			metricsClient.ResetMetricNodeDrainFailed(node.Name)
 		}

--- a/controllers/nodekeeper/nodekeeper_controller_test.go
+++ b/controllers/nodekeeper/nodekeeper_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -43,6 +44,7 @@ var _ = Describe("NodeKeeperController", func() {
 		testNodeName                    types.NamespacedName
 		upgradeConfigName               types.NamespacedName
 		config                          nodeKeeperConfig
+		node                            corev1.Node
 	)
 
 	BeforeEach(func() {
@@ -190,6 +192,46 @@ var _ = Describe("NodeKeeperController", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.Requeue).To(BeFalse())
 				Expect(result.RequeueAfter).To(BeZero())
+			})
+		})
+		Context("Metric reset", func() {
+			var uc upgradev1alpha1.UpgradeConfig
+			BeforeEach(func() {
+				uc = *testStructs.NewUpgradeConfigBuilder().WithNamespacedName(upgradeConfigName).WithPhase(upgradev1alpha1.UpgradePhaseUpgrading).GetUpgradeConfig()
+				config = nodeKeeperConfig{
+					NodeDrain: drain.NodeDrain{
+						DisableDrainStrategies: false,
+						Timeout:                5,
+						ExpectedNodeDrainTime:  8,
+					},
+				}
+				node = corev1.Node{}
+				node.Name = testNodeName.Name
+				node.DeletionTimestamp = &metav1.Time{
+					Time: time.Now(),
+				}
+			})
+			It("should reset NodeDraingFailed metric when node DeletionTimestamp set", func() {
+				gomock.InOrder(
+					mockUpgradeConfigManagerBuilder.EXPECT().NewManager(gomock.Any()).Return(mockUpgradeConfigManager, nil),
+					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
+					mockMachineryClient.EXPECT().IsUpgrading(mockKubeClient, "worker").Return(&machinery.UpgradingResult{IsUpgrading: true}, nil),
+					mockKubeClient.EXPECT().Get(context.TODO(), testNodeName, gomock.Any()).SetArg(2, node),
+					mockMachineryClient.EXPECT().IsNodeCordoned(gomock.Any()).Return(&machinery.IsCordonedResult{IsCordoned: true, AddedAt: &metav1.Time{Time: time.Now().Add(-10 * time.Minute)}}),
+					mockMetricsBuilder.EXPECT().NewClient(gomock.Any()).Return(mockMetricsClient, nil),
+					mockConfigManagerBuilder.EXPECT().New(gomock.Any(), gomock.Any()).Return(mockConfigManager),
+					mockConfigManager.EXPECT().Into(gomock.Any()).SetArg(0, config),
+					mockDrainStrategyBuilder.EXPECT().NewNodeDrainStrategy(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockDrainStrategy, nil),
+					mockDrainStrategy.EXPECT().Execute(gomock.Any(), gomock.Any()).Return([]*drain.DrainStrategyResult{}, nil),
+					mockDrainStrategy.EXPECT().HasFailed(gomock.Any(), gomock.Any()).Return(true, nil),
+					mockMetricsClient.EXPECT().ResetMetricNodeDrainFailed(gomock.Any()).Times(1),
+					mockMachineryClient.EXPECT().IsNodeUpgrading(gomock.Any()).Times(0),
+					mockMetricsClient.EXPECT().UpdateMetricNodeDrainFailed(gomock.Any()).Times(0),
+				)
+				result, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: testNodeName})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Requeue).To(BeFalse())
+				Expect(result.RequeueAfter).To(Not(BeNil()))
 			})
 		})
 	})


### PR DESCRIPTION
### What type of PR is this?
_bug_


### What this PR does / why we need it?
_Need to add a validation check to the Nodekeeper controller to verify, if the node has a deletion timestamp set then reset the metric and never set it again. This will make sure that we will not get an alert UpgradeNodeDrainFailedSRE once the node is deleted by MHC_
### Which Jira/Github issue(s) this PR fixes?
_Fixes #OSD-20246_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] All the unit tests are passing without errors 

