### PR TITLE
Osd 28839 mc should fire alert when node drain takes long time

### DIFF
--- a/controllers/nodekeeper/nodekeeper_controller.go
+++ b/controllers/nodekeeper/nodekeeper_controller.go
@@ -145,7 +145,7 @@ func (r *ReconcileNodeKeeper) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-// SetupWithManager sets up the controller with the Manager.
+// Check the NodeDrainResult
 func (r *ReconcileNodeKeeper) NodeDrainResult(node *corev1.Node, reqLogger logr.Logger, hasFailed bool, metricsClient metrics.Metrics) {
 
 	if hasFailed {

--- a/controllers/nodekeeper/nodekeeper_controller.go
+++ b/controllers/nodekeeper/nodekeeper_controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/openshift/managed-upgrade-operator/config"
 
 	upgradev1alpha1 "github.com/openshift/managed-upgrade-operator/api/v1alpha1"
@@ -119,23 +120,18 @@ func (r *ReconcileNodeKeeper) Reconcile(ctx context.Context, request reconcile.R
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-		if hasFailed {
-			// If the node.DeletionTimestamp is set NodeDrainFailed metric needs to be reset
-			if node.DeletionTimestamp != nil {
-				reqLogger.Info(fmt.Sprintf("DeletionTimestamp set for the node %s. Re-setting NodeDrainFailed metric",
-					node.Name))
-				metricsClient.ResetMetricNodeDrainFailed(node.Name)
-			} else {
-				reqLogger.Info(fmt.Sprintf("Node drain timed out %s. Alerting.", node.Name))
-				// Set metric only for the node going through upgrade
-				if r.Machinery.IsNodeUpgrading(node) {
-					metricsClient.UpdateMetricNodeDrainFailed(node.Name)
-				}
-				return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
-			}
-		} else {
-			metricsClient.ResetMetricNodeDrainFailed(node.Name)
+		r.NodeDrainResult(node, reqLogger, hasFailed, metricsClient)
+	} else {
+		drainStrategy, err := r.DrainstrategyBuilder.NewDefaultNodeDrainStrategy(r.Client, reqLogger, uc, &cfg.NodeDrain)
+		if err != nil {
+			reqLogger.Error(err, "Error while executing drain.")
+			return reconcile.Result{}, err
 		}
+		hasFailed, err := drainStrategy.HasFailed(node, reqLogger)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		r.NodeDrainResult(node, reqLogger, hasFailed, metricsClient)
 	}
 
 	return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
@@ -147,4 +143,25 @@ func (r *ReconcileNodeKeeper) SetupWithManager(mgr ctrl.Manager) error {
 		For(&corev1.Node{}).
 		WithEventFilter(IgnoreMasterPredicate()).
 		Complete(r)
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ReconcileNodeKeeper) NodeDrainResult(node *corev1.Node, reqLogger logr.Logger, hasFailed bool, metricsClient metrics.Metrics) {
+
+	if hasFailed {
+		// If the node.DeletionTimestamp is set NodeDrainFailed metric needs to be reset
+		if node.DeletionTimestamp != nil {
+			reqLogger.Info(fmt.Sprintf("DeletionTimestamp set for the node %s. Re-setting NodeDrainFailed metric",
+				node.Name))
+			metricsClient.ResetMetricNodeDrainFailed(node.Name)
+		} else {
+			reqLogger.Info(fmt.Sprintf("Node drain timed out %s. Alerting.", node.Name))
+			// Set metric only for the node going through upgrade
+			if r.Machinery.IsNodeUpgrading(node) {
+				metricsClient.UpdateMetricNodeDrainFailed(node.Name)
+			}
+		}
+	} else {
+		metricsClient.ResetMetricNodeDrainFailed(node.Name)
+	}
 }

--- a/controllers/nodekeeper/nodekeeper_controller_test.go
+++ b/controllers/nodekeeper/nodekeeper_controller_test.go
@@ -126,7 +126,7 @@ var _ = Describe("NodeKeeperController", func() {
 					},
 				}
 			})
-			It("should not execute drain strategies if disabled", func() {
+			It("Alerting if nodedrain takes long time when strategies if disabled", func() {
 				gomock.InOrder(
 					mockUpgradeConfigManagerBuilder.EXPECT().NewManager(gomock.Any()).Return(mockUpgradeConfigManager, nil),
 					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
@@ -136,6 +136,11 @@ var _ = Describe("NodeKeeperController", func() {
 					mockMetricsBuilder.EXPECT().NewClient(gomock.Any()).Return(mockMetricsClient, nil),
 					mockConfigManagerBuilder.EXPECT().New(gomock.Any(), gomock.Any()).Return(mockConfigManager),
 					mockConfigManager.EXPECT().Into(gomock.Any()).SetArg(0, config),
+					mockDrainStrategyBuilder.EXPECT().NewDefaultNodeDrainStrategy(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockDrainStrategy, nil),
+					mockDrainStrategy.EXPECT().HasFailed(gomock.Any(), gomock.Any()).Return(true, nil),
+					mockMachineryClient.EXPECT().IsNodeUpgrading(gomock.Any()).Return(true),
+					mockMetricsClient.EXPECT().UpdateMetricNodeDrainFailed(gomock.Any()).Times(1),
+					mockMetricsClient.EXPECT().ResetMetricNodeDrainFailed(gomock.Any()).Times(0),
 				)
 				result, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: testNodeName})
 				Expect(err).NotTo(HaveOccurred())

--- a/controllers/nodekeeper/nodekeeper_suite_test.go
+++ b/controllers/nodekeeper/nodekeeper_suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestUpgradeConfig(t *testing.T) {
+func TestNodeKeeperController(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "NodeKeeperController Suite")
 }

--- a/pkg/drain/mocks/nodeDrainStrategyBuilder.go
+++ b/pkg/drain/mocks/nodeDrainStrategyBuilder.go
@@ -42,6 +42,21 @@ func (m *MockNodeDrainStrategyBuilder) EXPECT() *MockNodeDrainStrategyBuilderMoc
 	return m.recorder
 }
 
+// NewDefaultNodeDrainStrategy mocks base method.
+func (m *MockNodeDrainStrategyBuilder) NewDefaultNodeDrainStrategy(arg0 client.Client, arg1 logr.Logger, arg2 *v1alpha1.UpgradeConfig, arg3 *drain.NodeDrain) (drain.NodeDrainStrategy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewDefaultNodeDrainStrategy", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(drain.NodeDrainStrategy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NewDefaultNodeDrainStrategy indicates an expected call of NewDefaultNodeDrainStrategy.
+func (mr *MockNodeDrainStrategyBuilderMockRecorder) NewDefaultNodeDrainStrategy(arg0, arg1, arg2, arg3 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewDefaultNodeDrainStrategy", reflect.TypeOf((*MockNodeDrainStrategyBuilder)(nil).NewDefaultNodeDrainStrategy), arg0, arg1, arg2, arg3)
+}
+
 // NewNodeDrainStrategy mocks base method.
 func (m *MockNodeDrainStrategyBuilder) NewNodeDrainStrategy(arg0 client.Client, arg1 logr.Logger, arg2 *v1alpha1.UpgradeConfig, arg3 *drain.NodeDrain) (drain.NodeDrainStrategy, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### What type of PR is this?
This is a bug fix


### What this PR does / why we need it?
The PR make sure nodekeeper controller is still monitoring the node drain process and set node drain failed metric when node drain takes long time.
### Which Jira/Github issue(s) this PR fixes?
[Osd-28839](https://issues.redhat.com//browse/Osd-28839)

Because nodedrain strategy is disabled on MC currently. There is no node drain failed metric is set when node drain takes long time. SRE is not able to know the node drain is stuck for a long time on the MC which lead to long upgrade time on the MC.
The PR make sure there is still default drain strategy is setup to monitoring the node drain process and set the metric when node drain takes long time

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

