### PR TITLE
OSD-25133 add node name with healthcheck failure

### DIFF
--- a/pkg/upgraders/healthcheck_nodes_test.go
+++ b/pkg/upgraders/healthcheck_nodes_test.go
@@ -83,7 +83,7 @@ var _ = Describe("HealthCheck Manually Cordoned node", func() {
 			)
 			result, err := ManuallyCordonedNodes(mockMetricsClient, mockMachineryClient, mockKubeClient, upgradeConfig, logger, version)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(result).Should(BeTrue())
+			Expect(result).Should(BeNil())
 		})
 	})
 
@@ -108,7 +108,7 @@ var _ = Describe("HealthCheck Manually Cordoned node", func() {
 			)
 			result, err := ManuallyCordonedNodes(mockMetricsClient, mockMachineryClient, mockKubeClient, upgradeConfig, logger, version)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(result).Should(BeTrue())
+			Expect(result).Should(BeNil())
 		})
 	})
 
@@ -118,7 +118,7 @@ var _ = Describe("HealthCheck Manually Cordoned node", func() {
 			mockMetricsClient.EXPECT().UpdateMetricHealthcheckFailed(upgradeConfig.Name, gomock.Any(), gomock.Any(), gomock.Any())
 			result, err := ManuallyCordonedNodes(mockMetricsClient, mockMachineryClient, mockKubeClient, upgradeConfig, logger, version)
 			Expect(err).Should(HaveOccurred())
-			Expect(result).Should(BeFalse())
+			Expect(result).Should(BeNil())
 		})
 	})
 
@@ -142,7 +142,7 @@ var _ = Describe("HealthCheck Manually Cordoned node", func() {
 			)
 			result, err := ManuallyCordonedNodes(mockMetricsClient, mockMachineryClient, mockKubeClient, upgradeConfig, logger, version)
 			Expect(err).Should(HaveOccurred())
-			Expect(result).Should(BeFalse())
+			Expect(result).Should(Not(BeNil()))
 		})
 	})
 	Context("When nodes has unschedule taints", func() {
@@ -154,7 +154,7 @@ var _ = Describe("HealthCheck Manually Cordoned node", func() {
 			)
 			result, err := NodeUnschedulableTaints(mockMetricsClient, mockMachineryClient, mockKubeClient, upgradeConfig, logger, version)
 			Expect(err).Should(HaveOccurred())
-			Expect(result).Should(BeFalse())
+			Expect(result).Should(BeNil())
 		})
 
 	})


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
[PHC] Include node details in mail notifications for node related PHC failures

### Which Jira/Github issue(s) this PR fixes?
[OSD-25133](https://issues.redhat.com/browse/OSD-25133)


_Fixes #_
As part of NodeUnschedulableHealthcheckFailed and NodeUnschedulableTaintHealthcheckFailed PreHealthCheck implemented in https://issues.redhat.com/browse/OSD-22457 and  https://issues.redhat.com/browse/OSD-23984 it would be more productive and easy for customers to know which node is having issue and what action should customer take to address the issue.

