### PR TITLE
SREP-4721- add ServiceAccount to PKO deployment manifests

### DIFF
--- a/deploy_pko/.test-fixtures/config-with-proxy/ServiceAccount-managed-upgrade-operator.yaml
+++ b/deploy_pko/.test-fixtures/config-with-proxy/ServiceAccount-managed-upgrade-operator.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: managed-upgrade-operator
+  namespace: openshift-managed-upgrade-operator
+  annotations:
+    package-operator.run/phase: namespace
+    package-operator.run/collision-protection: IfNoController

--- a/deploy_pko/ServiceAccount-managed-upgrade-operator.yaml
+++ b/deploy_pko/ServiceAccount-managed-upgrade-operator.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: managed-upgrade-operator
+  namespace: openshift-managed-upgrade-operator
+  annotations:
+    package-operator.run/phase: namespace
+    package-operator.run/collision-protection: IfNoController


### PR DESCRIPTION
OLM implicitly created the ServiceAccount; PKO requires it to be declared explicitly. Without it the Deployment fails on new clusters.

### What type of PR is this?
_bug_


### What this PR does / why we need it?
When MUO is deployed to new clusters, PKO needs to create its `managed-upgrade-operator` serviceaccount. This adds the required object in order to achieve that

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ https://redhat.atlassian.net/browse/SREP-4721

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added service account configuration for the managed upgrade operator with operator annotations and collision protection settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->