### PR TITLE
chore: update all OLM template SSSs to Upsert

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -37,7 +37,7 @@ objects:
       clusterDeploymentSelector:
         matchLabels:
           api.openshift.com/managed: "true"
-      resourceApplyMode: Sync
+      resourceApplyMode: Upsert
       resources:
         - apiVersion: v1
           kind: Namespace


### PR DESCRIPTION
### What type of PR is this?
_chore_


### What this PR does / why we need it?

Updates all SelectorSyncSets in the OLM template to `resourceApplyMode: Upsert`.
This will allow a safe transition to PKO when the old SelectorSyncSets are deleted.
When in `Upsert` mode Hive orphans the resources applied to clusters matching the SelectorSyncSet rather than deleting them when the SelectorSyncSet is deleted.

### Which Jira/Github issue(s) this PR fixes?

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

