### PR TITLE
[SREP-3999] DVO NS isn't present in MC and SC. Which impact the install

### DIFF
--- a/deploy_pko/Namespace.yaml
+++ b/deploy_pko/Namespace.yaml
@@ -1,0 +1,7 @@
+  apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: openshift-deployment-validation-operator
+    annotations:
+      package-operator.run/phase: namespace
+      package-operator.run/collision-protection: IfNoController


### PR DESCRIPTION
### What type of PR is this?
_(refactor)_


### What this PR does / why we need it?
The DVO NS isn't present in some cluster(Mc and sc), which blocks the unpacking of clusterpackage resource.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

