### PR TITLE
Add terminationMessagePolicy and required-scc annotation for OCP 4.21 conformance

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -12,6 +12,8 @@ spec:
     metadata:
       labels:
         name: managed-upgrade-operator
+      annotations:
+        openshift.io/required-scc: restricted-v2
     spec:
       serviceAccountName: managed-upgrade-operator
       affinity:
@@ -71,3 +73,4 @@ spec:
           - mountPath: /etc/pki/ca-trust/extracted/pem
             name: trusted-ca-bundle
             readOnly: true
+          terminationMessagePolicy: FallbackToLogsOnError

--- a/deploy_pko/Deployment-managed-upgrade-operator.yaml.gotmpl
+++ b/deploy_pko/Deployment-managed-upgrade-operator.yaml.gotmpl
@@ -15,6 +15,8 @@ spec:
     metadata:
       labels:
         name: managed-upgrade-operator
+      annotations:
+        openshift.io/required-scc: restricted-v2
     spec:
       serviceAccountName: managed-upgrade-operator
       affinity:
@@ -72,3 +74,4 @@ spec:
         - mountPath: /etc/pki/ca-trust/extracted/pem
           name: trusted-ca-bundle
           readOnly: true
+        terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
## Summary

- Adds `terminationMessagePolicy: FallbackToLogsOnError` to the operator container spec in both OLM (`deploy/`) and PKO (`deploy_pko/`) deployment manifests
- Adds `openshift.io/required-scc: restricted-v2` annotation to pod template metadata in both deployment manifests

These are required for OCP 4.21 conformance. The `terminationMessagePolicy` ensures container termination messages capture log output on error, and the `required-scc` annotation explicitly declares the security context constraint the pod needs.

## Test plan

- [ ] Verify YAML is valid and properly indented
- [ ] Deploy to integration and confirm operator starts correctly
- [ ] Confirm `terminationMessagePolicy` appears in pod spec via `oc get pod -o yaml`
- [ ] Confirm `required-scc` annotation appears in pod metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error diagnostics by enhancing how failure messages are captured and displayed in logs.

* **Security**
  * Added compliance with OpenShift security context constraints across deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->