### PR TITLE
OSD-25179 - Avoid deadlock when lockfile is presetn

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,8 @@ require (
 	github.com/openshift/machine-config-operator v0.0.1-0.20230330142923-2832f049b3f4
 	github.com/openshift/operator-custom-metrics v0.5.1
 	github.com/openshift/osde2e-common v0.0.0-20240531074950-36a7055798ae
+	// Note: Please revisit the stop-gap in ./main.go > cleanupLockForLeader when updating operator-lib module.
+	// If the issue has been fixed upstream, the stop-gap should be removed.
 	github.com/operator-framework/operator-lib v0.12.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.71.0
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.71.0

--- a/main.go
+++ b/main.go
@@ -122,6 +122,9 @@ func printVersion() {
 }
 
 // This function is used to pre-emptively avoid a deadlock
+// Note: This is a stop-gap solution until a fix has been implemented
+// upstream in operator-framework/operator-lib. This function and it's
+// usage should be removed once a fix is implemented upstream.
 func cleanupLockForLeader(ns string, crclient client.Client) {
 	lockConfigMap := &corev1.ConfigMap{}
 	key := client.ObjectKey{Namespace: ns, Name: muoLockConfigMapName}
@@ -162,6 +165,9 @@ func cleanupLockForLeader(ns string, crclient client.Client) {
 	setupLog.Info(fmt.Sprintf("Lock deleted with name %s in namespace %s", key.Name, key.Namespace))
 }
 
+// Note: This function is used by a stop-gap solution until a fix has been implemented
+// upstream in operator-framework/operator-lib. This function and it's
+// usage should be removed once a fix is implemented upstream.
 func getMUOPods(ns string, crclient client.Client) (corev1.PodList, error) {
 	fmt.Printf("Looking in %s\n", ns)
 	pods := &corev1.PodList{}


### PR DESCRIPTION
### What type of PR is this?
bug


### What this PR does / why we need it?
MUO can sometimes get stuck in a deadlock if a pre-existing lockfile has ownerReference mismatch. This PR pre-emtively removes the lock file to avoid such scenario.

### Which Jira/Github issue(s) this PR fixes?

[OSD-25179](https://issues.redhat.com/browse/OSD-25179)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster

