### PR TITLE
ROSAENG-65333: fix the muo nil pointer issue during node drain strategy

### DIFF
--- a/pkg/drain/pod_predicates.go
+++ b/pkg/drain/pod_predicates.go
@@ -45,6 +45,9 @@ func isNotDaemonSet(pod corev1.Pod) bool {
 func containsMatchLabel(p corev1.Pod, pdbList *policyv1.PodDisruptionBudgetList) bool {
 	isPdbPod := false
 	for _, pdb := range pdbList.Items {
+		if pdb.Spec.Selector == nil {
+			continue
+		}
 		for mlKey, mlValue := range pdb.Spec.Selector.MatchLabels {
 			lValue, ok := p.Labels[mlKey]
 			if ok && lValue == mlValue {

--- a/pkg/drain/pod_predicates_test.go
+++ b/pkg/drain/pod_predicates_test.go
@@ -2,6 +2,7 @@ package drain
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo"
@@ -23,6 +24,56 @@ var _ = Describe("Pod Predicates", func() {
 				},
 				Spec: corev1.PodSpec{},
 			}
+		})
+		Context("testing containsMatchLabel", func() {
+			It("does not panic when a PDB has a nil selector", func() {
+				pdbList := &policyv1.PodDisruptionBudgetList{
+					Items: []policyv1.PodDisruptionBudget{
+						{
+							Spec: policyv1.PodDisruptionBudgetSpec{
+								Selector: nil,
+							},
+						},
+					},
+				}
+				Expect(func() {
+					containsMatchLabel(pod, pdbList)
+				}).ShouldNot(Panic())
+				r := containsMatchLabel(pod, pdbList)
+				Expect(r).To(BeFalse())
+			})
+			It("returns true when pod labels match a PDB selector", func() {
+				pod.Labels = map[string]string{"app": "test"}
+				pdbList := &policyv1.PodDisruptionBudgetList{
+					Items: []policyv1.PodDisruptionBudget{
+						{
+							Spec: policyv1.PodDisruptionBudgetSpec{
+								Selector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"app": "test"},
+								},
+							},
+						},
+					},
+				}
+				r := containsMatchLabel(pod, pdbList)
+				Expect(r).To(BeTrue())
+			})
+			It("returns false when pod labels do not match any PDB selector", func() {
+				pod.Labels = map[string]string{"app": "other"}
+				pdbList := &policyv1.PodDisruptionBudgetList{
+					Items: []policyv1.PodDisruptionBudget{
+						{
+							Spec: policyv1.PodDisruptionBudgetSpec{
+								Selector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"app": "test"},
+								},
+							},
+						},
+					},
+				}
+				r := containsMatchLabel(pod, pdbList)
+				Expect(r).To(BeFalse())
+			})
 		})
 		Context("testing if pod namespace is allowed", func() {
 			It("allows pods with namespaces not in the ignore list", func() {


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
The MUO reported nil-pointer issue when trying to drain the node by reading the PDB
Which is blocking the controller move to next step

### Which Jira/Github issue(s) this PR fixes?

_Fixes [ROSAENG-65333](https://redhat.atlassian.net/browse/ROSAENG-65333)_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR



[ROSAENG-65333]: https://redhat.atlassian.net/browse/ROSAENG-65333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of PodDisruptionBudgets without label selectors, preventing processing errors during pod operations.
  * Preserved correct behavior for matching and non-matching pod labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->