### PR TITLE
fix(#698): update channel on image-based upgrades

### DIFF
--- a/pkg/clusterversion/clusterversion_test.go
+++ b/pkg/clusterversion/clusterversion_test.go
@@ -381,6 +381,39 @@ var _ = Describe("ClusterVersion client and utils", func() {
 					Expect(hasCommenced).To(BeTrue())
 				})
 			})
+			Context("When the clusterversion channel differs from the upgradeconfig and image is set", func() {
+				It("Updates the channel before setting the desired image", func() {
+					clusterVersion := configv1.ClusterVersion{
+						Spec: configv1.ClusterVersionSpec{
+							Channel: "stable-4.20",
+							DesiredUpdate: &configv1.Update{
+								Version: "Some version",
+							},
+						},
+					}
+					upgradeConfig.Spec.Desired.Channel = "stable-4.21"
+					upgradeConfig.Spec.Desired.Image = "quay.io/test/test-image"
+					channelPatch := client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf(`{"spec":{"channel":"%s"}}`, upgradeConfig.Spec.Desired.Channel)))
+					imagePatch := client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"image":"%s","version":null}}}`, upgradeConfig.Spec.Desired.Image)))
+					gomock.InOrder(
+						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, clusterVersion).Return(nil),
+						mockKubeClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+							func(ctx context.Context, cv *configv1.ClusterVersion, p client.Patch, po ...client.PatchOption) error {
+								Expect(reflect.DeepEqual(p, channelPatch)).To(BeTrue())
+								return nil
+							}),
+						mockKubeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, clusterVersion).Return(nil),
+						mockKubeClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+							func(ctx context.Context, cv *configv1.ClusterVersion, p client.Patch, po ...client.PatchOption) error {
+								Expect(reflect.DeepEqual(p, imagePatch)).To(BeTrue())
+								return nil
+							}),
+					)
+					result, err := cvClient.EnsureDesiredConfig(upgradeConfig)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(BeTrue())
+				})
+			})
 		})
 	})
 

--- a/pkg/clusterversion/cv.go
+++ b/pkg/clusterversion/cv.go
@@ -305,6 +305,24 @@ func checkUpgradeSource(uc *upgradev1alpha1.UpgradeConfig) (string, error) {
 func (c *clusterVersionClient) runUpgradeWithImage(cv *configv1.ClusterVersion, uc *upgradev1alpha1.UpgradeConfig) (bool, error) {
 	desired := uc.Spec.Desired
 
+	// When a desired channel is set alongside the image, keep the cluster's
+	// channel in sync so cross-minor image-based upgrades don't leave the
+	// cluster on the old channel.
+	if desired.Channel != "" && cv.Spec.Channel != desired.Channel {
+		logger.Info(fmt.Sprintf("Setting ClusterVersion to Channel %s", desired.Channel))
+		desiredChannel := []byte(fmt.Sprintf(`{"spec":{"channel":"%s"}}`, desired.Channel))
+		err := c.client.Patch(context.TODO(), cv, client.RawPatch(types.MergePatchType, desiredChannel))
+		if err != nil {
+			return false, err
+		}
+
+		// Retrieve the updated version
+		cv, err = c.GetClusterVersion()
+		if err != nil {
+			return false, err
+		}
+	}
+
 	if cv.Spec.DesiredUpdate == nil || cv.Spec.DesiredUpdate.Image != desired.Image {
 		logger.Info(fmt.Sprintf("Setting ClusterVersion to Image %s", desired.Image))
 		desiredImage := []byte(fmt.Sprintf(`{"spec":{"desiredUpdate":{"image":"%s","version":null}}}`, desired.Image))


### PR DESCRIPTION
## Description

Fixes #698

When an `UpgradeConfig` has `spec.desired.image` populated alongside `spec.desired.channel` and `spec.desired.version`, the operator performs the version upgrade but never updates the cluster's channel to match `spec.desired.channel`. After a cross-minor image-based upgrade (e.g. `stable-4.20` -> `stable-4.21`), the cluster is left on the old channel and must be corrected manually via `oc adm upgrade channel`.

The root cause is that when `spec.desired.image` is set, `checkUpgradeSource` routes the upgrade through `runUpgradeWithImage`, which only patched `spec.desiredUpdate.image` and never touched the channel. Channel syncing only happened in `runUpgradeWithChannelVersion`.

## Change

`runUpgradeWithImage` now syncs the cluster channel before patching the desired image when `spec.desired.channel` is set and differs from the current `cv.Spec.Channel`, mirroring the behavior of `runUpgradeWithChannelVersion`. Image-only upgrades (no channel provided) are unaffected.

## Testing

- Added a unit test covering the case where both image and a differing channel are set, asserting the channel patch is applied before the image patch.
- `go test ./pkg/clusterversion/...` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Image-based upgrades now synchronize the cluster’s update channel with the requested channel before applying the desired image.
  - Ensures channel and image updates are applied successfully and in the correct order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->