### PR TITLE
OSD-26790: Adding metric of SL failure

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1154
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179
 
 ENV USER_UID=1001 \
     USER_NAME=managed-upgrade-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1154
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/pkg/eventmanager/eventmanager.go
+++ b/pkg/eventmanager/eventmanager.go
@@ -154,8 +154,10 @@ func (s *eventManager) Notify(state notifier.MuoState) error {
 	// Send the notification
 	err = s.notifier.NotifyState(state, description)
 	if err != nil {
+		s.metrics.UpdatemetricUpgradeNotificationFailed(uc.Name, string(state))
 		return fmt.Errorf("can't send notification '%s': %v", state, err)
 	}
+	s.metrics.UpdatemetricUpgradeNotificationSucceeded(uc.Name, string(state))
 	s.metrics.UpdateMetricNotificationEventSent(uc.Name, string(state), uc.Spec.Desired.Version)
 
 	return nil

--- a/pkg/eventmanager/eventmanager_test.go
+++ b/pkg/eventmanager/eventmanager_test.go
@@ -93,6 +93,7 @@ var _ = Describe("OCM Notifier", func() {
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION).Return(false, nil),
 					mockNotifier.EXPECT().NotifyState(testState, gomock.Any()),
+					mockMetricsClient.EXPECT().UpdatemetricUpgradeNotificationSucceeded(TEST_UPGRADECONFIG_CR, string(testState)),
 					mockMetricsClient.EXPECT().UpdateMetricNotificationEventSent(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION),
 				)
 				err := manager.Notify(testState)
@@ -106,6 +107,7 @@ var _ = Describe("OCM Notifier", func() {
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION).Return(false, nil),
 					mockNotifier.EXPECT().NotifyState(testState, gomock.Any()).Return(fakeError),
+					mockMetricsClient.EXPECT().UpdatemetricUpgradeNotificationFailed(TEST_UPGRADECONFIG_CR, string(testState)),
 				)
 				err := manager.Notify(testState)
 				Expect(err).NotTo(BeNil())
@@ -143,6 +145,7 @@ var _ = Describe("OCM Notifier", func() {
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION).Return(false, nil),
 					mockNotifier.EXPECT().NotifyState(testState, expectedDescription),
+					mockMetricsClient.EXPECT().UpdatemetricUpgradeNotificationSucceeded(TEST_UPGRADECONFIG_CR, string(testState)),
 					mockMetricsClient.EXPECT().UpdateMetricNotificationEventSent(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION),
 				)
 				err := manager.Notify(testState)
@@ -165,6 +168,7 @@ var _ = Describe("OCM Notifier", func() {
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION).Return(false, nil),
 					mockNotifier.EXPECT().NotifyState(testState, expectedDescription),
+					mockMetricsClient.EXPECT().UpdatemetricUpgradeNotificationSucceeded(TEST_UPGRADECONFIG_CR, string(testState)),
 					mockMetricsClient.EXPECT().UpdateMetricNotificationEventSent(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION),
 				)
 				err := manager.Notify(testState)
@@ -187,6 +191,7 @@ var _ = Describe("OCM Notifier", func() {
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION).Return(false, nil),
 					mockNotifier.EXPECT().NotifyState(testState, expectedDescription),
+					mockMetricsClient.EXPECT().UpdatemetricUpgradeNotificationSucceeded(TEST_UPGRADECONFIG_CR, string(testState)),
 					mockMetricsClient.EXPECT().UpdateMetricNotificationEventSent(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION),
 				)
 				err := manager.Notify(testState)
@@ -209,6 +214,7 @@ var _ = Describe("OCM Notifier", func() {
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION).Return(false, nil),
 					mockNotifier.EXPECT().NotifyState(testState, expectedDescription),
+					mockMetricsClient.EXPECT().UpdatemetricUpgradeNotificationSucceeded(TEST_UPGRADECONFIG_CR, string(testState)),
 					mockMetricsClient.EXPECT().UpdateMetricNotificationEventSent(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION),
 				)
 				err := manager.Notify(testState)
@@ -247,6 +253,7 @@ var _ = Describe("OCM Notifier", func() {
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION).Return(false, nil),
 					mockNotifier.EXPECT().NotifyState(testState, expectedDescription),
+					mockMetricsClient.EXPECT().UpdatemetricUpgradeNotificationSucceeded(TEST_UPGRADECONFIG_CR, string(testState)),
 					mockMetricsClient.EXPECT().UpdateMetricNotificationEventSent(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION),
 				)
 				err := manager.Notify(testState)
@@ -269,6 +276,7 @@ var _ = Describe("OCM Notifier", func() {
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION).Return(false, nil),
 					mockNotifier.EXPECT().NotifyState(testState, expectedDescription),
+					mockMetricsClient.EXPECT().UpdatemetricUpgradeNotificationSucceeded(TEST_UPGRADECONFIG_CR, string(testState)),
 					mockMetricsClient.EXPECT().UpdateMetricNotificationEventSent(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION),
 				)
 				err := manager.Notify(testState)
@@ -291,6 +299,7 @@ var _ = Describe("OCM Notifier", func() {
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION).Return(false, nil),
 					mockNotifier.EXPECT().NotifyState(testState, expectedDescription),
+					mockMetricsClient.EXPECT().UpdatemetricUpgradeNotificationSucceeded(TEST_UPGRADECONFIG_CR, string(testState)),
 					mockMetricsClient.EXPECT().UpdateMetricNotificationEventSent(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION),
 				)
 				err := manager.Notify(testState)
@@ -313,6 +322,7 @@ var _ = Describe("OCM Notifier", func() {
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
 					mockMetricsClient.EXPECT().IsMetricNotificationEventSentSet(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION).Return(false, nil),
 					mockNotifier.EXPECT().NotifyState(testState, expectedDescription),
+					mockMetricsClient.EXPECT().UpdatemetricUpgradeNotificationSucceeded(TEST_UPGRADECONFIG_CR, string(testState)),
 					mockMetricsClient.EXPECT().UpdateMetricNotificationEventSent(TEST_UPGRADECONFIG_CR, string(testState), TEST_UPGRADE_VERSION),
 				)
 				err := manager.Notify(testState)

--- a/pkg/metrics/mocks/metrics.go
+++ b/pkg/metrics/mocks/metrics.go
@@ -354,3 +354,27 @@ func (mr *MockMetricsMockRecorder) UpdateMetricValidationSucceeded(arg0 any) *go
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetricValidationSucceeded", reflect.TypeOf((*MockMetrics)(nil).UpdateMetricValidationSucceeded), arg0)
 }
+
+// UpdatemetricUpgradeNotificationFailed mocks base method.
+func (m *MockMetrics) UpdatemetricUpgradeNotificationFailed(arg0, arg1 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdatemetricUpgradeNotificationFailed", arg0, arg1)
+}
+
+// UpdatemetricUpgradeNotificationFailed indicates an expected call of UpdatemetricUpgradeNotificationFailed.
+func (mr *MockMetricsMockRecorder) UpdatemetricUpgradeNotificationFailed(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatemetricUpgradeNotificationFailed", reflect.TypeOf((*MockMetrics)(nil).UpdatemetricUpgradeNotificationFailed), arg0, arg1)
+}
+
+// UpdatemetricUpgradeNotificationSucceeded mocks base method.
+func (m *MockMetrics) UpdatemetricUpgradeNotificationSucceeded(arg0, arg1 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdatemetricUpgradeNotificationSucceeded", arg0, arg1)
+}
+
+// UpdatemetricUpgradeNotificationSucceeded indicates an expected call of UpdatemetricUpgradeNotificationSucceeded.
+func (mr *MockMetricsMockRecorder) UpdatemetricUpgradeNotificationSucceeded(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatemetricUpgradeNotificationSucceeded", reflect.TypeOf((*MockMetrics)(nil).UpdatemetricUpgradeNotificationSucceeded), arg0, arg1)
+}


### PR DESCRIPTION
### What type of PR is this?
_(bug)_


### What this PR does / why we need it?
When the user gets banned (OR) PS has been rotated in a middle of the upgrade, the upgrade will stall. We're creating a metric if MUO unable to notify it's state to the OCM. This metric will help us to track via PD, so that we can unblock the upgrade.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [OSD-26790](https://issues.redhat.com//browse/OSD-26790)
