### PR TITLE
OSD-26790 continue upgrade despite notif failure

### DIFF
--- a/pkg/upgraders/controlplanestep.go
+++ b/pkg/upgraders/controlplanestep.go
@@ -51,7 +51,7 @@ func (c *clusterUpgrader) ControlPlaneUpgraded(ctx context.Context, logger logr.
 	if isCompleted {
 		err = c.notifier.Notify(notifier.MuoStateControlPlaneUpgradeFinishedSL)
 		if err != nil {
-			return false, err
+			logger.Error(err, fmt.Sprintf("Failed to notify upon upgrade completion %v", err))
 		}
 		c.metrics.ResetMetricUpgradeControlPlaneTimeout(c.upgradeConfig.Name, c.upgradeConfig.Spec.Desired.Version)
 		return true, nil

--- a/pkg/upgraders/controlplanestep_test.go
+++ b/pkg/upgraders/controlplanestep_test.go
@@ -103,10 +103,11 @@ var _ = Describe("ControlPlaneStep", func() {
 					mockCVClient.EXPECT().GetClusterVersion().Return(nil, nil),
 					mockCVClient.EXPECT().HasUpgradeCompleted(gomock.Any(), gomock.Any()).Return(true),
 					mockEMClient.EXPECT().Notify(gomock.Any()).Return(fakeError),
+					mockMetricsClient.EXPECT().ResetMetricUpgradeControlPlaneTimeout(upgradeConfig.Name, upgradeConfig.Spec.Desired.Version),
 				)
 				result, err := upgrader.ControlPlaneUpgraded(context.TODO(), logger)
-				Expect(err).To(HaveOccurred())
-				Expect(result).To(BeFalse())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
 			})
 		})
 


### PR DESCRIPTION
### What type of PR is this?
bug


### What this PR does / why we need it?
Fixes MUO upgrade completion blocked by SL failure.

### Which Jira/Github issue(s) this PR fixes?
[OSD-26790](https://issues.redhat.com//browse/OSD-26790)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

