### PR TITLE
[SREP-366] remove leader election logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/openshift/machine-config-operator v0.0.1-0.20230330142923-2832f049b3f4
 	github.com/openshift/operator-custom-metrics v0.5.1
 	github.com/openshift/osde2e-common v0.0.0-20240531074950-36a7055798ae
-	github.com/operator-framework/operator-lib v0.15.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.74.0
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.71.0
 	github.com/prometheus/alertmanager v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -634,8 +634,6 @@ github.com/openshift/osde2e-common v0.0.0-20240531074950-36a7055798ae/go.mod h1:
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
-github.com/operator-framework/operator-lib v0.15.0 h1:0QeRM4PMtThqINpcFGCEBnIV3Z8u7/8fYLEx6mUtdcM=
-github.com/operator-framework/operator-lib v0.15.0/go.mod h1:ZxLvFuQ7bRWiTNBOqodbuNvcsy/Iq0kOygdxhlbNdI0=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/main.go
+++ b/main.go
@@ -76,8 +76,6 @@ import (
 
 	opmetrics "github.com/openshift/operator-custom-metrics/pkg/metrics"
 
-	"github.com/operator-framework/operator-lib/leader"
-
 	configv1 "github.com/openshift/api/config/v1"
 	machineapi "github.com/openshift/api/machine/v1beta1"
 
@@ -118,13 +116,10 @@ func printVersion() {
 
 func main() {
 	var metricsAddr string
-	var enableLeaderElection bool
 	var probeAddr string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":"+fmt.Sprintf("%d", metricsPort), "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
-		"Enable leader election for controller manager. "+
-			"Enabling this will ensure there is only one active controller manager.")
+
 	opts := zap.Options{
 		Development: true,
 	}
@@ -164,8 +159,7 @@ func main() {
 			BindAddress: metricsAddr,
 		},
 		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "312e6264.managed.openshift.io",
+		LeaderElection:         false,
 		NewClient: func(config *rest.Config, options client.Options) (client.Client, error) {
 			options.Cache = nil
 			return client.New(config, options)
@@ -173,22 +167,6 @@ func main() {
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
-		os.Exit(1)
-	}
-
-	// Ensure lock for leader election
-	_, err = k8sutil.GetOperatorNamespace()
-	switch err {
-	case nil:
-		err = leader.Become(context.TODO(), "managed-upgrade-operator-lock")
-		if err != nil {
-			setupLog.Error(err, "failed to create leader lock")
-			os.Exit(1)
-		}
-	case k8sutil.ErrRunLocal, k8sutil.ErrNoNamespace:
-		setupLog.Info("Skipping leader election; not running in a cluster.")
-	default:
-		setupLog.Error(err, "Failed to get operator namespace")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
### What type of PR is this?
_(refactor)_


### What this PR does / why we need it?
- Remove leader election logic because MUO runs with a single replica (single instance), no risk of conflicting.


### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [SREP-366](https://issues.redhat.com/browse/SREP-366)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

