### PR TITLE
Adding featuregate for PreHealthCheck

### DIFF
--- a/api/v1alpha1/upgradeconfig_types.go
+++ b/api/v1alpha1/upgradeconfig_types.go
@@ -17,6 +17,17 @@ const (
 	ARO UpgradeType = "ARO"
 )
 
+// FeatureGate type defines the feature that managed-upgrade-operator should enable/disable when deployed.
+// By default, if a feature is not listed then it's disabled.
+type FeatureGate string
+
+const (
+	// PreHealthCheckFeatureGate enables running the PreHealthCheck in "New" upgrade phase if the upgrade is scheduled
+	// beyond two hours from current time. PreHealthCheck during "Upgrading" phase is always run irregard of whether
+	// the featuregate is enabled or not.
+	PreHealthCheckFeatureGate FeatureGate = "PreHealthCheck"
+)
+
 // UpgradeConfigSpec defines the desired state of UpgradeConfig and upgrade window and freeze window
 type UpgradeConfigSpec struct {
 	// Specify the desired OpenShift release

--- a/controllers/upgradeconfig/config.go
+++ b/controllers/upgradeconfig/config.go
@@ -7,6 +7,7 @@ import (
 
 type config struct {
 	UpgradeWindow upgradeWindow `yaml:"upgradeWindow"`
+	FeatureGate   featureGate   `yaml:"featureGate"`
 }
 
 type upgradeWindow struct {
@@ -30,4 +31,19 @@ func (cfg *config) GetUpgradeWindowTimeOutDuration() time.Duration {
 
 func (cfg *config) GetUpgradeWindowDelayTriggerDuration() time.Duration {
 	return time.Duration(cfg.UpgradeWindow.DelayTrigger) * time.Minute
+}
+
+type featureGate struct {
+	Enabled []string `yaml:"enabled"`
+}
+
+func (cfg *config) IsFeatureEnabled(feature string) bool {
+	if len(cfg.FeatureGate.Enabled) > 0 {
+		for _, f := range cfg.FeatureGate.Enabled {
+			if f == feature {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/controllers/upgradeconfig/upgradeconfig_controller.go
+++ b/controllers/upgradeconfig/upgradeconfig_controller.go
@@ -154,10 +154,17 @@ func (r *ReconcileUpgradeConfig) Reconcile(ctx context.Context, request reconcil
 	// is done.
 	case upgradev1alpha1.UpgradePhaseNew:
 
+		err = cfm.Into(cfg)
+		if err != nil {
+			reqLogger.Error(err, "Failed to sync configmap")
+			return reconcile.Result{}, err
+		}
+
 		schedulerResult := r.Scheduler.IsReadyToUpgrade(instance, cfg.GetUpgradeWindowTimeOutDuration())
 		timeToUpgrade := schedulerResult.TimeUntilUpgrade.Minutes()
 		healthCheckDuration := instance.GetHealthCheckDuration().Minutes()
-		if time.Duration(timeToUpgrade) > time.Duration(healthCheckDuration) {
+
+		if (time.Duration(timeToUpgrade) > time.Duration(healthCheckDuration)) && cfg.IsFeatureEnabled(string(upgradev1alpha1.PreHealthCheckFeatureGate)) {
 			reqLogger.Info("Running Pre-Health Check for upgrade")
 			// We do not block the upgrade from going to pending state deliberately
 			// since we want to notify and give a heads up regarding pre healthcheck
@@ -168,7 +175,7 @@ func (r *ReconcileUpgradeConfig) Reconcile(ctx context.Context, request reconcil
 				reqLogger.Error(err, "Pre HealthCheck failed on scheduling upgrade")
 			}
 		} else {
-			reqLogger.Info("Skipping pre healthcheck")
+			reqLogger.Info("Skipping PreHealthCheck")
 		}
 
 		history.Phase = upgradev1alpha1.UpgradePhasePending
@@ -187,11 +194,6 @@ func (r *ReconcileUpgradeConfig) Reconcile(ctx context.Context, request reconcil
 	// configmanager (as relevant) and proceed to "Upgrading" phase.
 	case upgradev1alpha1.UpgradePhasePending:
 		reqLogger.Info("Validating UpgradeConfig")
-
-		err = cfm.Into(cfg)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
 
 		// Build a Validator
 		validator, err := r.ValidationBuilder.NewClient(cfm)

--- a/docs/configmap.md
+++ b/docs/configmap.md
@@ -174,3 +174,19 @@ Example:
         urls:
           - http://www.example.com
 ```
+
+#### featureGate
+
+| Key | Description |
+| --- | --- |
+| `enabled` | a list of feature gates to be enabled when managed-upgrade-operator starts |
+
+Currently available featureGates:
+- PreHealthCheck
+
+Example:
+```yaml
+    featureGate:
+      enabled:
+      - PreHealthCheck
+```


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
As MUO is expected to deploy differently in different environments, the ongoing work on PreHealthCheck is set as a featuregate in MUO which is disabled by default and is enabled only if the right configuration is part of the configmap referred by MUO. This work helps in enabling/disabling the feature as required without changing code.

The feature is enabled only if the configmap has the following config:
```yaml
    featureGate:
      enabled:
      - PreHealthCheck
 ```

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [OSD-24482](https://issues.redhat.com/browse/OSD-24482)

### Special notes for your reviewer:


### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR

