### PR TITLE
Make no worker machinepool PHC as non-failing

### DIFF
--- a/pkg/eventmanager/eventmanager.go
+++ b/pkg/eventmanager/eventmanager.go
@@ -135,6 +135,8 @@ func (s *eventManager) Notify(state notifier.MuoState) error {
 		description = fmt.Sprintf(UPGRADE_SCALE_SKIP_DESC, uc.Spec.Desired.Version)
 	case notifier.MuoStateDelayed:
 		description = createDelayedDescription(uc)
+	case notifier.MuoStateDelayedWorkerMachinepoolNotFound:
+		description = fmt.Sprintf(UPGRADE_DEFAULT_DELAY_DESC, uc.Spec.Desired.Version)
 	case notifier.MuoStateSkipped:
 		description = fmt.Sprintf(UPGRADE_SCALE_DELAY_SKIP_DESC, uc.Spec.Desired.Version)
 	case notifier.MuoStateCompleted:

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -292,7 +292,6 @@ func (c *Counter) UpdateMetricValidationSucceeded(upgradeConfigName string) {
 		float64(0))
 }
 
-
 func (c *Counter) UpdateMetricHealthcheckSucceeded(upgradeConfigName string, reason string, version string, state string) {
 	metricHealthcheckFailed.With(prometheus.Labels{
 		nameLabel:    upgradeConfigName,

--- a/pkg/notifier/notifier.go
+++ b/pkg/notifier/notifier.go
@@ -29,20 +29,21 @@ type NotifierBuilder interface {
 
 // Represents valid notify states that can be reported
 const (
-	MuoStatePending                       MuoState = "StatePending"
-	MuoStateStarted                       MuoState = "StateStarted"
-	MuoStateCompleted                     MuoState = "StateCompleted"
-	MuoStateDelayed                       MuoState = "StateDelayed"
-	MuoStateFailed                        MuoState = "StateFailed"
-	MuoStateCancelled                     MuoState = "StateCancelled"
-	MuoStateScheduled                     MuoState = "StateScheduled"
-	MuoStateScaleSkipped                  MuoState = "StateScaleSkipped"
-	MuoStateSkipped                       MuoState = "StateSkipped"
-	MuoStateHealthCheckSL                 MuoState = "StateHealthCheckSL"
-	MuoStatePreHealthCheckSL              MuoState = "StatePreHealthCheckSL"
-	MuoStateControlPlaneUpgradeStartedSL  MuoState = "StateControlPlaneStartedSL"
-	MuoStateControlPlaneUpgradeFinishedSL MuoState = "StateControlPlaneFinishedSL"
-	MuoStateWorkerPlaneUpgradeFinishedSL  MuoState = "StateWorkerPlaneFinishedSL"
+	MuoStatePending                          MuoState = "StatePending"
+	MuoStateStarted                          MuoState = "StateStarted"
+	MuoStateCompleted                        MuoState = "StateCompleted"
+	MuoStateDelayed                          MuoState = "StateDelayed"
+	MuoStateFailed                           MuoState = "StateFailed"
+	MuoStateCancelled                        MuoState = "StateCancelled"
+	MuoStateScheduled                        MuoState = "StateScheduled"
+	MuoStateScaleSkipped                     MuoState = "StateScaleSkipped"
+	MuoStateSkipped                          MuoState = "StateSkipped"
+	MuoStateHealthCheckSL                    MuoState = "StateHealthCheckSL"
+	MuoStatePreHealthCheckSL                 MuoState = "StatePreHealthCheckSL"
+	MuoStateControlPlaneUpgradeStartedSL     MuoState = "StateControlPlaneStartedSL"
+	MuoStateControlPlaneUpgradeFinishedSL    MuoState = "StateControlPlaneFinishedSL"
+	MuoStateWorkerPlaneUpgradeFinishedSL     MuoState = "StateWorkerPlaneFinishedSL"
+	MuoStateDelayedWorkerMachinepoolNotFound MuoState = "StateDelayedWorkerMachinepoolNotFoundSL"
 )
 
 // MuoState is a type


### PR DESCRIPTION
### What type of PR is this?
_feature_


### What this PR does / why we need it?

For the no worker machinepool PHC, we do not want to fail the PHC. But we would still like to continue notifying the customer that the upgrade will be delayed since there's no worker machinepool. If there's no other PHC failure and there's no worker machinepool, the PHC should not fail.

### Which Jira/Github issue(s) this PR fixes?

_Fixes # [OSD-24705](https://issues.redhat.com/browse/OSD-24705)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster

