### PR TITLE
feat(SLSRE-704): add scale.extraMachinePools for additional capacity reservation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,14 @@
 # =============================================================================
 #
 # INSTALL
-#   pip install pre-commit
-#   pre-commit install
+#   For detailed setup instructions including uv (recommended) and pip,
+#   see: boilerplate/openshift/golang-osd-operator/docs/pre-commit.md
+#
+#   Quick start (uv):
+#     uv sync && source .venv/bin/activate && pre-commit install
+#
+#   Quick start (pip):
+#     pip install 'pre-commit==4.6.0' && pre-commit install
 #
 # USAGE
 #   pre-commit run              # staged files only (developer / agent workflow)
@@ -34,6 +40,9 @@
 #   Auto-fix hooks (trailing-whitespace, end-of-file-fixer) will correct
 #   pre-existing violations on the first run. Stage and commit those fixes
 #   separately before day-to-day use.
+#
+#   Fix commits can be excluded from git blame
+#   https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-filefile
 #
 # =============================================================================
 

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,10 +5,11 @@
 aliases:
   srep-functional-team-aurora:
     - AlexSmithGH
+    - BATMAN-JD
     - dakotalongRH
     - eth1030
+    - geowa4
     - joshbranham
-    - luis-falcon
     - reedcort
   srep-functional-team-fedramp:
     - theautoroboto

--- a/boilerplate/_data/last-boilerplate-commit
+++ b/boilerplate/_data/last-boilerplate-commit
@@ -1,1 +1,1 @@
-61dbfdfcfd8ab11f8ccbd58bf1d299c2fa3336dd
+cd127a60de1061ba326cbc04ccb63768aedbb4c0

--- a/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
+++ b/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
@@ -5,10 +5,11 @@
 aliases:
   srep-functional-team-aurora:
     - AlexSmithGH
+    - BATMAN-JD
     - dakotalongRH
     - eth1030
+    - geowa4
     - joshbranham
-    - luis-falcon
     - reedcort
   srep-functional-team-fedramp:
     - theautoroboto

--- a/boilerplate/openshift/golang-osd-operator/dependabot.yml
+++ b/boilerplate/openshift/golang-osd-operator/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     labels:
       - "area/dependency"
       - "ok-to-test"
+      - "lgtm"
+      - "approved"
     schedule:
       interval: "weekly"
     ignore:

--- a/boilerplate/openshift/golang-osd-operator/docs/pre-commit.md
+++ b/boilerplate/openshift/golang-osd-operator/docs/pre-commit.md
@@ -1,0 +1,123 @@
+# Pre-Commit Hooks Setup Guide
+
+## Installation
+
+### Recommended: Using uv
+
+[uv](https://github.com/astral-sh/uv) is recommended for Python dependency management. It provides dependency locking with package hashes (supply-chain protection), virtual environment management, and is 10-100x faster than pip.
+
+**Install uv:**
+```bash
+# macOS/Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Windows
+powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+
+# Via pip
+pip install uv
+```
+
+**First-time setup:**
+```bash
+uv init --bare                    # creates pyproject.toml
+uv add --dev pre-commit==4.6.0    # adds dependency, generates uv.lock
+source .venv/bin/activate         # macOS/Linux (.venv\Scripts\activate on Windows)
+pre-commit install
+```
+
+**Subsequent setup** (when `pyproject.toml` and `uv.lock` exist):
+```bash
+uv sync
+source .venv/bin/activate
+pre-commit install
+```
+
+### Alternative: Using pip
+
+```bash
+pip install 'pre-commit==4.6.0'   # pinned version (Golden Rule 15)
+pre-commit install
+```
+
+Add to `requirements-dev.txt`: `pre-commit==4.6.0`
+
+## First-Time Setup
+
+Run on all files to catch existing issues:
+```bash
+pre-commit run --all-files
+```
+
+Auto-fix hooks will modify files on first run. Stage and commit these separately:
+```bash
+git diff
+git add .
+git commit -m "Fix: Apply pre-commit auto-fixes"
+```
+
+**Exclude fix commits from git blame:**
+```bash
+# Create .git-blame-ignore-revs with commit hashes
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
+See [git-blame docs](https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-filefile).
+
+## Usage
+
+**Automatic** (runs on `git commit`):
+```bash
+git add <files>
+git commit -m "Message"
+```
+
+**Manual:**
+```bash
+pre-commit run                              # staged files only
+pre-commit run --all-files                  # entire repo
+pre-commit run --files path/to/file         # specific files
+```
+
+**Bypass (use sparingly):**
+```bash
+SKIP=hook-id git commit -m "Message"        # skip one hook
+git commit --no-verify                      # NEVER use (Golden Rule 16)
+```
+
+Rules: Agents never bypass hooks. Security hooks (gitleaks) never bypassable.
+
+## Troubleshooting
+
+**macOS timeout issues:**
+```bash
+brew install coreutils  # provides gtimeout
+```
+
+**Virtual environment not found:**
+```bash
+source .venv/bin/activate
+uv sync
+```
+
+**Hooks not running:**
+```bash
+ls -la .git/hooks/pre-commit  # verify installation
+pre-commit install            # reinstall
+```
+
+**Hook failures:** Read error messages and fix issues:
+- `go-build`: Fix compilation errors
+- `go-mod-tidy`: Run `go mod tidy` and stage go.mod/go.sum
+- `check-yaml`: Fix YAML syntax
+
+## CI Integration
+
+Pre-commit mirrors `ci/prow/lint`. CI is authoritative; pre-commit is developer convenience. All hooks run in CI with same config.
+
+If pre-commit passes but CI fails: `pre-commit autoupdate`
+
+## Resources
+
+- [Pre-Commit Documentation](https://pre-commit.com/)
+- [uv Documentation](https://github.com/astral-sh/uv)

--- a/boilerplate/openshift/golang-osd-operator/ensure.sh
+++ b/boilerplate/openshift/golang-osd-operator/ensure.sh
@@ -8,7 +8,7 @@ fi
 REPO_ROOT=$(git rev-parse --show-toplevel)
 source $REPO_ROOT/boilerplate/_lib/common.sh
 
-GOLANGCI_LINT_VERSION="2.7.2"
+GOLANGCI_LINT_VERSION="2.12.2"
 OPM_VERSION="v1.60.0"
 GRPCURL_VERSION="1.7.0"
 DEPENDENCY=${1:-}

--- a/boilerplate/openshift/golang-osd-operator/olm_pko_migration.py
+++ b/boilerplate/openshift/golang-osd-operator/olm_pko_migration.py
@@ -11,7 +11,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import yaml
 
@@ -629,7 +629,7 @@ def write_pko_dockerfile():
             )
         )
 
-def extract_deployment_selector() -> str | None:
+def extract_deployment_selector() -> Optional[str]:
     """
     Extract the clusterDeploymentSelector from hack/olm-registry/olm-artifacts-template.yaml.
 

--- a/boilerplate/openshift/golang-osd-operator/pre-commit-config.yaml
+++ b/boilerplate/openshift/golang-osd-operator/pre-commit-config.yaml
@@ -4,8 +4,14 @@
 # =============================================================================
 #
 # INSTALL
-#   pip install pre-commit
-#   pre-commit install
+#   For detailed setup instructions including uv (recommended) and pip,
+#   see: boilerplate/openshift/golang-osd-operator/docs/pre-commit.md
+#
+#   Quick start (uv):
+#     uv sync && source .venv/bin/activate && pre-commit install
+#
+#   Quick start (pip):
+#     pip install 'pre-commit==4.6.0' && pre-commit install
 #
 # USAGE
 #   pre-commit run              # staged files only (developer / agent workflow)
@@ -34,6 +40,9 @@
 #   Auto-fix hooks (trailing-whitespace, end-of-file-fixer) will correct
 #   pre-existing violations on the first run. Stage and commit those fixes
 #   separately before day-to-day use.
+#
+#   Fix commits can be excluded from git blame
+#   https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-filefile
 #
 # =============================================================================
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1779709832
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1779809423
 
 ENV USER_UID=1001 \
     USER_NAME=managed-upgrade-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1779709832
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1779809423
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/docs/configmap.md
+++ b/docs/configmap.md
@@ -97,11 +97,14 @@ The `scale` section is used to control the `managed-upgrade-operator`'s behaviou
 | Key | Description                                                              |
 | --- |--------------------------------------------------------------------------|
 | `timeOut` | timeout window for the extra workload scale up in minutes, default is 30 |
+| `extraMachinePools` | optional list of glob patterns matching additional `hive.openshift.io/machine-pool` label values whose MachineSets should also be scaled up during capacity reservation (e.g. `non-serving-*`). Patterns use Go's `path.Match` syntax. When empty or absent, only the default `worker` pool is scaled. |
 
 Example:
 ```
     scale:
       timeOut: 30
+      extraMachinePools:
+        - "non-serving-*"
 ```
 
 #### upgradeWindow

--- a/pkg/scaler/machineSetScaler.go
+++ b/pkg/scaler/machineSetScaler.go
@@ -3,6 +3,7 @@ package scaler
 import (
 	"context"
 	"fmt"
+	"path"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -22,6 +23,8 @@ const (
 	LABEL_UPGRADE = "upgrade.managed.openshift.io"
 	// LABEL_MACHINESET is the label used for machinesets
 	LABEL_MACHINESET = "machine.openshift.io/cluster-api-machineset"
+	// LABEL_MACHINE_POOL is the Hive machine pool label
+	LABEL_MACHINE_POOL = "hive.openshift.io/machine-pool"
 	// MACHINE_API_NAMESPACE is the namespace of the machine api
 	MACHINE_API_NAMESPACE = "openshift-machine-api"
 )
@@ -35,7 +38,7 @@ func (s *machineSetScaler) CanScale(c client.Client, logger logr.Logger) (bool, 
 	// Do we have an original "worker" machineset that can be scaled?
 	err := c.List(context.TODO(), originalMachineSets, []client.ListOption{
 		client.InNamespace(MACHINE_API_NAMESPACE),
-		client.MatchingLabels{"hive.openshift.io/machine-pool": "worker"},
+		client.MatchingLabels{LABEL_MACHINE_POOL: "worker"},
 	}...)
 	if err != nil {
 		logger.Error(err, "failed to get original machinesets")
@@ -51,7 +54,9 @@ func (s *machineSetScaler) CanScale(c client.Client, logger logr.Logger) (bool, 
 }
 
 // EnsureScaleUpNodes will create a new MachineSet with 1 extra replicas for workers in every region and report when the nodes are ready.
-func (s *machineSetScaler) EnsureScaleUpNodes(c client.Client, timeOut time.Duration, logger logr.Logger) (bool, error) {
+// When extraMachinePools is non-empty, additional MachineSets matching those pool patterns are also scaled.
+// Worker and extra pool fetching are independent: if workers are absent but extra pools match, only extra pools are scaled and vice versa.
+func (s *machineSetScaler) EnsureScaleUpNodes(c client.Client, timeOut time.Duration, logger logr.Logger, extraMachinePools []string) (bool, error) {
 	upgradeMachinesets := &machineapi.MachineSetList{}
 
 	err := c.List(context.TODO(), upgradeMachinesets, []client.ListOption{
@@ -62,20 +67,39 @@ func (s *machineSetScaler) EnsureScaleUpNodes(c client.Client, timeOut time.Dura
 		logger.Error(err, "failed to get upgrade extra machinesets")
 		return false, err
 	}
-	originalMachineSets := &machineapi.MachineSetList{}
 
-	err = c.List(context.TODO(), originalMachineSets, []client.ListOption{
+	// Collect all MachineSets that need upgrade clones
+	var allOriginals []machineapi.MachineSet
+
+	// Fetch worker MachineSets
+	workerMachineSets := &machineapi.MachineSetList{}
+	err = c.List(context.TODO(), workerMachineSets, []client.ListOption{
 		client.InNamespace(MACHINE_API_NAMESPACE),
-		client.MatchingLabels{"hive.openshift.io/machine-pool": "worker"},
+		client.MatchingLabels{LABEL_MACHINE_POOL: "worker"},
 	}...)
 	if err != nil {
-		logger.Error(err, "failed to get original machinesets")
-		return false, err
+		logger.Error(err, "failed to get worker machinesets")
+	} else {
+		allOriginals = append(allOriginals, workerMachineSets.Items...)
 	}
-	if len(originalMachineSets.Items) == 0 {
-		logger.Info("failed to get machineset")
-		return false, fmt.Errorf("failed to get original machineset")
+
+	// Fetch extra machine pool MachineSets if configured
+	if len(extraMachinePools) > 0 {
+		extraSets, err := listMachineSetsByPoolPatterns(c, extraMachinePools, logger)
+		if err != nil {
+			logger.Error(err, "failed to list extra machine pool machinesets")
+		} else if len(extraSets) > 0 {
+			logger.Info(fmt.Sprintf("found %d extra machine pool machineset(s) to scale", len(extraSets)))
+			allOriginals = append(allOriginals, extraSets...)
+		}
 	}
+
+	if len(allOriginals) == 0 {
+		logger.Info("no machinesets found to scale")
+		return false, fmt.Errorf("failed to get any machinesets to scale")
+	}
+
+	originalMachineSets := &machineapi.MachineSetList{Items: allOriginals}
 
 	created, err := extraMachineSetCreated(c, *originalMachineSets, *upgradeMachinesets, logger)
 	if err != nil {
@@ -176,6 +200,41 @@ func NotSelectorFromSet(ls NotMatchingLabels) labels.Selector {
 	}
 
 	return selector
+}
+
+// listMachineSetsByPoolPatterns returns MachineSets whose hive.openshift.io/machine-pool label value
+// matches any of the given glob patterns. MachineSets with pool value "worker" are excluded because
+// they are already handled separately.
+func listMachineSetsByPoolPatterns(c client.Client, patterns []string, logger logr.Logger) ([]machineapi.MachineSet, error) {
+	allPooled := &machineapi.MachineSetList{}
+	err := c.List(context.TODO(), allPooled, []client.ListOption{
+		client.InNamespace(MACHINE_API_NAMESPACE),
+		client.HasLabels{LABEL_MACHINE_POOL},
+	}...)
+	if err != nil {
+		return nil, fmt.Errorf("listing machinesets by pool label: %w", err)
+	}
+
+	var matched []machineapi.MachineSet
+	for _, ms := range allPooled.Items {
+		poolValue := ms.Labels[LABEL_MACHINE_POOL]
+		if poolValue == "worker" {
+			continue
+		}
+		for _, pattern := range patterns {
+			ok, err := path.Match(pattern, poolValue)
+			if err != nil {
+				// Pattern was validated at config load time; this should not happen.
+				return nil, fmt.Errorf("matching pattern %q against pool %q: %w", pattern, poolValue, err)
+			}
+			if ok {
+				logger.Info(fmt.Sprintf("extra machine pool %q matched pattern %q (machineset %s)", poolValue, pattern, ms.Name))
+				matched = append(matched, ms)
+				break
+			}
+		}
+	}
+	return matched, nil
 }
 
 func getExtraUpgradeNodes(c client.Client) (*corev1.NodeList, error) {

--- a/pkg/scaler/mocks/scaler.go
+++ b/pkg/scaler/mocks/scaler.go
@@ -73,16 +73,16 @@ func (mr *MockScalerMockRecorder) EnsureScaleDownNodes(arg0, arg1, arg2 any) *go
 }
 
 // EnsureScaleUpNodes mocks base method.
-func (m *MockScaler) EnsureScaleUpNodes(arg0 client.Client, arg1 time.Duration, arg2 logr.Logger) (bool, error) {
+func (m *MockScaler) EnsureScaleUpNodes(arg0 client.Client, arg1 time.Duration, arg2 logr.Logger, arg3 []string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureScaleUpNodes", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "EnsureScaleUpNodes", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EnsureScaleUpNodes indicates an expected call of EnsureScaleUpNodes.
-func (mr *MockScalerMockRecorder) EnsureScaleUpNodes(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockScalerMockRecorder) EnsureScaleUpNodes(arg0, arg1, arg2, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureScaleUpNodes", reflect.TypeOf((*MockScaler)(nil).EnsureScaleUpNodes), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureScaleUpNodes", reflect.TypeOf((*MockScaler)(nil).EnsureScaleUpNodes), arg0, arg1, arg2, arg3)
 }

--- a/pkg/scaler/scaler.go
+++ b/pkg/scaler/scaler.go
@@ -13,7 +13,7 @@ import (
 //go:generate mockgen -destination=mocks/scaler.go -package=mocks github.com/openshift/managed-upgrade-operator/pkg/scaler Scaler
 type Scaler interface {
 	CanScale(client.Client, logr.Logger) (bool, error)
-	EnsureScaleUpNodes(client.Client, time.Duration, logr.Logger) (bool, error)
+	EnsureScaleUpNodes(client.Client, time.Duration, logr.Logger, []string) (bool, error)
 	EnsureScaleDownNodes(client.Client, drain.NodeDrainStrategy, logr.Logger) (bool, error)
 }
 

--- a/pkg/scaler/scaling_test.go
+++ b/pkg/scaler/scaling_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Node scaling tests", func() {
 			It("will flag that scaling is not possible", func() {
 				originalMachineSets = &machineapi.MachineSetList{}
 				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
-					client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{"hive.openshift.io/machine-pool": "worker"},
+					client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_MACHINE_POOL: "worker"},
 				}).SetArg(1, *originalMachineSets)
 				result, err := scaler.CanScale(mockKubeClient, logger)
 				Expect(err).To(BeNil())
@@ -80,7 +80,7 @@ var _ = Describe("Node scaling tests", func() {
 					},
 				}
 				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
-					client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{"hive.openshift.io/machine-pool": "worker"},
+					client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_MACHINE_POOL: "worker"},
 				}).SetArg(1, *originalMachineSets)
 				result, err := scaler.CanScale(mockKubeClient, logger)
 				Expect(err).To(BeNil())
@@ -98,43 +98,43 @@ var _ = Describe("Node scaling tests", func() {
 				mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
 					client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_UPGRADE: "true"},
 				}).Return(fakeError)
-				result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger)
+				result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger, nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(Equal(fakeError))
 				Expect(result).To(BeFalse())
 			})
 		})
 		Context("When looking for original machinesets fails", func() {
-			It("Indicates an error", func() {
+			It("Indicates an error when no extra pools configured", func() {
 				fakeError := fmt.Errorf("fake error")
 				gomock.InOrder(
 					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
 						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_UPGRADE: "true"},
 					}),
 					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
-						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{"hive.openshift.io/machine-pool": "worker"},
+						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_MACHINE_POOL: "worker"},
 					}).Return(fakeError),
 				)
-				result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger)
+				result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger, nil)
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(Equal(fakeError))
+				Expect(err.Error()).To(ContainSubstring("failed to get any machinesets to scale"))
 				Expect(result).To(BeFalse())
 			})
 		})
 		Context("When no original machineset appears to exist", func() {
-			It("Indicates an error", func() {
+			It("Indicates an error when no extra pools configured", func() {
 				originalMachineSets = &machineapi.MachineSetList{}
 				gomock.InOrder(
 					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
 						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_UPGRADE: "true"},
 					}),
 					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
-						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{"hive.openshift.io/machine-pool": "worker"},
+						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_MACHINE_POOL: "worker"},
 					}).SetArg(1, *originalMachineSets),
 				)
-				result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger)
+				result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger, nil)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("failed to get original machineset"))
+				Expect(err.Error()).To(ContainSubstring("failed to get any machinesets to scale"))
 				Expect(result).To(BeFalse())
 			})
 		})
@@ -171,7 +171,7 @@ var _ = Describe("Node scaling tests", func() {
 						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_UPGRADE: "true"},
 					}).SetArg(1, *upgradeMachinesets),
 					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
-						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{"hive.openshift.io/machine-pool": "worker"},
+						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_MACHINE_POOL: "worker"},
 					}).SetArg(1, *originalMachineSets),
 				)
 				mockKubeClient.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -184,7 +184,7 @@ var _ = Describe("Node scaling tests", func() {
 						Expect(ms.Spec.Selector.MatchLabels[LABEL_UPGRADE]).To(Equal("true"))
 						return nil
 					})
-				result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger)
+				result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(BeFalse())
 			})
@@ -195,11 +195,11 @@ var _ = Describe("Node scaling tests", func() {
 						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_UPGRADE: "true"},
 					}).SetArg(1, *upgradeMachinesets),
 					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
-						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{"hive.openshift.io/machine-pool": "worker"},
+						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_MACHINE_POOL: "worker"},
 					}).SetArg(1, *originalMachineSets),
 				)
 				mockKubeClient.EXPECT().Create(gomock.Any(), gomock.Any()).Return(fakeError)
-				result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger)
+				result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger, nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(Equal(fakeError))
 				Expect(result).To(BeFalse())
@@ -239,10 +239,10 @@ var _ = Describe("Node scaling tests", func() {
 						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_UPGRADE: "true"},
 					}).SetArg(1, *upgradeMachinesets),
 					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
-						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{"hive.openshift.io/machine-pool": "worker"},
+						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_MACHINE_POOL: "worker"},
 					}).SetArg(1, *originalMachineSets),
 				)
-				result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger)
+				result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(BeFalse())
 			})
@@ -333,14 +333,14 @@ var _ = Describe("Node scaling tests", func() {
 							client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_UPGRADE: "true"},
 						}).SetArg(1, *upgradeMachinesets),
 						mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
-							client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{"hive.openshift.io/machine-pool": "worker"},
+							client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_MACHINE_POOL: "worker"},
 						}).SetArg(1, *originalMachineSets),
 						mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
 							client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_UPGRADE: "true"}, client.MatchingLabels{LABEL_MACHINESET: upgradeMachinesets.Items[0].ObjectMeta.Name},
 						}).SetArg(1, *upgradeMachines),
 						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, node),
 					)
-					result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger)
+					result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger, nil)
 					Expect(err).To(HaveOccurred())
 					Expect(IsScaleTimeOutError(err)).To(BeTrue())
 					Expect(result).To(BeFalse())
@@ -353,14 +353,14 @@ var _ = Describe("Node scaling tests", func() {
 							client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_UPGRADE: "true"},
 						}).SetArg(1, *upgradeMachinesets),
 						mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
-							client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{"hive.openshift.io/machine-pool": "worker"},
+							client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_MACHINE_POOL: "worker"},
 						}).SetArg(1, *originalMachineSets),
 						mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
 							client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_UPGRADE: "true"}, client.MatchingLabels{LABEL_MACHINESET: upgradeMachinesets.Items[0].ObjectMeta.Name},
 						}).SetArg(1, *upgradeMachines),
 						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, node),
 					)
-					result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger)
+					result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger, nil)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(BeFalse())
 				})
@@ -429,14 +429,14 @@ var _ = Describe("Node scaling tests", func() {
 						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_UPGRADE: "true"},
 					}).SetArg(1, *upgradeMachinesets),
 					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
-						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{"hive.openshift.io/machine-pool": "worker"},
+						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_MACHINE_POOL: "worker"},
 					}).SetArg(1, *originalMachineSets),
 					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
 						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_UPGRADE: "true"}, client.MatchingLabels{LABEL_MACHINESET: upgradeMachinesets.Items[0].ObjectMeta.Name},
 					}).SetArg(1, *upgradeMachines),
 					mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, node),
 				)
-				result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger)
+				result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(BeTrue())
 			})
@@ -548,6 +548,334 @@ var _ = Describe("Node scaling tests", func() {
 			})
 		})
 
+	})
+
+	Context("When extra machine pools are configured", func() {
+		var upgradeMachinesets *machineapi.MachineSetList
+		var originalMachineSets *machineapi.MachineSetList
+		testDuration := 30 * time.Minute
+
+		BeforeEach(func() {
+			upgradeMachinesets = &machineapi.MachineSetList{}
+			originalMachineSets = &machineapi.MachineSetList{
+				Items: []machineapi.MachineSet{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "worker-us-east-1a",
+							Namespace: MACHINE_API_NAMESPACE,
+						},
+						Spec: machineapi.MachineSetSpec{
+							Selector: metav1.LabelSelector{
+								MatchLabels: make(map[string]string),
+							},
+							Template: machineapi.MachineTemplateSpec{
+								ObjectMeta: machineapi.ObjectMeta{
+									Labels: make(map[string]string),
+								},
+							},
+						},
+					},
+				},
+			}
+		})
+
+		Context("When extra pools match machinesets", func() {
+			It("creates upgrade machinesets for both workers and extra pools", func() {
+				extraPoolSets := &machineapi.MachineSetList{
+					Items: []machineapi.MachineSet{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "non-serving-9a-us-east-1a",
+								Namespace: MACHINE_API_NAMESPACE,
+								Labels:    map[string]string{LABEL_MACHINE_POOL: "non-serving-9a"},
+							},
+							Spec: machineapi.MachineSetSpec{
+								Selector: metav1.LabelSelector{
+									MatchLabels: make(map[string]string),
+								},
+								Template: machineapi.MachineTemplateSpec{
+									ObjectMeta: machineapi.ObjectMeta{
+										Labels: make(map[string]string),
+									},
+								},
+							},
+						},
+					},
+				}
+				gomock.InOrder(
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
+						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_UPGRADE: "true"},
+					}).SetArg(1, *upgradeMachinesets),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
+						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_MACHINE_POOL: "worker"},
+					}).SetArg(1, *originalMachineSets),
+					// List all pooled machinesets for extra pool matching
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
+						client.InNamespace(MACHINE_API_NAMESPACE), client.HasLabels{LABEL_MACHINE_POOL},
+					}).SetArg(1, *extraPoolSets),
+				)
+				// Expect Create to be called twice: once for worker, once for extra pool
+				createdNames := []string{}
+				mockKubeClient.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, ms *machineapi.MachineSet, co ...client.CreateOption) error {
+						createdNames = append(createdNames, ms.Name)
+						Expect(ms.Labels[LABEL_UPGRADE]).To(Equal("true"))
+						Expect(*ms.Spec.Replicas).To(Equal(int32(1)))
+						return nil
+					}).Times(2)
+				result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger, []string{"non-serving-*"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse()) // just created, not yet ready
+				Expect(createdNames).To(ContainElements("worker-us-east-1a-upgrade", "non-serving-9a-us-east-1a-upgrade"))
+			})
+		})
+
+		Context("When extra pool patterns match no machinesets", func() {
+			It("creates upgrade machinesets for workers only", func() {
+				// Return machinesets that do not match the pattern
+				allPooled := &machineapi.MachineSetList{
+					Items: []machineapi.MachineSet{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "infra-us-east-1a",
+								Namespace: MACHINE_API_NAMESPACE,
+								Labels:    map[string]string{LABEL_MACHINE_POOL: "infra"},
+							},
+						},
+					},
+				}
+				gomock.InOrder(
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
+						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_UPGRADE: "true"},
+					}).SetArg(1, *upgradeMachinesets),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
+						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_MACHINE_POOL: "worker"},
+					}).SetArg(1, *originalMachineSets),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
+						client.InNamespace(MACHINE_API_NAMESPACE), client.HasLabels{LABEL_MACHINE_POOL},
+					}).SetArg(1, *allPooled),
+				)
+				mockKubeClient.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, ms *machineapi.MachineSet, co ...client.CreateOption) error {
+						Expect(ms.Name).To(Equal("worker-us-east-1a-upgrade"))
+						return nil
+					})
+				result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger, []string{"non-serving-*"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		Context("When no worker machinesets exist but extra pools match", func() {
+			It("creates upgrade machinesets for extra pools only", func() {
+				emptyWorkers := &machineapi.MachineSetList{}
+				extraPoolSets := &machineapi.MachineSetList{
+					Items: []machineapi.MachineSet{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "non-serving-9a-us-east-1a",
+								Namespace: MACHINE_API_NAMESPACE,
+								Labels:    map[string]string{LABEL_MACHINE_POOL: "non-serving-9a"},
+							},
+							Spec: machineapi.MachineSetSpec{
+								Selector: metav1.LabelSelector{
+									MatchLabels: make(map[string]string),
+								},
+								Template: machineapi.MachineTemplateSpec{
+									ObjectMeta: machineapi.ObjectMeta{
+										Labels: make(map[string]string),
+									},
+								},
+							},
+						},
+					},
+				}
+				gomock.InOrder(
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
+						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_UPGRADE: "true"},
+					}).SetArg(1, *upgradeMachinesets),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
+						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_MACHINE_POOL: "worker"},
+					}).SetArg(1, *emptyWorkers),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
+						client.InNamespace(MACHINE_API_NAMESPACE), client.HasLabels{LABEL_MACHINE_POOL},
+					}).SetArg(1, *extraPoolSets),
+				)
+				mockKubeClient.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, ms *machineapi.MachineSet, co ...client.CreateOption) error {
+						Expect(ms.Name).To(Equal("non-serving-9a-us-east-1a-upgrade"))
+						Expect(ms.Labels[LABEL_UPGRADE]).To(Equal("true"))
+						Expect(*ms.Spec.Replicas).To(Equal(int32(1)))
+						return nil
+					})
+				result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger, []string{"non-serving-*"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		Context("When worker list fails but extra pools match", func() {
+			It("creates upgrade machinesets for extra pools only", func() {
+				extraPoolSets := &machineapi.MachineSetList{
+					Items: []machineapi.MachineSet{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "non-serving-9a-us-east-1a",
+								Namespace: MACHINE_API_NAMESPACE,
+								Labels:    map[string]string{LABEL_MACHINE_POOL: "non-serving-9a"},
+							},
+							Spec: machineapi.MachineSetSpec{
+								Selector: metav1.LabelSelector{
+									MatchLabels: make(map[string]string),
+								},
+								Template: machineapi.MachineTemplateSpec{
+									ObjectMeta: machineapi.ObjectMeta{
+										Labels: make(map[string]string),
+									},
+								},
+							},
+						},
+					},
+				}
+				gomock.InOrder(
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
+						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_UPGRADE: "true"},
+					}).SetArg(1, *upgradeMachinesets),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
+						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_MACHINE_POOL: "worker"},
+					}).Return(fmt.Errorf("worker list error")),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
+						client.InNamespace(MACHINE_API_NAMESPACE), client.HasLabels{LABEL_MACHINE_POOL},
+					}).SetArg(1, *extraPoolSets),
+				)
+				mockKubeClient.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, ms *machineapi.MachineSet, co ...client.CreateOption) error {
+						Expect(ms.Name).To(Equal("non-serving-9a-us-east-1a-upgrade"))
+						return nil
+					})
+				result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger, []string{"non-serving-*"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		Context("When both worker list fails and extra pool list fails", func() {
+			It("returns an error", func() {
+				gomock.InOrder(
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
+						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_UPGRADE: "true"},
+					}).SetArg(1, *upgradeMachinesets),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
+						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_MACHINE_POOL: "worker"},
+					}).Return(fmt.Errorf("worker list error")),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
+						client.InNamespace(MACHINE_API_NAMESPACE), client.HasLabels{LABEL_MACHINE_POOL},
+					}).Return(fmt.Errorf("extra pool list error")),
+				)
+				result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger, []string{"non-serving-*"})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to get any machinesets to scale"))
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		Context("When extra pool list fails", func() {
+			It("continues with workers only", func() {
+				gomock.InOrder(
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
+						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_UPGRADE: "true"},
+					}).SetArg(1, *upgradeMachinesets),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
+						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_MACHINE_POOL: "worker"},
+					}).SetArg(1, *originalMachineSets),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
+						client.InNamespace(MACHINE_API_NAMESPACE), client.HasLabels{LABEL_MACHINE_POOL},
+					}).Return(fmt.Errorf("api error")),
+				)
+				mockKubeClient.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, ms *machineapi.MachineSet, co ...client.CreateOption) error {
+						Expect(ms.Name).To(Equal("worker-us-east-1a-upgrade"))
+						return nil
+					})
+				result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger, []string{"non-serving-*"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		Context("When extra pools is nil", func() {
+			It("behaves identically to no extra pools", func() {
+				gomock.InOrder(
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
+						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_UPGRADE: "true"},
+					}).SetArg(1, *upgradeMachinesets),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
+						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_MACHINE_POOL: "worker"},
+					}).SetArg(1, *originalMachineSets),
+				)
+				mockKubeClient.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil)
+				result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		Context("When worker machinesets also appear in extra pool list", func() {
+			It("does not duplicate worker machinesets", func() {
+				// The allPooled list includes both worker and non-serving, but worker should be excluded
+				allPooled := &machineapi.MachineSetList{
+					Items: []machineapi.MachineSet{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "worker-us-east-1a",
+								Namespace: MACHINE_API_NAMESPACE,
+								Labels:    map[string]string{LABEL_MACHINE_POOL: "worker"},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "non-serving-9a-us-east-1a",
+								Namespace: MACHINE_API_NAMESPACE,
+								Labels:    map[string]string{LABEL_MACHINE_POOL: "non-serving-9a"},
+							},
+							Spec: machineapi.MachineSetSpec{
+								Selector: metav1.LabelSelector{
+									MatchLabels: make(map[string]string),
+								},
+								Template: machineapi.MachineTemplateSpec{
+									ObjectMeta: machineapi.ObjectMeta{
+										Labels: make(map[string]string),
+									},
+								},
+							},
+						},
+					},
+				}
+				gomock.InOrder(
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
+						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_UPGRADE: "true"},
+					}).SetArg(1, *upgradeMachinesets),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
+						client.InNamespace(MACHINE_API_NAMESPACE), client.MatchingLabels{LABEL_MACHINE_POOL: "worker"},
+					}).SetArg(1, *originalMachineSets),
+					mockKubeClient.EXPECT().List(gomock.Any(), gomock.Any(), []client.ListOption{
+						client.InNamespace(MACHINE_API_NAMESPACE), client.HasLabels{LABEL_MACHINE_POOL},
+					}).SetArg(1, *allPooled),
+				)
+				// Only 2 creates: original worker + non-serving (worker not duplicated from extra pool list)
+				createdNames := []string{}
+				mockKubeClient.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, ms *machineapi.MachineSet, co ...client.CreateOption) error {
+						createdNames = append(createdNames, ms.Name)
+						return nil
+					}).Times(2)
+				result, err := scaler.EnsureScaleUpNodes(mockKubeClient, testDuration, logger, []string{"*"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeFalse())
+				Expect(createdNames).To(ContainElements("worker-us-east-1a-upgrade", "non-serving-9a-us-east-1a-upgrade"))
+				Expect(createdNames).To(HaveLen(2))
+			})
+		})
 	})
 
 	Context("When the upgrade is scaling in workers", func() {

--- a/pkg/upgraders/config.go
+++ b/pkg/upgraders/config.go
@@ -2,6 +2,7 @@ package upgraders
 
 import (
 	"fmt"
+	"path"
 	"time"
 
 	ac "github.com/openshift/managed-upgrade-operator/pkg/availabilitychecks"
@@ -63,6 +64,12 @@ func (cfg *scaleConfig) IsValid() error {
 		return fmt.Errorf("config scale timeOut is invalid")
 	}
 
+	for _, pattern := range cfg.ExtraMachinePools {
+		if _, err := path.Match(pattern, ""); err != nil {
+			return fmt.Errorf("config scale extraMachinePools contains invalid pattern %q: %w", pattern, err)
+		}
+	}
+
 	return nil
 }
 
@@ -80,7 +87,8 @@ func (cfg *upgradeWindow) GetUpgradeDelayedTriggerDuration() time.Duration {
 }
 
 type scaleConfig struct {
-	TimeOut int `yaml:"timeOut" default:"30"`
+	TimeOut           int      `yaml:"timeOut" default:"30"`
+	ExtraMachinePools []string `yaml:"extraMachinePools"`
 }
 
 type healthCheck struct {
@@ -90,6 +98,9 @@ type healthCheck struct {
 
 func (cfg *upgraderConfig) IsValid() error {
 	if err := cfg.Maintenance.IsValid(); err != nil {
+		return err
+	}
+	if err := cfg.Scale.IsValid(); err != nil {
 		return err
 	}
 	if cfg.NodeDrain.Timeout <= 0 {

--- a/pkg/upgraders/config_test.go
+++ b/pkg/upgraders/config_test.go
@@ -1,0 +1,116 @@
+package upgraders
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("scaleConfig", func() {
+	Describe("IsValid", func() {
+		It("returns no error for valid config with no extra machine pools", func() {
+			cfg := &scaleConfig{TimeOut: 30}
+			Expect(cfg.IsValid()).NotTo(HaveOccurred())
+		})
+
+		It("returns no error for valid config with valid extra machine pool patterns", func() {
+			cfg := &scaleConfig{
+				TimeOut:           30,
+				ExtraMachinePools: []string{"non-serving-*", "infra-*"},
+			}
+			Expect(cfg.IsValid()).NotTo(HaveOccurred())
+		})
+
+		It("returns an error when TimeOut is zero", func() {
+			cfg := &scaleConfig{TimeOut: 0}
+			err := cfg.IsValid()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("config scale timeOut is invalid"))
+		})
+
+		It("returns an error when TimeOut is negative", func() {
+			cfg := &scaleConfig{TimeOut: -1}
+			err := cfg.IsValid()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("config scale timeOut is invalid"))
+		})
+
+		It("returns an error for a malformed glob pattern", func() {
+			cfg := &scaleConfig{
+				TimeOut:           30,
+				ExtraMachinePools: []string{"[invalid"},
+			}
+			err := cfg.IsValid()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("config scale extraMachinePools contains invalid pattern"))
+			Expect(err.Error()).To(ContainSubstring("[invalid"))
+		})
+
+		It("returns an error when one pattern among many is malformed", func() {
+			cfg := &scaleConfig{
+				TimeOut:           30,
+				ExtraMachinePools: []string{"non-serving-*", "[bad", "infra-*"},
+			}
+			err := cfg.IsValid()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("[bad"))
+		})
+
+		It("returns no error for an empty extra machine pools slice", func() {
+			cfg := &scaleConfig{
+				TimeOut:           30,
+				ExtraMachinePools: []string{},
+			}
+			Expect(cfg.IsValid()).NotTo(HaveOccurred())
+		})
+
+		It("accepts exact pool names without wildcards", func() {
+			cfg := &scaleConfig{
+				TimeOut:           30,
+				ExtraMachinePools: []string{"non-serving-9a"},
+			}
+			Expect(cfg.IsValid()).NotTo(HaveOccurred())
+		})
+
+		It("accepts patterns with character classes", func() {
+			cfg := &scaleConfig{
+				TimeOut:           30,
+				ExtraMachinePools: []string{"non-serving-[0-9]*"},
+			}
+			Expect(cfg.IsValid()).NotTo(HaveOccurred())
+		})
+
+		It("accepts patterns with question mark wildcards", func() {
+			cfg := &scaleConfig{
+				TimeOut:           30,
+				ExtraMachinePools: []string{"non-serving-?a"},
+			}
+			Expect(cfg.IsValid()).NotTo(HaveOccurred())
+		})
+	})
+})
+
+var _ = Describe("upgraderConfig", func() {
+	Describe("IsValid", func() {
+		var cfg *upgraderConfig
+		BeforeEach(func() {
+			cfg = buildTestUpgraderConfig(90, 30, 8, 120, 30)
+			cfg.NodeDrain.Timeout = 45
+		})
+
+		It("returns an error when scale config has an invalid pattern", func() {
+			cfg.Scale.ExtraMachinePools = []string{"[invalid"}
+			err := cfg.IsValid()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("config scale extraMachinePools contains invalid pattern"))
+		})
+
+		It("passes validation when scale config has valid patterns", func() {
+			cfg.Scale.ExtraMachinePools = []string{"non-serving-*"}
+			Expect(cfg.IsValid()).NotTo(HaveOccurred())
+		})
+
+		It("passes validation when scale config has no extra machine pools", func() {
+			Expect(cfg.IsValid()).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/pkg/upgraders/scalerstep.go
+++ b/pkg/upgraders/scalerstep.go
@@ -37,15 +37,18 @@ func (c *clusterUpgrader) EnsureExtraUpgradeWorkers(ctx context.Context, logger 
 	if err != nil {
 		return false, err
 	}
-	if !canScale {
+	if !canScale && len(c.config.Scale.ExtraMachinePools) == 0 {
 		err := c.SendScaleSkippedNotification(ctx, logger)
 		if err != nil {
 			logger.Info(fmt.Sprintf("Failed to send ScaleSkipped notification:  %s", err))
 		}
 		return true, nil
 	}
+	if !canScale {
+		logger.Info("worker machinesets not found, but extra machine pools are configured; proceeding with extra pool scaling")
+	}
 
-	isScaled, err := c.scaler.EnsureScaleUpNodes(c.client, c.config.GetScaleDuration(), logger)
+	isScaled, err := c.scaler.EnsureScaleUpNodes(c.client, c.config.GetScaleDuration(), logger, c.config.Scale.ExtraMachinePools)
 	if err != nil {
 		if scaler.IsScaleTimeOutError(err) {
 			c.metrics.UpdateMetricScalingFailed(c.upgradeConfig.Name)
@@ -83,7 +86,7 @@ func (c *clusterUpgrader) RemoveExtraScaledNodes(ctx context.Context, logger log
 	if err != nil {
 		return false, err
 	}
-	if !canScale {
+	if !canScale && len(c.config.Scale.ExtraMachinePools) == 0 {
 		// We don't need to perform a scaling step
 		return true, nil
 	}

--- a/pkg/upgraders/scalerstep_test.go
+++ b/pkg/upgraders/scalerstep_test.go
@@ -102,7 +102,7 @@ var _ = Describe("ScalerStep", func() {
 				gomock.InOrder(
 					mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(false, nil),
 					mockScalerClient.EXPECT().CanScale(gomock.Any(), gomock.Any()).Return(true, nil),
-					mockScalerClient.EXPECT().EnsureScaleUpNodes(gomock.Any(), config.GetScaleDuration(), gomock.Any()).Return(true, nil),
+					mockScalerClient.EXPECT().EnsureScaleUpNodes(gomock.Any(), config.GetScaleDuration(), gomock.Any(), gomock.Any()).Return(true, nil),
 					mockMetricsClient.EXPECT().UpdateMetricScalingSucceeded(gomock.Any()),
 				)
 
@@ -114,7 +114,7 @@ var _ = Describe("ScalerStep", func() {
 				gomock.InOrder(
 					mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(false, nil),
 					mockScalerClient.EXPECT().CanScale(gomock.Any(), gomock.Any()).Return(true, nil),
-					mockScalerClient.EXPECT().EnsureScaleUpNodes(gomock.Any(), config.GetScaleDuration(), gomock.Any()).Return(false, scaler.NewScaleTimeOutError("test scale timed out")),
+					mockScalerClient.EXPECT().EnsureScaleUpNodes(gomock.Any(), config.GetScaleDuration(), gomock.Any(), gomock.Any()).Return(false, scaler.NewScaleTimeOutError("test scale timed out")),
 					mockMetricsClient.EXPECT().UpdateMetricScalingFailed(gomock.Any()),
 					mockEMClient.EXPECT().Notify(notifier.MuoStateSkipped),
 				)
@@ -157,6 +157,36 @@ var _ = Describe("ScalerStep", func() {
 				Expect(err).To(Not(HaveOccurred()))
 				Expect(ok).To(BeTrue())
 			})
+		})
+	})
+
+	Context("When scaling cannot proceed but extra machine pools are configured", func() {
+		BeforeEach(func() {
+			config.Scale.ExtraMachinePools = []string{"non-serving-*"}
+		})
+
+		It("should still attempt to scale up extra nodes when CanScale returns false", func() {
+			gomock.InOrder(
+				mockCVClient.EXPECT().HasUpgradeCommenced(gomock.Any()).Return(false, nil),
+				mockScalerClient.EXPECT().CanScale(gomock.Any(), gomock.Any()).Return(false, nil),
+				mockScalerClient.EXPECT().EnsureScaleUpNodes(gomock.Any(), config.GetScaleDuration(), gomock.Any(), gomock.Any()).Return(true, nil),
+				mockMetricsClient.EXPECT().UpdateMetricScalingSucceeded(gomock.Any()),
+			)
+			ok, err := upgrader.EnsureExtraUpgradeWorkers(context.TODO(), logger)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should still attempt to scale down extra nodes when CanScale returns false", func() {
+			gomock.InOrder(
+				mockScalerClient.EXPECT().CanScale(gomock.Any(), gomock.Any()).Return(false, nil),
+				mockDrainStrategyBuilder.EXPECT().NewNodeDrainStrategy(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil),
+				mockScalerClient.EXPECT().EnsureScaleDownNodes(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil),
+				mockMetricsClient.EXPECT().ResetAllMetricNodeDrainFailed(),
+			)
+			ok, err := upgrader.RemoveExtraScaledNodes(context.TODO(), logger)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(ok).To(BeTrue())
 		})
 	})
 


### PR DESCRIPTION
## Summary

- Adds a new `scale.extraMachinePools` ConfigMap field (list of glob patterns) to select additional MachineSets beyond the default `worker` pool for capacity reservation scaling during upgrades.
- Enables management clusters to scale non-serving MachineSets (e.g. `non-serving-*`) alongside workers, controlled per-cluster via the operator ConfigMap.
- Worker and extra pool scaling are independent: either can proceed without the other. Extra pool scaling is best-effort — failures are logged but do not block the upgrade.

## Changes

**`pkg/upgraders/config.go`**: Added `ExtraMachinePools []string` to `scaleConfig`, with glob pattern validation via `path.Match`. Wired `Scale.IsValid()` into the `upgraderConfig.IsValid()` chain so invalid patterns fail at upgrader construction time.

**`pkg/scaler/scaler.go`**: Updated `Scaler` interface — `EnsureScaleUpNodes` now accepts a `[]string` parameter for extra pool patterns.

**`pkg/scaler/machineSetScaler.go`**: Added `LABEL_MACHINE_POOL` constant and `listMachineSetsByPoolPatterns()` helper (lists MachineSets with `hive.openshift.io/machine-pool` label, filters by glob, excludes `worker`). Restructured `EnsureScaleUpNodes` so worker and extra pool fetching are independent.

**`pkg/upgraders/scalerstep.go`**: Threads `ExtraMachinePools` into `EnsureScaleUpNodes`. When `CanScale` returns false (no worker MachineSets) but extra pools are configured, scaling proceeds with extra pools only instead of skipping entirely.

**Tests**: 8 new scaler tests, 2 new scalerstep tests, 12 new config validation tests. All existing tests updated for the new interface.

**`docs/configmap.md`**: Documented the new `extraMachinePools` field with description and YAML example.

## Configuration

```yaml
scale:
  timeOut: 30
  extraMachinePools:
    - "non-serving-*"
```

When `extraMachinePools` is empty or absent, behavior is identical to the current implementation — only the default `worker` pool is scaled. Patterns use Go's `path.Match` syntax.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure additional machine pools for capacity reservation during upgrades using glob patterns.

* **Behavior Changes**
  * Extra machine pools are considered for scale-up/scale-down even when primary worker scaling is unavailable; avoids duplicating worker entries.

* **Documentation**
  * Scale config docs updated with the new extraMachinePools setting and examples; pre-commit quick-start notes expanded.

* **Validation & Tests**
  * Config validation for glob patterns and unit tests added/updated.

* **Chores**
  * OWNERS_ALIASES updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->