### PR TITLE
Adding ServiceLogNotification featureGate for controlling notifications

### DIFF
--- a/api/v1alpha1/upgradeconfig_types.go
+++ b/api/v1alpha1/upgradeconfig_types.go
@@ -26,6 +26,9 @@ const (
 	// beyond two hours from current time. PreHealthCheck during "Upgrading" phase is always run irregard of whether
 	// the featuregate is enabled or not.
 	PreHealthCheckFeatureGate FeatureGate = "PreHealthCheck"
+	// ServiceLogNotificationFeatureGate enables sending the additional servicelog notifications from managed-upgrade-operator during an upgrade.
+	// This feature can be optionally enabled/disabled based on the featureGate configuration in the configmap.
+	ServiceLogNotificationFeatureGate FeatureGate = "ServiceLogNotification"
 )
 
 // UpgradeConfigSpec defines the desired state of UpgradeConfig and upgrade window and freeze window

--- a/docs/configmap.md
+++ b/docs/configmap.md
@@ -183,10 +183,14 @@ Example:
 
 Currently available featureGates:
 - PreHealthCheck
+  - PreHealthCheck featureGate will selectively enable/disable the run of upgrade health check in the "New" upgrade phase if the upgrade is scheduled more than 2 hours. It is disabled by default if the configuration is not part of the configmap.
+- ServiceLogNotification
+  - ServiceLogNotification featureGate will selectively enable/disable the servicelog notifications during an upgrade if the configuration is part of the configmap. It is disabled by default if the configuration is not part of the configmap.
 
 Example:
 ```yaml
     featureGate:
       enabled:
       - PreHealthCheck
+      - ServiceLogNotification
 ```

--- a/pkg/notifier/ocmconfig.go
+++ b/pkg/notifier/ocmconfig.go
@@ -10,6 +10,16 @@ type OcmNotifierConfig struct {
 	ConfigManager OcmNotifierConfigManager `yaml:"configManager"`
 }
 
+// OcmFeatureConfig holds the OCMFeatureGate field for its features configuration
+type OcmFeatureConfig struct {
+	OCMFeatureGate OcmFeatureGates `yaml:"featureGate"`
+}
+
+// OcmFeatureGates holds the list of featuregates that are enabled for OCM
+type OcmFeatureGates struct {
+	Enabled []string `yaml:"enabled"`
+}
+
 // OcmNotifierConfigManager holds the OcmBaseUrl field
 type OcmNotifierConfigManager struct {
 	OcmBaseUrl string `yaml:"ocmBaseUrl"`
@@ -27,4 +37,9 @@ func (cfg *OcmNotifierConfig) IsValid() error {
 func (cfg *OcmNotifierConfig) GetOCMBaseURL() *url.URL {
 	url, _ := url.Parse(cfg.ConfigManager.OcmBaseUrl)
 	return url
+}
+
+// IsValid returns a nil error when the OcmFeatureConfig is valid
+func (cfg *OcmFeatureConfig) IsValid() error {
+	return nil
 }


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
This is a small PR to enabled/disable the servicelog notifications from managed-upgrade-operator depending on the configmap configuration.

The featureGate can be enabled via the following configuration in the configmap:
```yaml
    featureGate:                                                                                                                                                                                                    
      enabled:                                                                                                                                                                                                      
      - ServiceLogNotification
```

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [OSD-24483](https://issues.redhat.com/browse/OSD-24483)

### Special notes for your reviewer:
Following tests were done and was successful:

TEST 1:
1. Setup the following configmap configuration for featureGates:
```yaml
     featureGate:                                                                                                                                                                                                    
      enabled:                                                                                                                                                                                                      
      - PreHealthCheck
      - ServiceLogNotification
```
2. Schedule upgrade for more than 2 hours to trigger PreHealthCheck in "New" phase
3. Make sure there's a failure in any of the PreHealthCheck such that the servicelog notification is sent.
4. The notification count should increase by 1.

TEST 2:
 1. Setup the following configmap configuration for featureGates:
```yaml
     featureGate:                                                                                                                                                                                                    
      enabled:                                                                                                                                                                                                      
      - PreHealthCheck
```
2. Schedule upgrade for more than 2 hours to trigger PreHealthCheck in "New" phase
3. Make sure there's a failure in any of the PreHealthCheck such that the servicelog notification is sent.
4. The notification count should remain the same without any ServiceLog notification.


### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR

