### PR TITLE
fix(SREP-4825: Fix stale UpgradeNodeDrainFailedSRE alert blocking upgrade completion)

### DIFF
--- a/controllers/nodekeeper/nodekeeper_controller.go
+++ b/controllers/nodekeeper/nodekeeper_controller.go
@@ -72,6 +72,12 @@ func (r *ReconcileNodeKeeper) Reconcile(ctx context.Context, request reconcile.R
 	err = r.Client.Get(context.TODO(), request.NamespacedName, node)
 	if err != nil {
 		if errors.IsNotFound(err) {
+			// Node was deleted - reset the metric for this node to prevent stale alerts
+			metricsClient, err := r.MetricsClientBuilder.NewClient(r.Client)
+			if err == nil {
+				reqLogger.Info(fmt.Sprintf("Node %s deleted, resetting NodeDrainFailed metric", request.Name))
+				metricsClient.ResetMetricNodeDrainFailed(request.Name)
+			}
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.

--- a/controllers/nodekeeper/nodekeeper_controller.go
+++ b/controllers/nodekeeper/nodekeeper_controller.go
@@ -74,10 +74,12 @@ func (r *ReconcileNodeKeeper) Reconcile(ctx context.Context, request reconcile.R
 		if errors.IsNotFound(err) {
 			// Node was deleted - reset the metric for this node to prevent stale alerts
 			metricsClient, err := r.MetricsClientBuilder.NewClient(r.Client)
-			if err == nil {
-				reqLogger.Info(fmt.Sprintf("Node %s deleted, resetting NodeDrainFailed metric", request.Name))
-				metricsClient.ResetMetricNodeDrainFailed(request.Name)
+			if err != nil {
+				reqLogger.Error(err, "failed to create metrics client for resetting NodeDrainFailed", "node", request.Name)
+				return reconcile.Result{}, nil
 			}
+			reqLogger.Info(fmt.Sprintf("Node %s deleted, resetting NodeDrainFailed metric", request.Name))
+			metricsClient.ResetMetricNodeDrainFailed(request.Name)
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.

--- a/controllers/nodekeeper/nodekeeper_controller_test.go
+++ b/controllers/nodekeeper/nodekeeper_controller_test.go
@@ -7,6 +7,7 @@ import (
 
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -234,7 +235,20 @@ var _ = Describe("NodeKeeperController", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.RequeueAfter).To(Not(BeNil()))
 			})
+			It("should reset NodeDrainFailed metric when node is deleted (NotFound)", func() {
+				notFoundErr := errors.NewNotFound(corev1.Resource("nodes"), testNodeName.Name)
+				gomock.InOrder(
+					mockUpgradeConfigManagerBuilder.EXPECT().NewManager(gomock.Any()).Return(mockUpgradeConfigManager, nil),
+					mockUpgradeConfigManager.EXPECT().Get().Return(&uc, nil),
+					mockMachineryClient.EXPECT().IsUpgrading(mockKubeClient, "worker").Return(&machinery.UpgradingResult{IsUpgrading: true}, nil),
+					mockKubeClient.EXPECT().Get(context.TODO(), testNodeName, gomock.Any()).Return(notFoundErr),
+					mockMetricsBuilder.EXPECT().NewClient(gomock.Any()).Return(mockMetricsClient, nil),
+					mockMetricsClient.EXPECT().ResetMetricNodeDrainFailed(testNodeName.Name).Times(1),
+				)
+				result, err := reconciler.Reconcile(context.TODO(), reconcile.Request{NamespacedName: testNodeName})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.RequeueAfter).To(BeZero())
+			})
 		})
 	})
 })
-// Test added for node deletion metric reset

--- a/controllers/nodekeeper/nodekeeper_controller_test.go
+++ b/controllers/nodekeeper/nodekeeper_controller_test.go
@@ -237,3 +237,4 @@ var _ = Describe("NodeKeeperController", func() {
 		})
 	})
 })
+// Test added for node deletion metric reset

--- a/pkg/upgraders/healthcheckstep.go
+++ b/pkg/upgraders/healthcheckstep.go
@@ -147,6 +147,11 @@ func (c *clusterUpgrader) PostUpgradeHealthCheck(ctx context.Context, logger log
 		return false, err
 	}
 
+	// Reset all node drain metrics after successful upgrade to prevent stale alerts
+	// This ensures any metrics from deleted/replaced nodes during upgrade are cleared
+	logger.Info("PostUpgradeHealthCheck passed, resetting all node drain metrics")
+	c.metrics.ResetAllMetricNodeDrainFailed()
+
 	return true, nil
 }
 

--- a/pkg/upgraders/healthcheckstep_test.go
+++ b/pkg/upgraders/healthcheckstep_test.go
@@ -436,6 +436,7 @@ var _ = Describe("HealthCheck Step", func() {
 					mockCVClient.EXPECT().HasDegradedOperators().Return(&clusterversion.HasDegradedOperatorsResult{Degraded: []string{}}, nil),
 					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name, metrics.ClusterOperatorsStatusFailed, gomock.Any(), gomock.Any()),
 					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name, metrics.ClusterOperatorsDegraded, gomock.Any(), gomock.Any()),
+					mockMetricsClient.EXPECT().ResetAllMetricNodeDrainFailed(),
 				)
 				result, err := upgrader.PostUpgradeHealthCheck(context.TODO(), logger)
 				Expect(err).NotTo(HaveOccurred())
@@ -491,6 +492,7 @@ var _ = Describe("HealthCheck Step", func() {
 					mockCVClient.EXPECT().HasDegradedOperators().Return(&clusterversion.HasDegradedOperatorsResult{Degraded: []string{}}, nil),
 					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name, metrics.ClusterOperatorsStatusFailed, gomock.Any(), gomock.Any()),
 					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name, metrics.ClusterOperatorsDegraded, gomock.Any(), gomock.Any()),
+					mockMetricsClient.EXPECT().ResetAllMetricNodeDrainFailed(),
 				)
 				result, err := upgrader.PostUpgradeHealthCheck(context.TODO(), logger)
 				Expect(err).NotTo(HaveOccurred())
@@ -545,6 +547,7 @@ var _ = Describe("HealthCheck Step", func() {
 					mockCVClient.EXPECT().HasDegradedOperators().Return(&clusterversion.HasDegradedOperatorsResult{Degraded: []string{}}, nil),
 					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name, metrics.ClusterOperatorsStatusFailed, gomock.Any(), gomock.Any()),
 					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name, metrics.ClusterOperatorsDegraded, gomock.Any(), gomock.Any()),
+					mockMetricsClient.EXPECT().ResetAllMetricNodeDrainFailed(),
 				)
 				result, err := upgrader.PostUpgradeHealthCheck(context.TODO(), logger)
 				Expect(err).NotTo(HaveOccurred())
@@ -600,6 +603,7 @@ var _ = Describe("HealthCheck Step", func() {
 					mockCVClient.EXPECT().HasDegradedOperators().Return(&clusterversion.HasDegradedOperatorsResult{Degraded: []string{}}, nil),
 					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name, metrics.ClusterOperatorsStatusFailed, gomock.Any(), gomock.Any()),
 					mockMetricsClient.EXPECT().UpdateMetricHealthcheckSucceeded(upgradeConfig.Name, metrics.ClusterOperatorsDegraded, gomock.Any(), gomock.Any()),
+					mockMetricsClient.EXPECT().ResetAllMetricNodeDrainFailed(),
 				)
 				result, err := upgrader.PostUpgradeHealthCheck(context.TODO(), logger)
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
### What type of PR is this?
_bug_


### What this PR does / why we need it?
When a node is deleted/replaced during upgrade, the `upgradeoperator_node_drain_timeout` metric persists in Prometheus, causing the UpgradeNodeDrainFailedSRE alert to continue firing for non-existent nodes. This blocks the ClusterHealthyAfterUpgrade stage indefinitely.

For detailed analysis refer to [comment in JIRA](https://redhat.atlassian.net/browse/SREP-4825?focusedCommentId=16933545)

This commit changes the following

1. NodeKeeper controller now resets the node drain metric when a node deletion is detected during reconciliation, preventing stale metrics from accumulating.
2. PostUpgradeHealthCheck step resets all node drain metrics after successful upgrade completion, ensuring any edge-case stale metrics are cleaned up.

Both changes use the existing ResetAllMetricNodeDrainFailed() method and only affect node-specific metrics without impacting other alert functionality.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #[SREP-4825](https://redhat.atlassian.net/browse/SREP-4825)_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR



[SREP-4825]: https://redhat.atlassian.net/browse/SREP-4825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Node deletion now triggers automatic cleanup of associated drain failure metrics, eliminating stale alerts and improving overall cluster health monitoring.
  * Successful post-upgrade health checks now reset all node drain failure metrics, ensuring that alerting systems accurately reflect the current state of nodes in the cluster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->