### PR TITLE
Updating boilerplate to v7.4.0

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: boilerplate
   namespace: openshift
-  tag: image-v7.3.0
+  tag: image-v7.4.0

--- a/boilerplate/_data/backing-image-tag
+++ b/boilerplate/_data/backing-image-tag
@@ -1,1 +1,1 @@
-image-v7.3.0
+image-v7.4.0

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/redhat-services-prod/openshift/boilerplate:image-v7.3.0 AS builder
+FROM quay.io/redhat-services-prod/openshift/boilerplate:image-v7.4.0 AS builder
 
 RUN mkdir -p /workdir
 WORKDIR /workdir


### PR DESCRIPTION
### What type of PR is this?
_(boilerplate update)_

### What this PR does / why we need it?
Updating boilerplate to v7.4.0 version mainly to have Go 1.23.9 version for the operator binary. It addresses some of the stdlib vulnerabilities too.

### Which Jira/Github issue(s) this PR fixes?
_Fixes #_ [SREP-856](https://issues.redhat.com/browse/SREP-856)

### Special notes for your reviewer:
We have had recent boilerplate update and promotion and this is a minor change with no functional impact.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

