### PR TITLE
SL/Mail notifications for PDB failure with PDB details

### DIFF
--- a/pkg/upgraders/healthcheck_pdb.go
+++ b/pkg/upgraders/healthcheck_pdb.go
@@ -19,55 +19,61 @@ var namespaceException = []string{"openshift-logging", "openshift-redhat-marketp
 // HealthCheckPDB performs a health check on the PodDisruptionBudget (PDB) metrics.
 // It returns true if the health check passes, false otherwise.
 // It also returns an error if there was an issue performing the health check.
-func HealthCheckPDB(metricsClient metrics.Metrics, c client.Client, dvo dvo.DvoClientBuilder, ug *upgradev1alpha1.UpgradeConfig, logger logr.Logger, version string) (bool, error) {
+func HealthCheckPDB(metricsClient metrics.Metrics, c client.Client, dvo dvo.DvoClientBuilder, ug *upgradev1alpha1.UpgradeConfig, logger logr.Logger, version string) ([]PDBDetails, bool, error) {
 
 	// Get current cluster version and upgrade state info
 	history := ug.Status.History.GetHistory(ug.Spec.Desired.Version)
 	state := string(history.Phase)
 
-	reason, err := checkPodDisruptionBudgets(c, logger)
+	pdbDetails, reason, err := checkPodDisruptionBudgets(c, logger)
 	if err != nil {
 		metricsClient.UpdateMetricHealthcheckFailed(ug.Name, reason, version, state)
-		return false, err
+		return pdbDetails, false, err
 	}
 
 	reason, err = checkDvoMetrics(c, dvo, logger)
 	if err != nil {
 		metricsClient.UpdateMetricHealthcheckFailed(ug.Name, reason, version, state)
-		return false, err
+		return pdbDetails, false, err
 	}
 	// Health check passed
 	logger.Info("Prehealth check for PodDisruptionBudget passed")
 	metricsClient.UpdateMetricHealthcheckSucceeded(ug.Name, metrics.ClusterInvalidPDB, version, state)
 
-	return true, nil
+	return pdbDetails, true, nil
 }
 
-func checkPodDisruptionBudgets(c client.Client, logger logr.Logger) (string, error) {
+func checkPodDisruptionBudgets(c client.Client, logger logr.Logger) ([]PDBDetails, string, error) {
 	// List all PodDisruptionBudgets
 	pdbList := &policyv1.PodDisruptionBudgetList{}
+	pdbDetails := []PDBDetails{}
 	err := c.List(context.TODO(), pdbList)
 	if err != nil {
 		logger.Info("unable to list PodDisruptionBudgets/v1")
-		return metrics.PDBQueryFailed, err
+		return pdbDetails, metrics.PDBQueryFailed, err
 	}
 
 	for _, pdb := range pdbList.Items {
 		if !strings.HasPrefix(pdb.Namespace, "openshift-*") || checkNamespaceExistsInArray(namespaceException, pdb.Namespace) {
+			pdbDetail := PDBDetails{}
+			pdbDetail.Name = pdb.Name
+			pdbDetail.Namespace = pdb.Namespace
 
 			maxResult, err := validateMaxUnavailable(pdb, logger)
 			if !maxResult {
-				return metrics.ClusterInvalidPDBConf, err
+				pdbDetails = append(pdbDetails, pdbDetail)
+				return pdbDetails, metrics.ClusterInvalidPDBConf, err
 			}
 
 			minResult, err := validateMinAvailable(pdb, logger)
 			if !minResult {
-				return metrics.ClusterInvalidPDBConf, err
+				pdbDetails = append(pdbDetails, pdbDetail)
+				return pdbDetails, metrics.ClusterInvalidPDBConf, err
 			}
 		}
 	}
 
-	return "", nil
+	return pdbDetails, "", nil
 }
 
 func checkNamespaceExistsInArray(namespaceException []string, s string) bool {

--- a/pkg/upgraders/healthcheck_pdb_test.go
+++ b/pkg/upgraders/healthcheck_pdb_test.go
@@ -83,9 +83,10 @@ var _ = Describe("checkPodDisruptionBudgets", func() {
 				mockClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *pdbList),
 				mockMetricsClient.EXPECT().UpdateMetricHealthcheckFailed(upgradeConfig.Name, reason, version, "New"),
 			)
-			result, err := HealthCheckPDB(mockMetricsClient, mockClient, mockdvoclientbulder, upgradeConfig, logger, version)
+			pdbDetails, result, err := HealthCheckPDB(mockMetricsClient, mockClient, mockdvoclientbulder, upgradeConfig, logger, version)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(Equal(false))
+			Expect(pdbDetails).ShouldNot(BeEmpty())
 		})
 	})
 
@@ -124,9 +125,10 @@ var _ = Describe("checkPodDisruptionBudgets", func() {
 				mockClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *pdbList),
 				mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name, reason, version, metrics.ClusterInvalidPDB),
 			)
-			result, err := checkPodDisruptionBudgets(mockClient, logger)
+			pdbDetails, result, err := checkPodDisruptionBudgets(mockClient, logger)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeEmpty())
+			Expect(pdbDetails).To(BeEmpty())
 		})
 	})
 
@@ -153,9 +155,10 @@ var _ = Describe("checkPodDisruptionBudgets", func() {
 				mockClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *pdbList),
 				mockMetricsClient.EXPECT().UpdateMetricHealthcheckFailed(upgradeConfig.Name, reason, version, "New"),
 			)
-			result, err := checkPodDisruptionBudgets(mockClient, logger)
+			pdbDetails, result, err := checkPodDisruptionBudgets(mockClient, logger)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(Equal(metrics.ClusterInvalidPDBConf))
+			Expect(pdbDetails).ShouldNot(BeEmpty())
 		})
 
 		It("Prehealth PDB check will fail will fail when maxunavailable is 0%", func() {
@@ -180,9 +183,10 @@ var _ = Describe("checkPodDisruptionBudgets", func() {
 				mockClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *pdbList),
 				mockMetricsClient.EXPECT().UpdateMetricHealthcheckFailed(upgradeConfig.Name, reason, version, "New"),
 			)
-			result, err := checkPodDisruptionBudgets(mockClient, logger)
+			pdbDetails, result, err := checkPodDisruptionBudgets(mockClient, logger)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(Equal(metrics.ClusterInvalidPDBConf))
+			Expect(pdbDetails).ShouldNot(BeEmpty())
 		})
 	})
 
@@ -209,9 +213,10 @@ var _ = Describe("checkPodDisruptionBudgets", func() {
 				mockClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(1, *pdbList),
 				mockMetricsClient.EXPECT().UpdateMetricHealthcheckFailed(upgradeConfig.Name, reason, version, "New"),
 			)
-			result, err := checkPodDisruptionBudgets(mockClient, logger)
+			pdbDetails, result, err := checkPodDisruptionBudgets(mockClient, logger)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(Equal(metrics.ClusterInvalidPDBConf))
+			Expect(pdbDetails).ShouldNot(BeEmpty())
 		})
 	})
 
@@ -222,9 +227,10 @@ var _ = Describe("checkPodDisruptionBudgets", func() {
 				mockClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("Fake cannot fetch all pdb ")),
 				mockMetricsClient.EXPECT().UpdateMetricHealthcheckFailed(upgradeConfig.Name, reason, version, "New"),
 			)
-			result, err := checkPodDisruptionBudgets(mockClient, logger)
+			pdbDetails, result, err := checkPodDisruptionBudgets(mockClient, logger)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(Equal(metrics.PDBQueryFailed))
+			Expect(pdbDetails).To(BeEmpty())
 		})
 	})
 


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
SL/mail notifications for PDB failure should include the PDB details with namespace and PDB name

### Which Jira/Github issue(s) this PR fixes?
_Fixes #_https://issues.redhat.com/browse/OSD-25132

### Special notes for your reviewer:
Tested the changes by creating cluster on staging

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

