### PR TITLE
increasing timeout to 100 seconds

### DIFF
--- a/test/e2e/managed_upgrade_operator_tests.go
+++ b/test/e2e/managed_upgrade_operator_tests.go
@@ -151,7 +151,7 @@ var _ = ginkgo.Describe("managed-upgrade-operator", ginkgo.Ordered, func() {
 				defer cancel()
 				vector, err := prom.InstantQuery(context, query)
 				return err == nil && vector.Len() == 1
-			}).WithContext(ctx).WithTimeout(60*time.Second).WithPolling(5*time.Second).Should(BeTrue(),
+			}).WithContext(ctx).WithTimeout(100*time.Second).WithPolling(5*time.Second).Should(BeTrue(),
 				"MUO should raise prometheus metric for invalid start time for upgrade config", upgradeConfigResourceName)
 		})
 


### PR DESCRIPTION
### What type of PR is this?
Fix test "should raise prometheus metric if start time is invalid"


### What this PR does / why we need it?
This PR will increase the timeout for prometheus metrics are getting emitted within given timeout. Looks like today we have 60 seconds as timeout and some times tests are taking more than that. So we increased the timeout to 100 seconds to address this issue.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-29395

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

