### PR TITLE
SREP-669 - Add ephemeral-storage request

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -48,6 +48,7 @@ spec:
             requests:
               cpu: 20m
               memory: 100Mi
+              ephemeral-storage: 30Ki
             limits:
               cpu: 50m
               memory: 200Mi


### PR DESCRIPTION
### What type of PR is this?
bug


### What this PR does / why we need it?
This PR is needed to address a bug in MUO. The bug occurs due to a lack of request set on ephemeral storage. Multiple pod evictions happens due to not having the request set.

### Which Jira/Github issue(s) this PR fixes?
[SREP-669](https://issues.redhat.com//browse/SREP-669)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

