### PR TITLE
ROSA-745: boilerplate-update and enable MintMaker gomod

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>openshift/boilerplate//.github/renovate.json"
+  ],
+  "enabledManagers": [
+    "tekton",
+    "gomod"
   ]
 }


### PR DESCRIPTION
## Summary

- `make boilerplate-update` (includes boilerplate #748 dependabot template)
- `.github/renovate.json` — `enabledManagers: [tekton, gomod]` for MintMaker gomod PRs

## Test plan

- [ ] CI green

Jira: [ROSA-745](https://redhat.atlassian.net/browse/ROSA-745)


[ROSA-745]: https://redhat.atlassian.net/browse/ROSA-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update coverage by enabling additional project formats for update detection.
  * This helps keep relevant dependencies current with less manual maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->