### PR TITLE
Make no worker machinepool PHC as non-failing

### DIFF
--- a/pkg/upgraders/healthcheckstep.go
+++ b/pkg/upgraders/healthcheckstep.go
@@ -106,9 +106,9 @@ func (c *clusterUpgrader) PreUpgradeHealthCheck(ctx context.Context, logger logr
 				if err != nil {
 					return false, err
 				}
+				// In the upgrade stage,if the only failure is the capacity reservation,
+				// should not block the upgrade
 				if capacityReservationFailed && len(healthCheckFailed) == 1 {
-					// In the upgrade stage,if there is only one failure and it's capacity reservation failure,
-					// return true which doesn't block the upgrade
 					return true, nil
 				}
 			case " ":

--- a/pkg/upgraders/healthcheckstep_test.go
+++ b/pkg/upgraders/healthcheckstep_test.go
@@ -771,6 +771,48 @@ var _ = Describe("HealthCheck Step", func() {
 			})
 		})
 
+		Context("When cluster is not allowed to scale", func() {
+			var alertsResponse *metrics.AlertResponse
+			pdb := &policyv1.PodDisruptionBudgetList{}
+			JustBeforeEach(func() {
+				alertsResponse = &metrics.AlertResponse{}
+				upgradeConfig.Spec.CapacityReservation = true
+			})
+
+			It("will satisfy a pre-Upgrade health check", func() {
+				gomock.InOrder(
+					mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(false, nil),
+					mockCVClient.EXPECT().GetClusterVersion().Return(mockClusterVersion, nil),
+					mockMetricsClient.EXPECT().Query(gomock.Any()).Return(alertsResponse, nil),
+					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name, metrics.MetricsQueryFailed, gomock.Any(), gomock.Any()),
+					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name, metrics.CriticalAlertsFiring, gomock.Any(), gomock.Any()),
+					mockCVClient.EXPECT().HasDegradedOperators().Return(&clusterversion.HasDegradedOperatorsResult{Degraded: []string{}}, nil),
+					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name, metrics.ClusterOperatorsStatusFailed, gomock.Any(), gomock.Any()),
+					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name, metrics.ClusterOperatorsDegraded, gomock.Any(), gomock.Any()),
+					mockScalerClient.EXPECT().CanScale(gomock.Any(), logger).Return(false, nil),
+					mockMetricsClient.EXPECT().UpdateMetricHealthcheckFailed(upgradeConfig.Name, metrics.DefaultWorkerMachinepoolNotFound, gomock.Any(), gomock.Any()),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes),
+					mockMachineryClient.EXPECT().IsNodeCordoned(gomock.Any()).Return(&machinery.IsCordonedResult{IsCordoned: false, AddedAt: cordonAddedTime}),
+					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name, metrics.ClusterNodeQueryFailed, gomock.Any(), gomock.Any()),
+					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name, metrics.ClusterNodesManuallyCordoned, gomock.Any(), gomock.Any()),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *nodes),
+					mockMachineryClient.EXPECT().HasMemoryPressure(gomock.Any()).Return(false),
+					mockMachineryClient.EXPECT().HasDiskPressure(gomock.Any()).Return(false),
+					mockMachineryClient.EXPECT().HasPidPressure(gomock.Any()).Return(false),
+					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name, metrics.ClusterNodeQueryFailed, gomock.Any(), gomock.Any()),
+					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name, metrics.ClusterNodesTaintedUnschedulable, gomock.Any(), gomock.Any()),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *pdb),
+					mockdvobuilderclient.EXPECT().New(gomock.Any()).Return(mockdvoclient, nil),
+					mockdvoclient.EXPECT().GetMetrics().Return([]byte{}, nil),
+					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name, metrics.ClusterInvalidPDB, gomock.Any(), gomock.Any()),
+					mockEMClient.EXPECT().NotifyResult(gomock.Any(), gomock.Any()).Return(nil),
+				)
+				result, err := upgrader.PreUpgradeHealthCheck(context.TODO(), logger)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+		})
+
 		Context("When node is cordoned manually", func() {
 			var alertsResponse *metrics.AlertResponse
 			nodes := &corev1.NodeList{


### PR DESCRIPTION
### What type of PR is this?
_feature_


### What this PR does / why we need it?

For the no worker machinepool PHC, we do not want to fail the PHC. But we would still like to continue notifying the customer that the upgrade will be delayed since there's no worker machinepool. If there's no other PHC failure and there's no worker machinepool, the PHC should not fail.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #[OSD-24705](https://issues.redhat.com//browse/OSD-24705) 

### Special notes for your reviewer:
Previous MR https://github.com/openshift/managed-upgrade-operator/pull/457 where there are some comments.
Mentioned here for reference only. 

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster

