### PR TITLE
Enabling Lease based leader-election for MUO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ boilerplate-update: ## Make boilerplate update itself
 
 .PHONY: run
 run:
-	ENABLE_LEADER_ELECTION_NAMESPACE="true" OPERATOR_NAMESPACE="openshift-managed-upgrade-operator" WATCH_NAMESPACE="" go run ./main.go
+	OPERATOR_NAMESPACE="openshift-managed-upgrade-operator" WATCH_NAMESPACE="" go run ./main.go
 
 .PHONY: tools
 tools: ## Install local go tools for MUO

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ boilerplate-update: ## Make boilerplate update itself
 
 .PHONY: run
 run:
-	OPERATOR_NAMESPACE="openshift-managed-upgrade-operator" WATCH_NAMESPACE="" go run ./main.go
+	ENABLE_LEADER_ELECTION_NAMESPACE="true" OPERATOR_NAMESPACE="openshift-managed-upgrade-operator" WATCH_NAMESPACE="" go run ./main.go
 
 .PHONY: tools
 tools: ## Install local go tools for MUO

--- a/deploy/managed_upgrade_role.yaml
+++ b/deploy/managed_upgrade_role.yaml
@@ -29,3 +29,22 @@ rules:
   - list
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/development/port-forwards
+++ b/development/port-forwards
@@ -12,7 +12,7 @@ do
     then
         echo "Setup port forwarding for local development using internal svc"
 		echo "usage ${0##} context (to execute oc commands as). This is useful if you are running the actual operator the MUO service account [OPTIONAL]"
-        echo "example: ${0##} default/dofinn-20210802/dofinn.openshift" 
+        echo "example: ${0##} \$CONTEXT"
 		echo
         exit 1
     fi 

--- a/docs/development.md
+++ b/docs/development.md
@@ -24,11 +24,11 @@ This document should entail all you need to develop this operator locally.
 
 ### golang
 
-A recent Go distribution (>=1.20) with enabled Go modules.
+A recent Go distribution (>=1.22) with enabled Go modules.
 
 ```shell
 $ go version
-go version go1.20.13 linux/amd64
+go version go1.22.12 linux/amd64
 ```
 
 ### operator-sdk
@@ -165,8 +165,8 @@ You can run this script to set this up for you (Requires `sudo` as it writes to 
 $ ./development/port-forwards -h
 Setup port forwarding for local development using internal svc
 usage ./development/port-forwards context (to execute oc commands as). This is useful if you are running the actual operator the MUO service account [OPTIONAL]
-example: ./development/port-forwards default/dofinn-20210802/dofinn.openshift
-$ ./development/port-forwards default/dofinn-20210802/dofinn.openshift
+example: ./development/port-forwards $CONTEXT
+$ ./development/port-forwards $CONTEXT
 ```
 
 The operator can then be ran as follows. 
@@ -174,7 +174,7 @@ The operator can then be ran as follows.
 ```
 $ oc login $(oc get infrastructures cluster -o json | jq -r '.status.apiServerURL') --token $(oc -n openshift-managed-upgrade-operator serviceaccounts get-token managed-upgrade-operator)
 
-Logged into "https://api.dofinn-20210802.8dqo.s1.devshift.org:6443" as "system:serviceaccount:openshift-managed-upgrade-operator:managed-upgrade-operator" using the token provided.
+Logged into "https://$API_URL:6443" as "system:serviceaccount:openshift-managed-upgrade-operator:managed-upgrade-operator" using the token provided.
 
 You don't have any projects. Contact your system administrator to request a project.
 ```

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/openshift/machine-config-operator v0.0.1-0.20230330142923-2832f049b3f4
 	github.com/openshift/operator-custom-metrics v0.5.1
 	github.com/openshift/osde2e-common v0.0.0-20240531074950-36a7055798ae
-	github.com/operator-framework/operator-lib v0.15.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.74.0
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.71.0
 	github.com/prometheus/alertmanager v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -634,8 +634,6 @@ github.com/openshift/osde2e-common v0.0.0-20240531074950-36a7055798ae/go.mod h1:
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
-github.com/operator-framework/operator-lib v0.15.0 h1:0QeRM4PMtThqINpcFGCEBnIV3Z8u7/8fYLEx6mUtdcM=
-github.com/operator-framework/operator-lib v0.15.0/go.mod h1:ZxLvFuQ7bRWiTNBOqodbuNvcsy/Iq0kOygdxhlbNdI0=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/test/e2e/managed_upgrade_operator_tests.go
+++ b/test/e2e/managed_upgrade_operator_tests.go
@@ -28,7 +28,6 @@ import (
 const (
 	operatorName                           = "managed-upgrade-operator"
 	operatorNamespace                      = "openshift-managed-upgrade-operator"
-	operatorLockFile                       = "managed-upgrade-operator-lock"
 	upgradeConfigResourceName              = "managed-upgrade-config"
 	upgradeConfigForDedicatedAdminTestName = "osde2e-da-upgrade-config"
 	rolePrefix                             = "managed-upgrade-operator"
@@ -61,9 +60,6 @@ var _ = ginkgo.Describe("managed-upgrade-operator", ginkgo.Ordered, func() {
 		ginkgo.By("Checking the namespace exists")
 		err := k8s.Get(ctx, operatorNamespace, operatorNamespace, &corev1.Namespace{})
 		Expect(err).ShouldNot(HaveOccurred(), "namespace %s not found", operatorNamespace)
-
-		ginkgo.By("Checking the operator lock file config map exists")
-		assertions.EventuallyConfigMap(ctx, k8s, operatorLockFile, operatorNamespace).WithTimeout(300*time.Second).WithPolling(30*time.Second).Should(Not(BeNil()), "configmap %s should exist", operatorLockFile)
 
 		ginkgo.By("Checking the operator deployment exists and is available")
 		assertions.EventuallyDeployment(ctx, k8s, operatorName, operatorNamespace)


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
Based on https://issues.redhat.com/browse/SREP-366, we are moving away from configmap based leader election that was enabled around 5 years ago and enabling `Lease` based leader-election which is default.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [SREP-366](https://issues.redhat.com/browse/SREP-366)

### Special notes for your reviewer:
- Introducing `Lease` also required change to handle local MUO run so introduced a variable `ENABLE_LEADER_ELECTION_NAMESPACE="true"` for `make run` command. For the users, `make run` command is the same and local run will continue as it is. The test was also done with the operator running in the cluster. 

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR

